### PR TITLE
feat: lazy render tool panel via batch_update API

### DIFF
--- a/hermes_lark_streaming/cardkit.py
+++ b/hermes_lark_streaming/cardkit.py
@@ -9,6 +9,7 @@ from typing import Any
 _logger = logging.getLogger("hermes_lark_streaming")
 
 STREAMING_ELEMENT_ID = "streaming_content"
+TOOL_PANEL_ELEMENT_ID = "tool_panel"
 _LOADING_ELEMENT_ID = "loading_icon"
 _LOADING_IMG_KEY = "img_v3_02vb_496bec09-4b43-4773-ad6b-0cdd103cd2bg"
 
@@ -215,7 +216,7 @@ def _build_tool_panel(steps: list[dict], elapsed_ms: float = 0, *, expanded: boo
     for s in steps:
         children.extend(_build_tool_step_elements(s))
 
-    return _collapsible_panel(
+    panel = _collapsible_panel(
         expanded=expanded,
         title_el={
             "tag": "plain_text",
@@ -226,6 +227,8 @@ def _build_tool_panel(steps: list[dict], elapsed_ms: float = 0, *, expanded: boo
         },
         elements=children,
     )
+    panel["element_id"] = TOOL_PANEL_ELEMENT_ID
+    return panel
 
 
 def _build_tool_step_elements(step: dict) -> list[dict]:

--- a/hermes_lark_streaming/controller.py
+++ b/hermes_lark_streaming/controller.py
@@ -17,12 +17,14 @@ from typing import Any, Coroutine
 
 from .cardkit import (
     STREAMING_ELEMENT_ID,
+    TOOL_PANEL_ELEMENT_ID,
     build_complete_card,
     build_im_fallback_card,
     build_streaming_card,
     build_streaming_card_v2,
     optimize_markdown_style,
 )
+from .cardkit import _build_tool_panel
 from .config import Config
 from .feishu import (
     CARDKIT_CONTENT_FAILED,
@@ -62,6 +64,7 @@ class CardSession:
         "_loop",
         "guard", "image_resolver",
         "last_tool_use_update", "created_at",
+        "tool_panel_added",
     )
 
     def __init__(
@@ -94,6 +97,7 @@ class CardSession:
         )
 
         self.image_resolver: ImageResolver | None = None
+        self.tool_panel_added = False
 
 
 class StreamCardController:
@@ -238,10 +242,10 @@ class StreamCardController:
                 output="" if is_error else detail,
             )
 
-        self._schedule_card_update(session)
-
-        if session.use_cardkit and session.card_id and not session.text.display_text:
+        if session.use_cardkit and session.card_id:
             self._schedule_tool_use_status_update(session)
+        else:
+            self._schedule_card_update(session)
 
     def on_answer(self, *, message_id: str, text: str) -> None:
         """答案文本增量（流式）."""
@@ -356,7 +360,7 @@ class StreamCardController:
                 )
 
             try:
-                card = build_streaming_card_v2(show_tool_use=True)
+                card = build_streaming_card_v2(show_tool_use=False)
                 card_id = await self._client.cardkit_create(card)
                 card_msg_id = await self._client.reply_card_by_id(
                     session.message_id, card_id,
@@ -444,15 +448,31 @@ class StreamCardController:
             return
         try:
             tool_steps = session.tool_use.build_display_steps()
-            card = build_streaming_card_v2(
-                tool_steps=tool_steps,
-                elapsed_ms=session.tool_use.elapsed_ms,
-                show_tool_use=True,
+            panel = _build_tool_panel(
+                tool_steps, session.tool_use.elapsed_ms,
             )
+            if not session.tool_panel_added:
+                actions = [{
+                    "action": "add_elements",
+                    "params": {
+                        "type": "insert_before",
+                        "target_element_id": STREAMING_ELEMENT_ID,
+                        "elements": [panel],
+                    },
+                }]
+            else:
+                actions = [{
+                    "action": "update_element",
+                    "params": {
+                        "element_id": TOOL_PANEL_ELEMENT_ID,
+                        "element": panel,
+                    },
+                }]
             session.sequence += 1
-            await self._client.cardkit_update(
-                session.card_id, card, sequence=session.sequence,
+            await self._client.cardkit_batch_update(
+                session.card_id, actions, sequence=session.sequence,
             )
+            session.tool_panel_added = True
         except Exception as e:
             _logger.debug("tool use status update failed: %s", e)
 

--- a/hermes_lark_streaming/feishu.py
+++ b/hermes_lark_streaming/feishu.py
@@ -13,6 +13,8 @@ from urllib.error import URLError
 
 import lark_oapi as lark
 from lark_oapi.api.cardkit.v1 import (
+    BatchUpdateCardRequest,
+    BatchUpdateCardRequestBody,
     Card,
     ContentCardElementRequest,
     ContentCardElementRequestBody,
@@ -226,6 +228,28 @@ class FeishuClient:
         )
         resp = await self._client.cardkit.v1.card.aupdate(request)
         self._check(resp, "cardkit_update")
+
+    async def cardkit_batch_update(
+        self,
+        card_id: str,
+        actions: list[dict[str, Any]],
+        *,
+        sequence: int = 0,
+    ) -> None:
+        """局部更新 CardKit 卡片（增删改组件）."""
+        body_builder = (
+            BatchUpdateCardRequestBody.builder()
+            .sequence(sequence)
+            .actions(self._dumps(actions))
+        )
+        request = (
+            BatchUpdateCardRequest.builder()
+            .card_id(card_id)
+            .request_body(body_builder.build())
+            .build()
+        )
+        resp = await self._client.cardkit.v1.card.abatch_update(request)
+        self._check(resp, "cardkit_batch_update")
 
     async def cardkit_close_streaming(self, card_id: str, sequence: int = 0) -> None:
         """关闭 CardKit 卡片的流式模式."""


### PR DESCRIPTION
## Summary
- Use CardKit batch_update API to lazily insert and update tool panel during streaming, instead of rebuilding the entire card
- Fix `tool_panel_added` flag set before API call succeeds, causing silent retry failures
- Fix tool panel not updating when model sends pre-tool text in the same iteration

## Test plan
- [x] Verify tool panel appears and updates during tool execution phase
- [x] Verify tool panel works when model sends text before tool calls (e.g., "Let me search...")
- [x] Verify final complete card renders correctly with all tool steps
- [x] Verify IM fallback path unaffected