### PR TITLE
chore: add ruff lint/format and mypy type checking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,5 +23,11 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[dev]"
 
+      - name: Run ruff
+        run: python -m ruff check .
+
+      - name: Run mypy
+        run: python -m mypy hermes_lark_streaming/
+
       - name: Run tests
         run: python -m pytest tests/ -v

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ build/
 .eggs/
 tests/samples/
 .pytest_cache/
+.mypy_cache/
+.ruff_cache/

--- a/hermes_lark_streaming/__main__.py
+++ b/hermes_lark_streaming/__main__.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .patcher import Patcher
 
 
 def main() -> int:
@@ -122,14 +126,16 @@ def _cmd_status() -> int:
 
     if patched:
         from .patcher import Patcher as _PatcherCls
+
         content = patcher.run_path.read_text(encoding="utf-8")
-        for begin, end in _PatcherCls.MARKERS:
+        for begin, _end in _PatcherCls.MARKERS:
             found = begin in content
             label = begin.replace("# HERMES_LARK_", "").replace("_BEGIN", "").lower()
             print(f"  {label}: {'installed' if found else 'missing'}")
 
     # Check config
     from .config import Config
+
     cfg = Config()
     print(f"Config streaming.enabled: {cfg.enabled}")
     print(f"Feishu credentials: {'configured' if (cfg.env_app_id or cfg.feishu_app_id) else 'MISSING'}")

--- a/hermes_lark_streaming/cardkit.py
+++ b/hermes_lark_streaming/cardkit.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import re
 import logging
+import re
 from typing import Any
 
 _logger = logging.getLogger("hermes_lark_streaming")
@@ -20,19 +20,19 @@ _LOCALES = ["zh_cn", "en_us"]
 
 _T: dict[str, tuple[str, str]] = {
     "status_completed": ("✅ Completed", "✅ 已完成"),
-    "status_error":     ("❌ Error", "❌ 出错"),
-    "status_stopped":   ("🛑 Stopped", "🛑 已停止"),
-    "elapsed":          ("Elapsed {}", "耗时 {}"),
-    "context":          ("Context {}", "上下文 {}"),
-    "processing":       ("Processing...", "处理中..."),
-    "processing_prefix":("💭 Processing...", "💭 处理中..."),
-    "tool_use":         ("Tool use", "工具执行"),
-    "tool_pending":     ("🛠️ Tool use pending", "🛠️ 等待工具执行"),
-    "steps":            ("{} step{}", "{} 步"),
-    "thinking":         ("💭 **Thinking...**", "💭 **思考中...**"),
-    "thought":          ("Thought", "思考"),
-    "thought_for":      ("Thought for {}", "思考了 {}"),
-    "done":             ("Done.", "完成。"),
+    "status_error": ("❌ Error", "❌ 出错"),
+    "status_stopped": ("🛑 Stopped", "🛑 已停止"),
+    "elapsed": ("Elapsed {}", "耗时 {}"),
+    "context": ("Context {}", "上下文 {}"),
+    "processing": ("Processing...", "处理中..."),
+    "processing_prefix": ("💭 Processing...", "💭 处理中..."),
+    "tool_use": ("Tool use", "工具执行"),
+    "tool_pending": ("🛠️ Tool use pending", "🛠️ 等待工具执行"),
+    "steps": ("{} step{}", "{} 步"),
+    "thinking": ("💭 **Thinking...**", "💭 **思考中...**"),
+    "thought": ("Thought", "思考"),
+    "thought_for": ("Thought for {}", "思考了 {}"),
+    "done": ("Done.", "完成。"),
 }
 
 
@@ -89,7 +89,7 @@ def optimize_markdown_style(text: str) -> str:
 
         def _extract(m: re.Match) -> str:
             prefix = m.group(1) or ""
-            block = m.group(0)[len(prefix):]
+            block = m.group(0)[len(prefix) :]
             idx = len(code_blocks)
             code_blocks.append(block)
             return f"{prefix}{mark}{idx}___"
@@ -372,7 +372,8 @@ def _build_footer_elements(
             en, zh = _render_footer_field(field, data, is_error, is_aborted, show_label)
             if en:
                 en_parts.append(en)
-                zh_parts.append(zh)
+                if zh:
+                    zh_parts.append(zh)
         if en_parts:
             en_lines.append(" · ".join(en_parts))
             zh_lines.append(" · ".join(zh_parts))
@@ -541,14 +542,16 @@ def build_streaming_card(
         elements.append(_build_tool_panel(tool_steps))
 
     if reasoning_text and not text:
-        elements.append({
-            "tag": "markdown",
-            "content": f"{_T['thinking'][0]}\n\n{reasoning_text}",
-            "i18n_content": _i18n(
-                f"{_T['thinking'][0]}\n\n{reasoning_text}",
-                f"{_T['thinking'][1]}\n\n{reasoning_text}",
-            ),
-        })
+        elements.append(
+            {
+                "tag": "markdown",
+                "content": f"{_T['thinking'][0]}\n\n{reasoning_text}",
+                "i18n_content": _i18n(
+                    f"{_T['thinking'][0]}\n\n{reasoning_text}",
+                    f"{_T['thinking'][1]}\n\n{reasoning_text}",
+                ),
+            }
+        )
 
     elements.append({"tag": "markdown", "content": _downgrade_tables(optimize_markdown_style(text)) if text else " "})
 
@@ -589,10 +592,15 @@ def build_complete_card(
     for chunk in _split_long_text(content):
         elements.append({"tag": "markdown", "content": chunk})
 
-    elements.extend(_build_footer_elements(
-        footer_data, is_error, is_aborted,
-        fields=footer_fields, show_label=footer_show_label,
-    ))
+    elements.extend(
+        _build_footer_elements(
+            footer_data,
+            is_error,
+            is_aborted,
+            fields=footer_fields,
+            show_label=footer_show_label,
+        )
+    )
 
     summary = (text or reasoning_text or "")[:120]
     summary = summary.replace("\n", " ").replace("```", "").strip()

--- a/hermes_lark_streaming/config.py
+++ b/hermes_lark_streaming/config.py
@@ -8,7 +8,6 @@ from typing import Any
 
 import yaml
 
-
 _HERMES_CONFIG_PATH = Path.home() / ".hermes" / "config.yaml"
 
 
@@ -18,7 +17,6 @@ class Config:
     def __init__(self) -> None:
         self._raw: dict[str, Any] | None = None
 
-
     @property
     def enabled(self) -> bool:
         """是否启用流式卡片."""
@@ -27,15 +25,15 @@ class Config:
 
     @property
     def feishu_app_id(self) -> str:
-        return self._platform_cfg().get("app_id", "")
+        return str(self._platform_cfg().get("app_id", ""))
 
     @property
     def feishu_app_secret(self) -> str:
-        return self._platform_cfg().get("app_secret", "")
+        return str(self._platform_cfg().get("app_secret", ""))
 
     @property
     def feishu_base_url(self) -> str:
-        return self._platform_cfg().get("base_url", "https://open.feishu.cn/open-apis")
+        return str(self._platform_cfg().get("base_url", "https://open.feishu.cn/open-apis"))
 
     @property
     def card_duration_sec(self) -> int:
@@ -70,7 +68,6 @@ class Config:
     def _default_footer_fields() -> list[list[str]]:
         return [["status", "elapsed", "context", "model"]]
 
-
     @property
     def env_app_id(self) -> str:
         return os.environ.get("FEISHU_APP_ID") or os.environ.get("LARK_APP_ID") or ""
@@ -78,7 +75,6 @@ class Config:
     @property
     def env_app_secret(self) -> str:
         return os.environ.get("FEISHU_APP_SECRET") or os.environ.get("LARK_APP_SECRET") or ""
-
 
     def _streaming_sec(self) -> dict[str, Any]:
         raw = self._load()

--- a/hermes_lark_streaming/controller.py
+++ b/hermes_lark_streaming/controller.py
@@ -13,11 +13,14 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from typing import Any, Coroutine
+from collections.abc import Coroutine
+from concurrent.futures import Future as ConcurrentFuture
+from typing import Any
 
 from .cardkit import (
     STREAMING_ELEMENT_ID,
     TOOL_PANEL_ELEMENT_ID,
+    _build_tool_panel,
     _downgrade_tables,
     build_complete_card,
     build_im_fallback_card,
@@ -25,7 +28,6 @@ from .cardkit import (
     build_streaming_card_v2,
     optimize_markdown_style,
 )
-from .cardkit import _build_tool_panel
 from .config import Config
 from .feishu import (
     CARDKIT_CONTENT_FAILED,
@@ -58,15 +60,25 @@ class CardSession:
     """单条消息的卡片会话状态."""
 
     __slots__ = (
-        "message_id", "chat_id", "state",
-        "card_msg_id", "card_id", "use_cardkit",
-        "text", "tool_use", "flush",
-        "reasoning_text", "reasoning_start",
-        "footer", "sequence",
         "_loop",
-        "guard", "image_resolver",
-        "last_tool_use_update", "created_at",
+        "card_id",
+        "card_msg_id",
+        "chat_id",
+        "created_at",
+        "flush",
+        "footer",
+        "guard",
+        "image_resolver",
+        "last_tool_use_update",
+        "message_id",
+        "reasoning_start",
+        "reasoning_text",
+        "sequence",
+        "state",
+        "text",
         "tool_panel_added",
+        "tool_use",
+        "use_cardkit",
     )
 
     def __init__(
@@ -129,11 +141,13 @@ class StreamCardController:
             app_secret = self._cfg.feishu_app_secret or self._cfg.env_app_secret
             if not app_id or not app_secret:
                 raise RuntimeError("feishu credentials not configured")
-            self._client = FeishuClient(FeishuClientConfig(
-                app_id=app_id,
-                app_secret=app_secret,
-                base_url=self._cfg.feishu_base_url,
-            ))
+            self._client = FeishuClient(
+                FeishuClientConfig(
+                    app_id=app_id,
+                    app_secret=app_secret,
+                    base_url=self._cfg.feishu_base_url,
+                )
+            )
             self._initialized = True
 
     def _client_ok(self) -> bool:
@@ -211,15 +225,15 @@ class StreamCardController:
         split = split_reasoning_text(text)
 
         if split.get("reasoning_text") and not split.get("answer_text"):
-            session.reasoning_text = split["reasoning_text"]
+            session.reasoning_text = split["reasoning_text"] or ""
             if not session.reasoning_start:
                 session.reasoning_start = time.time()
         elif split.get("answer_text"):
             if split.get("reasoning_text"):
-                session.reasoning_text = split["reasoning_text"]
+                session.reasoning_text = split["reasoning_text"] or ""
                 if not session.reasoning_start:
                     session.reasoning_start = time.time()
-            session.text.on_partial(split["answer_text"])
+            session.text.on_partial(split["answer_text"] or "")
 
         self._schedule_card_update(session)
 
@@ -263,7 +277,7 @@ class StreamCardController:
 
         split = split_reasoning_text(text)
         if split.get("reasoning_text"):
-            session.reasoning_text = split["reasoning_text"]
+            session.reasoning_text = split["reasoning_text"] or ""
             if not session.reasoning_start:
                 session.reasoning_start = time.time()
 
@@ -304,7 +318,8 @@ class StreamCardController:
             old_session.state = ABORTED
             old_session.flush.mark_completed()
             _logger.info(
-                "on_interrupted: abort old msg=%s", old_message_id[:12],
+                "on_interrupted: abort old msg=%s",
+                old_message_id[:12],
             )
             self._fire_and_forget(self._do_complete(old_session), old_session._loop)
 
@@ -315,7 +330,8 @@ class StreamCardController:
                 self._sessions[new_message_id] = session
                 _logger.info(
                     "on_interrupted: create new msg=%s chat=%s",
-                    new_message_id[:12], chat_id[:12],
+                    new_message_id[:12],
+                    chat_id[:12],
                 )
                 self._fire_and_forget(self._do_create_card(session), loop)
 
@@ -343,12 +359,13 @@ class StreamCardController:
             if redirected_id is not None:
                 _logger.info(
                     "on_completed: redirect msg=%s -> msg=%s",
-                    message_id[:12], redirected_id[:12],
+                    message_id[:12],
+                    redirected_id[:12],
                 )
                 session = self._get_active_session(redirected_id)
             if session is None:
                 return False
-            message_id = redirected_id
+            message_id = redirected_id or message_id
 
         # 卡片创建失败 → 交回 gateway 正常回复
         if session.state == FAILED:
@@ -358,7 +375,10 @@ class StreamCardController:
 
         _logger.info(
             "on_completed: msg=%s has_card=%s state=%s use_cardkit=%s",
-            message_id[:12], bool(session.card_msg_id), session.state, session.use_cardkit,
+            message_id[:12],
+            bool(session.card_msg_id),
+            session.state,
+            session.use_cardkit,
         )
 
         if answer:
@@ -382,9 +402,7 @@ class StreamCardController:
         if session.guard.should_skip("_schedule_card_update"):
             return
 
-        session.flush.schedule_update(
-            lambda: self._do_update_card(session)
-        )
+        session.flush.schedule_update(lambda: self._do_update_card(session))
 
     def _schedule_tool_use_status_update(self, session: CardSession) -> None:
         if not session.use_cardkit or not session.card_id:
@@ -393,9 +411,7 @@ class StreamCardController:
         if now - session.last_tool_use_update < 1.5:
             return
         session.last_tool_use_update = now
-        session.flush.schedule_update(
-            lambda: self._do_tool_use_status_update(session)
-        )
+        session.flush.schedule_update(lambda: self._do_tool_use_status_update(session))
 
     async def _do_create_card(self, session: CardSession) -> None:
         if session.state != IDLE:
@@ -404,6 +420,7 @@ class StreamCardController:
 
         try:
             await self._ensure_init()
+            assert self._client is not None
             if session.image_resolver is None and self._client:
                 session.image_resolver = ImageResolver(
                     client=self._client,
@@ -414,7 +431,8 @@ class StreamCardController:
                 card = build_streaming_card_v2(show_tool_use=False)
                 card_id = await self._client.cardkit_create(card)
                 card_msg_id = await self._client.reply_card_by_id(
-                    session.message_id, card_id,
+                    session.message_id,
+                    card_id,
                 )
                 session.card_id = card_id
                 session.card_msg_id = card_msg_id
@@ -423,7 +441,8 @@ class StreamCardController:
             except FeishuAPIError:
                 card = build_im_fallback_card()
                 card_msg_id = await self._client.reply_card(
-                    session.message_id, card,
+                    session.message_id,
+                    card,
                 )
                 session.card_msg_id = card_msg_id
                 session.use_cardkit = False
@@ -434,7 +453,9 @@ class StreamCardController:
                 session.state = STREAMING
             _logger.info(
                 "card created: msg=%s cardkit=%s card_id=%s",
-                session.message_id[:12], session.use_cardkit, (session.card_id or "")[:12],
+                session.message_id[:12],
+                session.use_cardkit,
+                (session.card_id or "")[:12],
             )
         except Exception:
             _logger.exception("_do_create_card failed")
@@ -452,7 +473,8 @@ class StreamCardController:
         if not session.text.is_dirty(display):
             _logger.info(
                 "update_card skipped (not dirty): msg=%s len=%d",
-                session.message_id[:12], len(display),
+                session.message_id[:12],
+                len(display),
             )
             return
 
@@ -461,11 +483,14 @@ class StreamCardController:
 
         _logger.info(
             "update_card: msg=%s seq=%d len=%d cardkit=%s",
-            session.message_id[:12], session.sequence + 1,
-            len(display), session.use_cardkit,
+            session.message_id[:12],
+            session.sequence + 1,
+            len(display),
+            session.use_cardkit,
         )
 
         try:
+            assert self._client is not None
             if session.use_cardkit and session.card_id:
                 optimized = _downgrade_tables(optimize_markdown_style(display))
                 session.sequence += 1
@@ -512,36 +537,45 @@ class StreamCardController:
         if not session.card_id or session.state in _TERMINAL:
             return
         try:
+            assert self._client is not None
             tool_steps = session.tool_use.build_display_steps()
             panel = _build_tool_panel(
-                tool_steps, session.tool_use.elapsed_ms,
+                tool_steps,
+                session.tool_use.elapsed_ms,
             )
             if not session.tool_panel_added:
-                actions = [{
-                    "action": "add_elements",
-                    "params": {
-                        "type": "insert_before",
-                        "target_element_id": STREAMING_ELEMENT_ID,
-                        "elements": [panel],
-                    },
-                }]
+                actions = [
+                    {
+                        "action": "add_elements",
+                        "params": {
+                            "type": "insert_before",
+                            "target_element_id": STREAMING_ELEMENT_ID,
+                            "elements": [panel],
+                        },
+                    }
+                ]
             else:
-                actions = [{
-                    "action": "update_element",
-                    "params": {
-                        "element_id": TOOL_PANEL_ELEMENT_ID,
-                        "element": panel,
-                    },
-                }]
+                actions = [
+                    {
+                        "action": "update_element",
+                        "params": {
+                            "element_id": TOOL_PANEL_ELEMENT_ID,
+                            "element": panel,
+                        },
+                    }
+                ]
             session.sequence += 1
             _logger.info(
                 "tool_update: msg=%s seq=%d action=%s steps=%d",
-                session.message_id[:12], session.sequence,
+                session.message_id[:12],
+                session.sequence,
                 "add" if not session.tool_panel_added else "update",
                 len(tool_steps),
             )
             await self._client.cardkit_batch_update(
-                session.card_id, actions, sequence=session.sequence,
+                session.card_id,
+                actions,
+                sequence=session.sequence,
             )
             session.tool_panel_added = True
         except Exception as e:
@@ -563,8 +597,10 @@ class StreamCardController:
         display = session.text.display_text
         _logger.info(
             "do_complete: msg=%s state=%s display_len=%d cardkit=%s seq=%d",
-            session.message_id[:12], session.state,
-            len(display), session.use_cardkit,
+            session.message_id[:12],
+            session.state,
+            len(display),
+            session.use_cardkit,
             session.sequence,
         )
         if session.image_resolver:
@@ -595,13 +631,17 @@ class StreamCardController:
 
         for attempt in range(3):
             try:
+                assert self._client is not None
                 if session.use_cardkit and session.card_id:
                     await self._client.cardkit_close_streaming(
-                        session.card_id, sequence=session.sequence + 1,
+                        session.card_id,
+                        sequence=session.sequence + 1,
                     )
                     session.sequence += 1
                     await self._client.cardkit_update(
-                        session.card_id, card, sequence=session.sequence + 1,
+                        session.card_id,
+                        card,
+                        sequence=session.sequence + 1,
                     )
                     session.sequence += 1
                 elif session.card_msg_id:
@@ -610,32 +650,39 @@ class StreamCardController:
                 return True
             except FeishuAPIError as e:
                 _logger.warning(
-                    "cardkit complete attempt %d failed (FeishuAPIError): "
-                    "code=%s msg=%s card_id=%s seq=%d",
-                    attempt, e.code, e,
-                    session.card_id, session.sequence,
+                    "cardkit complete attempt %d failed (FeishuAPIError): code=%s msg=%s card_id=%s seq=%d",
+                    attempt,
+                    e.code,
+                    e,
+                    session.card_id,
+                    session.sequence,
                     exc_info=True,
                 )
                 if session.guard.terminate("_do_complete", e):
                     return False
                 if attempt < 2:
-                    await asyncio.sleep(2 ** attempt)
+                    await asyncio.sleep(2**attempt)
                 continue
             except Exception as e:
                 _logger.warning(
-                    "cardkit complete attempt %d failed: %s: %s "
-                    "card_id=%s card_msg_id=%s seq=%d",
-                    attempt, type(e).__name__, e,
-                    session.card_id, session.card_msg_id, session.sequence,
+                    "cardkit complete attempt %d failed: %s: %s card_id=%s card_msg_id=%s seq=%d",
+                    attempt,
+                    type(e).__name__,
+                    e,
+                    session.card_id,
+                    session.card_msg_id,
+                    session.sequence,
                     exc_info=True,
                 )
                 if attempt < 2:
-                    await asyncio.sleep(2 ** attempt)
+                    await asyncio.sleep(2**attempt)
                 continue
 
         _logger.error(
             "cardkit complete failed after 3 attempts: card_id=%s card_msg_id=%s seq=%d",
-            session.card_id, session.card_msg_id, session.sequence,
+            session.card_id,
+            session.card_msg_id,
+            session.sequence,
         )
         session.state = FAILED
         return False
@@ -653,16 +700,13 @@ class StreamCardController:
 
     def _prune_stale_sessions(self) -> None:
         now = time.time()
-        stale = [
-            mid for mid, s in self._sessions.items()
-            if mid is not None and now - s.created_at > self._session_ttl
-        ]
+        stale = [mid for mid, s in self._sessions.items() if mid is not None and now - s.created_at > self._session_ttl]
         for mid in stale:
             _logger.warning("pruning stale session: msg=%s", mid[:12])
             self._cleanup(mid)
 
     @staticmethod
-    def _on_bg_task_done(fut: asyncio.Future) -> None:
+    def _on_bg_task_done(fut: ConcurrentFuture) -> None:
         try:
             fut.result()
         except Exception:

--- a/hermes_lark_streaming/controller.py
+++ b/hermes_lark_streaming/controller.py
@@ -519,8 +519,7 @@ class StreamCardController:
                 return
 
             if e.code == CARDKIT_STREAMING_CLOSED:
-                _logger.info("streaming mode closed, skipping update: msg=%s",
-                             session.message_id[:12])
+                _logger.info("streaming mode closed, skipping update: msg=%s", session.message_id[:12])
                 return
 
             if e.code == CARDKIT_CONTENT_FAILED:

--- a/hermes_lark_streaming/feishu.py
+++ b/hermes_lark_streaming/feishu.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import asyncio
 import io
 import json
+import logging
 import re
 from dataclasses import dataclass
 from typing import Any
-from urllib.request import urlopen, Request
 from urllib.error import URLError
+from urllib.request import Request, urlopen
 
 import lark_oapi as lark
 from lark_oapi.api.cardkit.v1 import (
@@ -28,20 +29,20 @@ from lark_oapi.api.cardkit.v1 import (
 from lark_oapi.api.im.v1 import (
     CreateImageRequest,
     CreateImageRequestBody,
-    CreateMessageRequest,
-    CreateMessageRequestBody,
     PatchMessageRequest,
     PatchMessageRequestBody,
     ReplyMessageRequest,
     ReplyMessageRequestBody,
 )
 
+_logger = logging.getLogger("hermes_lark_streaming")
+
 
 def _sanitize_message(msg: str) -> str:
     """从错误消息中移除 token 和 secret."""
-    msg = re.sub(r'(tenant_access_token["\s:=]+)([A-Za-z0-9_-]{10,})', r'\1***', msg)
-    msg = re.sub(r'(app_secret["\s:=]+)([A-Za-z0-9]{10,})', r'\1***', msg)
-    msg = re.sub(r'(Bearer\s+)([A-Za-z0-9_-]{10,})', r'\1***', msg)
+    msg = re.sub(r'(tenant_access_token["\s:=]+)([A-Za-z0-9_-]{10,})', r"\1***", msg)
+    msg = re.sub(r'(app_secret["\s:=]+)([A-Za-z0-9]{10,})', r"\1***", msg)
+    msg = re.sub(r"(Bearer\s+)([A-Za-z0-9_-]{10,})", r"\1***", msg)
     return msg
 
 
@@ -63,11 +64,11 @@ class FeishuAPIError(RuntimeError):
         return None
 
 
-CARDKIT_RATE_LIMITED = 230020       # 频控
-CARDKIT_CONTENT_FAILED = 230099     # 卡片内容创建失败（通用码，需检查子错误）
-CARDKIT_ELEMENT_LIMIT = 11310       # 子码: 卡片元素数量超限
-CARDKIT_STREAMING_CLOSED = 300309   # 卡片流式模式已关闭
-MSG_NOT_FOUND = 1000023             # 消息不存在/已删除
+CARDKIT_RATE_LIMITED = 230020  # 频控
+CARDKIT_CONTENT_FAILED = 230099  # 卡片内容创建失败（通用码，需检查子错误）
+CARDKIT_ELEMENT_LIMIT = 11310  # 子码: 卡片元素数量超限
+CARDKIT_STREAMING_CLOSED = 300309  # 卡片流式模式已关闭
+MSG_NOT_FOUND = 1000023  # 消息不存在/已删除
 
 
 @dataclass(frozen=True)
@@ -91,11 +92,7 @@ class FeishuClient:
 
     def __init__(self, config: FeishuClientConfig) -> None:
         self.config = config
-        builder = (
-            lark.Client.builder()
-            .app_id(config.app_id)
-            .app_secret(config.app_secret)
-        )
+        builder = lark.Client.builder().app_id(config.app_id).app_secret(config.app_secret)
         self._client = builder.build()
 
     @staticmethod
@@ -118,18 +115,13 @@ class FeishuClient:
         request = (
             ReplyMessageRequest.builder()
             .message_id(message_id)
-            .request_body(
-                ReplyMessageRequestBody.builder()
-                .msg_type("interactive")
-                .content(self._dumps(card))
-                .build()
-            )
+            .request_body(ReplyMessageRequestBody.builder().msg_type("interactive").content(self._dumps(card)).build())
             .build()
         )
         resp = await self._client.im.v1.message.areply(request)
         self._check(resp, "reply_card")
         if resp.data and resp.data.message_id:
-            return resp.data.message_id
+            return str(resp.data.message_id)
         raise FeishuAPIError("reply_card: response missing message_id")
 
     async def reply_card_by_id(self, message_id: str, card_id: str) -> str:
@@ -148,7 +140,7 @@ class FeishuClient:
         resp = await self._client.im.v1.message.areply(request)
         self._check(resp, "reply_card_by_id")
         if resp.data and resp.data.message_id:
-            return resp.data.message_id
+            return str(resp.data.message_id)
         raise FeishuAPIError("reply_card_by_id: response missing message_id")
 
     async def update_card(self, message_id: str, card: dict[str, Any]) -> None:
@@ -156,11 +148,7 @@ class FeishuClient:
         request = (
             PatchMessageRequest.builder()
             .message_id(message_id)
-            .request_body(
-                PatchMessageRequestBody.builder()
-                .content(self._dumps(card))
-                .build()
-            )
+            .request_body(PatchMessageRequestBody.builder().content(self._dumps(card)).build())
             .build()
         )
         resp = await self._client.im.v1.message.apatch(request)
@@ -170,18 +158,13 @@ class FeishuClient:
         """创建 CardKit 实体，返回 card_id."""
         request = (
             CreateCardRequest.builder()
-            .request_body(
-                CreateCardRequestBody.builder()
-                .type("card_json")
-                .data(self._dumps(card))
-                .build()
-            )
+            .request_body(CreateCardRequestBody.builder().type("card_json").data(self._dumps(card)).build())
             .build()
         )
         resp = await self._client.cardkit.v1.card.acreate(request)
         self._check(resp, "cardkit_create")
         if resp.data and resp.data.card_id:
-            return resp.data.card_id
+            return str(resp.data.card_id)
         raise FeishuAPIError("cardkit_create: response missing card_id")
 
     async def cardkit_stream_element(
@@ -203,7 +186,8 @@ class FeishuClient:
             .build()
         )
         resp = await asyncio.to_thread(
-            self._client.cardkit.v1.card_element.content, request,
+            self._client.cardkit.v1.card_element.content,
+            request,
         )
         self._check(resp, "cardkit_stream_element")
 
@@ -215,18 +199,10 @@ class FeishuClient:
     ) -> None:
         """全量更新 CardKit 卡片."""
         body_builder = UpdateCardRequestBody.builder().card(
-            Card.builder()
-            .type("card_json")
-            .data(self._dumps(card))
-            .build()
+            Card.builder().type("card_json").data(self._dumps(card)).build()
         )
         body_builder = body_builder.sequence(sequence)
-        request = (
-            UpdateCardRequest.builder()
-            .card_id(card_id)
-            .request_body(body_builder.build())
-            .build()
-        )
+        request = UpdateCardRequest.builder().card_id(card_id).request_body(body_builder.build()).build()
         resp = await self._client.cardkit.v1.card.aupdate(request)
         self._check(resp, "cardkit_update")
 
@@ -238,32 +214,16 @@ class FeishuClient:
         sequence: int = 0,
     ) -> None:
         """局部更新 CardKit 卡片（增删改组件）."""
-        body_builder = (
-            BatchUpdateCardRequestBody.builder()
-            .sequence(sequence)
-            .actions(self._dumps(actions))
-        )
-        request = (
-            BatchUpdateCardRequest.builder()
-            .card_id(card_id)
-            .request_body(body_builder.build())
-            .build()
-        )
+        body_builder = BatchUpdateCardRequestBody.builder().sequence(sequence).actions(self._dumps(actions))
+        request = BatchUpdateCardRequest.builder().card_id(card_id).request_body(body_builder.build()).build()
         resp = await self._client.cardkit.v1.card.abatch_update(request)
         self._check(resp, "cardkit_batch_update")
 
     async def cardkit_close_streaming(self, card_id: str, sequence: int = 0) -> None:
         """关闭 CardKit 卡片的流式模式."""
-        body_builder = SettingsCardRequestBody.builder().settings(
-            self._dumps({"streaming_mode": False})
-        )
+        body_builder = SettingsCardRequestBody.builder().settings(self._dumps({"streaming_mode": False}))
         body_builder = body_builder.sequence(sequence)
-        request = (
-            SettingsCardRequest.builder()
-            .card_id(card_id)
-            .request_body(body_builder.build())
-            .build()
-        )
+        request = SettingsCardRequest.builder().card_id(card_id).request_body(body_builder.build()).build()
         resp = await self._client.cardkit.v1.card.asettings(request)
         self._check(resp, "cardkit_close_streaming")
 
@@ -272,7 +232,9 @@ class FeishuClient:
         try:
             loop = asyncio.get_running_loop()
             data = await loop.run_in_executor(
-                None, self._download_image, image_url,
+                None,
+                self._download_image,
+                image_url,
             )
         except Exception:
             _logger.debug("image upload failed for %s", image_url, exc_info=True)
@@ -284,17 +246,12 @@ class FeishuClient:
         file = io.BytesIO(data)
         request = (
             CreateImageRequest.builder()
-            .request_body(
-                CreateImageRequestBody.builder()
-                .image_type("message")
-                .image(file)
-                .build()
-            )
+            .request_body(CreateImageRequestBody.builder().image_type("message").image(file).build())
             .build()
         )
         resp = await self._client.im.v1.image.acreate(request)
         if resp.success() and resp.data and resp.data.image_key:
-            return resp.data.image_key
+            return str(resp.data.image_key)
         return None
 
     @staticmethod
@@ -305,7 +262,7 @@ class FeishuClient:
             with urlopen(req, timeout=timeout) as resp:
                 if resp.status != 200:
                     return None
-                return resp.read()
+                return bytes(resp.read())
         except (URLError, OSError):
             _logger.debug("image download failed: %s", url)
             return None

--- a/hermes_lark_streaming/flush.py
+++ b/hermes_lark_streaming/flush.py
@@ -11,14 +11,14 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from typing import Awaitable, Callable
+from collections.abc import Awaitable, Callable
 
 _logger = logging.getLogger("hermes_lark_streaming")
 
 
-CARDKIT_MS = 0.100        # CardKit 流式 API 的刷新间隔
-PATCH_MS = 1.500          # IM patch 降级通道的刷新间隔
-LONG_GAP_MS = 2.000       # 超过此间隔 → 认为是长时间空闲
+CARDKIT_MS = 0.100  # CardKit 流式 API 的刷新间隔
+PATCH_MS = 1.500  # IM patch 降级通道的刷新间隔
+LONG_GAP_MS = 2.000  # 超过此间隔 → 认为是长时间空闲
 BATCH_AFTER_GAP_MS = 0.300  # 长时间空闲后等待这个时间再 flush
 
 
@@ -42,7 +42,6 @@ class FlushController:
         except RuntimeError:
             self._loop = asyncio.get_event_loop()
 
-
     @property
     def throttle_ms(self) -> float:
         return self._throttle_ms
@@ -54,7 +53,6 @@ class FlushController:
     @property
     def last_update_time(self) -> float:
         return self._last_update_time
-
 
     def schedule_update(self, do_flush: Callable[[], Awaitable[None]]) -> None:
         """请求一次节流后的卡片刷新.
@@ -114,11 +112,12 @@ class FlushController:
         if ready:
             self._last_update_time = time.monotonic()
 
-
     def _schedule(self, delay: float, do_flush: Callable[[], Awaitable[None]]) -> None:
         self._cancel_timer()
         self._pending_timer = self._loop.call_later(
-            delay, self._do_flush_task, do_flush,
+            delay,
+            self._do_flush_task,
+            do_flush,
         )
 
     def _do_flush_task(self, do_flush: Callable[[], Awaitable[None]]) -> None:

--- a/hermes_lark_streaming/image.py
+++ b/hermes_lark_streaming/image.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
-from typing import TYPE_CHECKING, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .feishu import FeishuClient
@@ -35,9 +36,9 @@ class ImageResolver:
         self._client = client
         self._timeout = timeout
         self._on_image_resolved = on_image_resolved
-        self._cache: dict[str, str] = {}       # url → img_key
+        self._cache: dict[str, str] = {}  # url → img_key
         self._pending: dict[str, asyncio.Task[str | None]] = {}  # url → upload task
-        self._failed: set[str] = set()          # 已失败的不重试
+        self._failed: set[str] = set()  # 已失败的不重试
 
     def resolve_images(self, text: str) -> str:
         """同步解析图片：缓存命中替换、新 URL strip 并触发异步上传.
@@ -48,12 +49,12 @@ class ImageResolver:
             return text
 
         def _replace(m: re.Match) -> str:
-            alt = m.group(0).split("](")[0][2:]  # extract alt text
-            url = m.group(1)
+            alt = str(m.group(0)).split("](")[0][2:]  # extract alt text
+            url = str(m.group(1))
 
             # 已经是飞书 img_key
             if url.startswith("img_"):
-                return m.group(0)
+                return str(m.group(0))
 
             # 缓存命中
             if url in self._cache:
@@ -89,7 +90,7 @@ class ImageResolver:
                     asyncio.gather(*tasks, return_exceptions=True),
                     timeout=self._timeout,
                 )
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 _logger.warning("image_resolver: timeout waiting for uploads")
 
         # 第二遍：替换已完成的

--- a/hermes_lark_streaming/patch.py
+++ b/hermes_lark_streaming/patch.py
@@ -7,8 +7,9 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from functools import wraps
-from typing import Any, Callable
+from typing import Any
 
 from .controller import get_controller
 
@@ -20,6 +21,7 @@ def _safe_hook(
     log_level: str = "warning",
 ) -> Callable:
     """统一处理 enabled 检查和异常捕获."""
+
     def decorator(func: Callable) -> Callable:
         @wraps(func)
         def wrapper(*, message_id: str, **kwargs: Any) -> Any:
@@ -31,7 +33,9 @@ def _safe_hook(
             except Exception as exc:
                 getattr(_logger, log_level)("%s error: %s", func.__name__, exc, exc_info=True)
                 return default_return
+
         return wrapper
+
     return decorator
 
 
@@ -53,14 +57,14 @@ def on_message_completed(
     context: dict[str, Any] | None = None,
 ) -> bool:
     """[注入点 2] return 前 — message.completed."""
-    return ctrl.on_completed(
+    return bool(ctrl.on_completed(
         message_id=message_id,
         answer=answer,
         duration=duration,
         model=model,
         tokens=tokens,
         context=context,
-    )
+    ))
 
 
 @_safe_hook(default_return=False)

--- a/hermes_lark_streaming/patch.py
+++ b/hermes_lark_streaming/patch.py
@@ -57,14 +57,16 @@ def on_message_completed(
     context: dict[str, Any] | None = None,
 ) -> bool:
     """[注入点 2] return 前 — message.completed."""
-    return bool(ctrl.on_completed(
-        message_id=message_id,
-        answer=answer,
-        duration=duration,
-        model=model,
-        tokens=tokens,
-        context=context,
-    ))
+    return bool(
+        ctrl.on_completed(
+            message_id=message_id,
+            answer=answer,
+            duration=duration,
+            model=model,
+            tokens=tokens,
+            context=context,
+        )
+    )
 
 
 @_safe_hook(default_return=False)

--- a/hermes_lark_streaming/patcher.py
+++ b/hermes_lark_streaming/patcher.py
@@ -13,9 +13,7 @@ _logger = logging.getLogger("hermes_lark_streaming")
 PREFIX = "HERMES_LARK"
 
 _HOOK_NAMES = ["START", "COMPLETE", "TOOL", "ANSWER", "THINKING", "ABORT", "INTERRUPT"]
-MARKERS: list[tuple[str, str]] = [
-    (f"# {PREFIX}_{n}_BEGIN", f"# {PREFIX}_{n}_END") for n in _HOOK_NAMES
-]
+MARKERS: list[tuple[str, str]] = [(f"# {PREFIX}_{n}_BEGIN", f"# {PREFIX}_{n}_END") for n in _HOOK_NAMES]
 
 MK_START, MK_START_END = MARKERS[0]
 MK_COMPLETE, MK_COMPLETE_END = MARKERS[1]
@@ -35,103 +33,138 @@ def _make_hook(indent: str, begin: str, end: str, body_lines: list[str]) -> str:
 
 
 def _start_hook(indent: str) -> str:
-    return _make_hook(indent, MK_START, MK_START_END, [
-        "try:",
-        "    from hermes_lark_streaming.patch import on_message_started",
-        "    on_message_started(message_id=event.message_id, chat_id=source.chat_id)",
-        "except Exception:",
-        "    pass",
-    ])
+    return _make_hook(
+        indent,
+        MK_START,
+        MK_START_END,
+        [
+            "try:",
+            "    from hermes_lark_streaming.patch import on_message_started",
+            "    on_message_started(message_id=event.message_id, chat_id=source.chat_id)",
+            "except Exception:",
+            "    pass",
+        ],
+    )
 
 
 def _complete_hook(indent: str) -> str:
-    return _make_hook(indent, MK_COMPLETE, MK_COMPLETE_END, [
-        "try:",
-        "    from hermes_lark_streaming.patch import on_message_completed",
-        "    _lark_card_sent = on_message_completed(",
-        "        message_id=event.message_id,",
-        "        answer=response,",
-        "        duration=_response_time,",
-        "        model=agent_result.get('model', ''),",
-        "        tokens={",
-        "            'input_tokens': agent_result.get('input_tokens', 0),",
-        "            'output_tokens': agent_result.get('output_tokens', 0),",
-        "        },",
-        "        context={",
-        "            'used_tokens': agent_result.get('last_prompt_tokens', 0),",
-        "            'max_tokens': agent_result.get('context_length', 0),",
-        "        },",
-        "    )",
-        "    if _lark_card_sent:",
-        "        agent_result['already_sent'] = True",
-        "except Exception:",
-        "    pass",
-    ])
+    return _make_hook(
+        indent,
+        MK_COMPLETE,
+        MK_COMPLETE_END,
+        [
+            "try:",
+            "    from hermes_lark_streaming.patch import on_message_completed",
+            "    _lark_card_sent = on_message_completed(",
+            "        message_id=event.message_id,",
+            "        answer=response,",
+            "        duration=_response_time,",
+            "        model=agent_result.get('model', ''),",
+            "        tokens={",
+            "            'input_tokens': agent_result.get('input_tokens', 0),",
+            "            'output_tokens': agent_result.get('output_tokens', 0),",
+            "        },",
+            "        context={",
+            "            'used_tokens': agent_result.get('last_prompt_tokens', 0),",
+            "            'max_tokens': agent_result.get('context_length', 0),",
+            "        },",
+            "    )",
+            "    if _lark_card_sent:",
+            "        agent_result['already_sent'] = True",
+            "except Exception:",
+            "    pass",
+        ],
+    )
 
 
 def _tool_hook(indent: str) -> str:
-    return _make_hook(indent, MK_TOOL, MK_TOOL_END, [
-        "try:",
-        "    from hermes_lark_streaming.patch import on_tool_updated",
-        "    if _run_still_current() and event_type in ('tool.started', 'tool.completed'):",
-        "        if on_tool_updated(",
-        "            message_id=event_message_id,",
-        "            tool_name=tool_name or '',",
-        "            status='started' if event_type == 'tool.started' else 'completed',",
-        "            detail=preview or '',",
-        "        ):",
-        "            return",
-        "except Exception:",
-        "    pass",
-    ])
+    return _make_hook(
+        indent,
+        MK_TOOL,
+        MK_TOOL_END,
+        [
+            "try:",
+            "    from hermes_lark_streaming.patch import on_tool_updated",
+            "    if _run_still_current() and event_type in ('tool.started', 'tool.completed'):",
+            "        if on_tool_updated(",
+            "            message_id=event_message_id,",
+            "            tool_name=tool_name or '',",
+            "            status='started' if event_type == 'tool.started' else 'completed',",
+            "            detail=preview or '',",
+            "        ):",
+            "            return",
+            "except Exception:",
+            "    pass",
+        ],
+    )
 
 
 def _answer_hook(indent: str) -> str:
-    return _make_hook(indent, MK_ANSWER, MK_ANSWER_END, [
-        "try:",
-        "    from hermes_lark_streaming.patch import on_answer_delta",
-        "    if text and _run_still_current() and on_answer_delta(message_id=event_message_id, text=text):",
-        "        return",
-        "except Exception:",
-        "    pass",
-    ])
+    return _make_hook(
+        indent,
+        MK_ANSWER,
+        MK_ANSWER_END,
+        [
+            "try:",
+            "    from hermes_lark_streaming.patch import on_answer_delta",
+            "    if text and _run_still_current() and on_answer_delta(message_id=event_message_id, text=text):",
+            "        return",
+            "except Exception:",
+            "    pass",
+        ],
+    )
 
 
 def _thinking_hook(indent: str) -> str:
-    return _make_hook(indent, MK_THINKING, MK_THINKING_END, [
-        "try:",
-        "    from hermes_lark_streaming.patch import on_thinking_delta",
-        "    if (text and not already_streamed and _run_still_current()",
-        "            and on_thinking_delta(message_id=event_message_id, text=text)):",
-        "        return",
-        "except Exception:",
-        "    pass",
-    ])
+    return _make_hook(
+        indent,
+        MK_THINKING,
+        MK_THINKING_END,
+        [
+            "try:",
+            "    from hermes_lark_streaming.patch import on_thinking_delta",
+            "    if (text and not already_streamed and _run_still_current()",
+            "            and on_thinking_delta(message_id=event_message_id, text=text)):",
+            "        return",
+            "except Exception:",
+            "    pass",
+        ],
+    )
 
 
 def _abort_hook(indent: str) -> str:
-    return _make_hook(indent, MK_ABORT, MK_ABORT_END, [
-        "try:",
-        "    from hermes_lark_streaming.patch import on_message_aborted",
-        "    on_message_aborted(message_id=event.message_id)",
-        "except Exception:",
-        "    pass",
-    ])
+    return _make_hook(
+        indent,
+        MK_ABORT,
+        MK_ABORT_END,
+        [
+            "try:",
+            "    from hermes_lark_streaming.patch import on_message_aborted",
+            "    on_message_aborted(message_id=event.message_id)",
+            "except Exception:",
+            "    pass",
+        ],
+    )
 
 
 def _interrupt_hook(indent: str) -> str:
-    return _make_hook(indent, MK_INTERRUPT, MK_INTERRUPT_END, [
-        "try:",
-        "    from hermes_lark_streaming.patch import on_message_interrupted",
-        "    if was_interrupted and next_message_id:",
-        "        on_message_interrupted(",
-        "            message_id=event_message_id,",
-        "            new_message_id=next_message_id,",
-        "            chat_id=source.chat_id,",
-        "        )",
-        "except Exception:",
-        "    pass",
-    ])
+    return _make_hook(
+        indent,
+        MK_INTERRUPT,
+        MK_INTERRUPT_END,
+        [
+            "try:",
+            "    from hermes_lark_streaming.patch import on_message_interrupted",
+            "    if was_interrupted and next_message_id:",
+            "        on_message_interrupted(",
+            "            message_id=event_message_id,",
+            "            new_message_id=next_message_id,",
+            "            chat_id=source.chat_id,",
+            "        )",
+            "except Exception:",
+            "    pass",
+        ],
+    )
 
 
 class PatcherError(RuntimeError):
@@ -157,10 +190,7 @@ class Patcher:
 
         handler = _find_func_body(tree, content.splitlines(keepends=True), "_handle_message_with_agent")
         if handler is None:
-            raise PatcherError(
-                "Cannot find _handle_message_with_agent in run.py — "
-                "Hermes version may be incompatible"
-            )
+            raise PatcherError("Cannot find _handle_message_with_agent in run.py — Hermes version may be incompatible")
 
         anchor_found = False
         for node in ast.walk(tree):
@@ -168,18 +198,16 @@ class Patcher:
                 func = node.func
                 if isinstance(func, ast.Attribute) and func.attr == "emit":
                     hooks_obj = func.value
-                    if isinstance(hooks_obj, ast.Attribute) and hooks_obj.attr == "hooks":
-                        if (
-                            node.args
-                            and isinstance(node.args[0], ast.Constant)
-                            and node.args[0].value == "agent:end"
-                        ):
-                            anchor_found = True
-                            break
+                    if (
+                        isinstance(hooks_obj, ast.Attribute)
+                        and hooks_obj.attr == "hooks"
+                        and (node.args and isinstance(node.args[0], ast.Constant) and node.args[0].value == "agent:end")
+                    ):
+                        anchor_found = True
+                        break
         if not anchor_found:
             raise PatcherError(
-                "Cannot find hooks.emit('agent:end', ...) anchor in run.py — "
-                "Hermes version may be incompatible"
+                "Cannot find hooks.emit('agent:end', ...) anchor in run.py — Hermes version may be incompatible"
             )
 
         required_callbacks = {
@@ -188,21 +216,16 @@ class Patcher:
             "_interim_assistant_cb": False,
         }
         for node in ast.walk(tree):
-            if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
-                if node.name in required_callbacks:
-                    required_callbacks[node.name] = True
+            if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name in required_callbacks:
+                required_callbacks[node.name] = True
         missing = [name for name, found in required_callbacks.items() if not found]
         if missing:
             raise PatcherError(
-                f"Missing injection targets in run.py: {', '.join(missing)} — "
-                "Hermes version may be incompatible"
+                f"Missing injection targets in run.py: {', '.join(missing)} — Hermes version may be incompatible"
             )
 
         if "Restart typing indicator so the user sees activity" not in content:
-            raise PatcherError(
-                "Cannot find interrupt anchor in run.py — "
-                "Hermes version may be incompatible"
-            )
+            raise PatcherError("Cannot find interrupt anchor in run.py — Hermes version may be incompatible")
 
     def apply(self) -> None:
         if self.is_patched():
@@ -227,7 +250,6 @@ class Patcher:
         if not backup.exists():
             raise PatcherError(f"No backup found: {backup}")
         shutil.copy2(backup, self.run_path)
-
 
     def _backup(self) -> None:
         backup = self.run_path.with_suffix(self.run_path.suffix + _BACKUP_SUFFIX)
@@ -283,7 +305,7 @@ class Patcher:
                 break
 
         if begin_idx is not None and end_idx is not None:
-            return "".join(lines[:begin_idx] + lines[end_idx + 1:])
+            return "".join(lines[:begin_idx] + lines[end_idx + 1 :])
         return content
 
 
@@ -316,9 +338,10 @@ def _find_handler_return(tree: ast.Module, lines: list[str]) -> tuple[int, str] 
     for node in ast.walk(tree):
         if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == "_handle_message_with_agent":
             returns = [
-                n for n in ast.walk(node)
+                n
+                for n in ast.walk(node)
                 if isinstance(n, ast.Return)
-                and isinstance(getattr(n, "value", None), ast.Name)
+                and isinstance(n.value, ast.Name)
                 and n.value.id == "response"
                 and n.lineno is not None
             ]
@@ -353,8 +376,8 @@ def _safe_indent(lines: list[str], lineno: int) -> str:
     """获取缩进，跳过空行."""
     for i in range(lineno, -1, -1):
         if 0 <= i < len(lines) and lines[i].strip():
-            return lines[i][:len(lines[i]) - len(lines[i].lstrip())]
+            return lines[i][: len(lines[i]) - len(lines[i].lstrip())]
     for i in range(lineno + 1, len(lines)):
         if lines[i].strip():
-            return lines[i][:len(lines[i]) - len(lines[i].lstrip())]
+            return lines[i][: len(lines[i]) - len(lines[i].lstrip())]
     return ""

--- a/hermes_lark_streaming/text.py
+++ b/hermes_lark_streaming/text.py
@@ -47,15 +47,20 @@ def extract_thinking_content(text: str) -> str:
 
 def strip_reasoning_tags(text: str) -> str:
     result = _REASONING_OPEN_RE.sub(
-        lambda _: "", _REASONING_CLOSE_RE.sub("", text),
+        lambda _: "",
+        _REASONING_CLOSE_RE.sub("", text),
     )
     result = re.sub(
         r"<\s*" + _REASONING_TAG + r"\s*>[\s\S]*?<\s*/\s*" + _REASONING_TAG + r"\s*>",
-        "", result, flags=re.IGNORECASE,
+        "",
+        result,
+        flags=re.IGNORECASE,
     )
     result = re.sub(
         r"<\s*" + _REASONING_TAG + r"\s*>[\s\S]*$",
-        "", result, flags=re.IGNORECASE,
+        "",
+        result,
+        flags=re.IGNORECASE,
     )
     if result.strip().startswith(REASONING_PREFIX):
         result = ""
@@ -65,8 +70,7 @@ def strip_reasoning_tags(text: str) -> str:
 def _clean_reasoning_prefix(text: str) -> str:
     cleaned = re.sub(r"^Reasoning:\s*", "", text, flags=re.IGNORECASE)
     cleaned = "\n".join(
-        line.replace("_", "") if line.startswith("_") and line.endswith("_") else line
-        for line in cleaned.split("\n")
+        line.replace("_", "") if line.startswith("_") and line.endswith("_") else line for line in cleaned.split("\n")
     )
     return cleaned.strip()
 

--- a/hermes_lark_streaming/tooluse.py
+++ b/hermes_lark_streaming/tooluse.py
@@ -13,11 +13,11 @@ from typing import Any
 @dataclass
 class ToolStep:
     name: str
-    status: str          # running | success | error
+    status: str  # running | success | error
     detail: str = ""
     output: str = ""
     error: str = ""
-    result_block: dict[str, Any] | None = None   # {"language": "json"|"text", "content": str}
+    result_block: dict[str, Any] | None = None  # {"language": "json"|"text", "content": str}
     error_block: dict[str, Any] | None = None
     started_at: float = 0.0
     elapsed_ms: float = 0.0
@@ -35,11 +35,10 @@ _SENSITIVE_NAME_RE = re.compile(
     re.IGNORECASE,
 )
 
-_INLINE_ASSIGNMENT_RE = re.compile(
-    r'(^|[\s"\'`])([A-Za-z_][A-Za-z0-9_]*)(=(?:"[^"]*"|\'[^\']*\'|[^\s"\'`]+))'
-)
+_INLINE_ASSIGNMENT_RE = re.compile(r'(^|[\s"\'`])([A-Za-z_][A-Za-z0-9_]*)(=(?:"[^"]*"|\'[^\']*\'|[^\s"\'`]+))')
 _AUTH_HEADER_RE = re.compile(
-    r"(Authorization\s*:\s*(?:Bearer|Basic|Token)\s+)([^\'\"\s]+)", re.IGNORECASE,
+    r"(Authorization\s*:\s*(?:Bearer|Basic|Token)\s+)([^\'\"\s]+)",
+    re.IGNORECASE,
 )
 _SECRET_FLAG_RE = re.compile(
     r'((?:^|[\s"\'`])(--?[A-Za-z0-9][A-Za-z0-9-]*)(=|\s+)("(?:[^"]*)"|\'(?:[^\']*)\'|[^\s"\'`]+))'
@@ -48,21 +47,22 @@ _SECRET_FLAG_RE = re.compile(
 
 def redact_inline_secrets(value: str) -> str:
     """脱敏 key=secret、Authorization header、--flag secret 模式."""
+
     def _redact_assign(m: re.Match) -> str:
-        key = m.group(2)
+        key = str(m.group(2))
         if _SENSITIVE_NAME_RE.search(key):
             return f"{m.group(1)}{key}=[redacted]"
-        return m.group(0)
+        return str(m.group(0))
 
     def _redact_flag(m: re.Match) -> str:
-        flag = re.sub(r'^-+', '', m.group(2))
+        flag = re.sub(r"^-+", "", str(m.group(2)))
         if _SENSITIVE_NAME_RE.search(flag):
             return f"{m.group(1)}{m.group(2)}{m.group(3)}[redacted]"
-        return m.group(0)
+        return str(m.group(0))
 
     return _SECRET_FLAG_RE.sub(
         _redact_flag,
-        _AUTH_HEADER_RE.sub(r'\1[redacted]', _INLINE_ASSIGNMENT_RE.sub(_redact_assign, value)),
+        _AUTH_HEADER_RE.sub(r"\1[redacted]", _INLINE_ASSIGNMENT_RE.sub(_redact_assign, value)),
     )
 
 
@@ -77,11 +77,9 @@ def _sanitize_detail(text: str, sanitizer: str | None) -> str:
         cleaned = redact_inline_secrets(cleaned)
         return _redact_paths(cleaned)
     if sanitizer == "path":
-        return _basename_only(
-            re.sub(r'^(?:from|file|path)\s+', '', cleaned, flags=re.IGNORECASE).strip()
-        )
+        return _basename_only(re.sub(r"^(?:from|file|path)\s+", "", cleaned, flags=re.IGNORECASE).strip())
     if sanitizer == "search":
-        return cleaned.strip('\'"')
+        return cleaned.strip("'\"")
     if sanitizer == "url":
         if cleaned.lower().startswith("from "):
             return cleaned.strip("'\"").replace("from ", "", 1)
@@ -233,13 +231,14 @@ class ToolUseTracker:
             self._session = ToolSession(started_at=time.time())
         if len(self._session.steps) >= self._max_steps:
             return
-        desc = _resolve_tool_descriptor(name)
-        self._session.steps.append(ToolStep(
-            name=name,
-            status="running",
-            detail=detail,
-            started_at=time.time(),
-        ))
+        self._session.steps.append(
+            ToolStep(
+                name=name,
+                status="running",
+                detail=detail,
+                started_at=time.time(),
+            )
+        )
 
     def record_end(self, name: str, *, error: str = "", output: str = "") -> None:
         """通过名字匹配最近的一个 running 步骤来结束."""
@@ -258,16 +257,18 @@ class ToolUseTracker:
                 elif output:
                     step.result_block = _build_display_block(output, "json", sanitizer=sanitizer)
                 return
-        self._session.steps.append(ToolStep(
-            name=name,
-            status="error" if error else "success",
-            detail=error or output,
-            output=output,
-            error=error,
-            started_at=time.time(),
-            error_block=_build_display_block(error, "text", sanitizer=sanitizer) if error else None,
-            result_block=_build_display_block(output, "json", sanitizer=sanitizer) if output else None,
-        ))
+        self._session.steps.append(
+            ToolStep(
+                name=name,
+                status="error" if error else "success",
+                detail=error or output,
+                output=output,
+                error=error,
+                started_at=time.time(),
+                error_block=_build_display_block(error, "text", sanitizer=sanitizer) if error else None,
+                result_block=_build_display_block(output, "json", sanitizer=sanitizer) if output else None,
+            )
+        )
 
     def build_display_steps(self) -> list[dict[str, Any]]:
         """构建用于卡片渲染的步骤列表 — 与 openclaw 结构对齐."""
@@ -281,16 +282,18 @@ class ToolUseTracker:
                 base_title = f"{base_title} ({_format_duration_label(s.elapsed_ms)})"
             sanitizer = desc.get("sanitizer") if desc else None
             detail = _sanitize_detail(s.detail, sanitizer)
-            steps.append({
-                "name": s.name,
-                "title": base_title,
-                "status": s.status,
-                "detail": detail,
-                "output": s.output,
-                "error": s.error,
-                "icon": desc["icon"] if desc else "setting-inter_outlined",
-                "elapsed_ms": s.elapsed_ms,
-                "result_block": None if (desc and desc.get("no_result")) else s.result_block,
-                "error_block": s.error_block,
-            })
+            steps.append(
+                {
+                    "name": s.name,
+                    "title": base_title,
+                    "status": s.status,
+                    "detail": detail,
+                    "output": s.output,
+                    "error": s.error,
+                    "icon": desc["icon"] if desc else "setting-inter_outlined",
+                    "elapsed_ms": s.elapsed_ms,
+                    "result_block": None if (desc and desc.get("no_result")) else s.result_block,
+                    "error_block": s.error_block,
+                }
+            )
         return steps

--- a/hermes_lark_streaming/unavailable_guard.py
+++ b/hermes_lark_streaming/unavailable_guard.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 import logging
 import re
 import time
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from .feishu import MSG_NOT_FOUND
 
@@ -16,9 +17,9 @@ _logger = logging.getLogger("hermes_lark_streaming")
 
 
 _TERMINAL_MESSAGE_CODES = {
-    231003,    # message deleted
+    231003,  # message deleted
     MSG_NOT_FOUND,
-    230011,    # message recalled
+    230011,  # message recalled
 }
 
 
@@ -29,10 +30,7 @@ _UNENHANCED_CACHE_TTL_SEC = 30 * 60  # 30 分钟 TTL
 def _prune_cache() -> None:
     """清理过期缓存条目."""
     now = time.time()
-    expired = [
-        k for k, v in _unavailable_cache.items()
-        if now - v.get("at", 0) > _UNENHANCED_CACHE_TTL_SEC
-    ]
+    expired = [k for k, v in _unavailable_cache.items() if now - v.get("at", 0) > _UNENHANCED_CACHE_TTL_SEC]
     for k in expired:
         _unavailable_cache.pop(k, None)
 
@@ -59,7 +57,7 @@ def extract_api_code(err: Exception | None) -> int | None:
     if err is None:
         return None
     if hasattr(err, "code"):
-        code = getattr(err, "code")
+        code = err.code
         if isinstance(code, int):
             return code
     if hasattr(err, "args") and err.args:
@@ -116,15 +114,15 @@ class UnavailableGuard:
         card_msg_id = self._get_card_message_id()
 
         # 从错误码或缓存中判断
-        if code is None:
-            # 检查缓存
-            if is_unavailable(self._reply_to_message_id) or is_unavailable(card_msg_id):
-                code = _unavailable_cache.get(
-                    self._reply_to_message_id or "", {}
-                ).get("code") or _unavailable_cache.get(card_msg_id or "", {}).get("code")
+        if code is None and (is_unavailable(self._reply_to_message_id) or is_unavailable(card_msg_id)):
+            code = _unavailable_cache.get(self._reply_to_message_id or "", {}).get("code") or _unavailable_cache.get(
+                card_msg_id or "", {}
+            ).get("code")
 
         if not is_terminal_api_code(code):
             return False
+
+        assert code is not None
 
         self._terminated = True
         self._on_terminate()
@@ -132,7 +130,9 @@ class UnavailableGuard:
         affected = self._reply_to_message_id or card_msg_id or "unknown"
         _logger.warning(
             "reply pipeline terminated by unavailable message: source=%s code=%s message_id=%s",
-            source, code, affected,
+            source,
+            code,
+            affected,
         )
 
         # 标记缓存

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,32 @@ hermes-lark-streaming = "hermes_lark_streaming"
 dev = [
   "pytest>=7.0",
   "pytest-asyncio>=0.21",
+  "ruff>=0.8",
+  "mypy>=1.11",
+  "types-PyYAML",
 ]
 
 [tool.setuptools.packages.find]
 include = ["hermes_lark_streaming*"]
+
+[tool.ruff]
+target-version = "py311"
+line-length = 120
+exclude = ["tests/samples"]
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "B", "SIM", "RUF"]
+ignore = ["RUF002", "RUF003", "RUF006"]
+
+[tool.ruff.format]
+quote-style = "double"
+
+[tool.mypy]
+python_version = "3.11"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+
+[[tool.mypy.overrides]]
+module = "lark_oapi.*"
+ignore_missing_imports = true

--- a/tests/test_cardkit.py
+++ b/tests/test_cardkit.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-import pytest
-
 from hermes_lark_streaming.cardkit import (
-    STREAMING_ELEMENT_ID,
     TOOL_PANEL_ELEMENT_ID,
     _build_footer_elements,
     _build_reasoning_panel,
@@ -25,8 +22,8 @@ from hermes_lark_streaming.cardkit import (
     optimize_markdown_style,
 )
 
-
 # --- Markdown 优化 ---
+
 
 class TestOptimizeMarkdownStyle:
     def test_h1_downgraded_to_h4(self) -> None:
@@ -79,12 +76,11 @@ class TestStripInvalidImageKeys:
         assert "img_v3_test" in _strip_invalid_image_keys("![a](img_v3_test)")
 
     def test_non_img_removed(self) -> None:
-        assert "http://example.com/img.png" not in _strip_invalid_image_keys(
-            "![a](http://example.com/img.png)"
-        )
+        assert "http://example.com/img.png" not in _strip_invalid_image_keys("![a](http://example.com/img.png)")
 
 
 # --- 表格处理 ---
+
 
 class TestFindTablesOutsideCodeBlocks:
     def test_no_tables(self) -> None:
@@ -121,6 +117,7 @@ class TestDowngradeTables:
 
 # --- 文本拆分 ---
 
+
 class TestSplitLongText:
     def test_short_text_not_split(self) -> None:
         assert _split_long_text("short") == ["short"]
@@ -145,9 +142,16 @@ class TestSplitLongText:
 # --- 工具面板 ---
 
 _STEP_RUNNING = {
-    "name": "read", "title": "Read", "status": "running",
-    "detail": "", "output": "", "error": "", "icon": "icon",
-    "elapsed_ms": 0, "result_block": None, "error_block": None,
+    "name": "read",
+    "title": "Read",
+    "status": "running",
+    "detail": "",
+    "output": "",
+    "error": "",
+    "icon": "icon",
+    "elapsed_ms": 0,
+    "result_block": None,
+    "error_block": None,
 }
 _STEP_SUCCESS = {**_STEP_RUNNING, "status": "success", "output": "ok", "elapsed_ms": 100}
 
@@ -169,6 +173,7 @@ class TestBuildToolPanel:
 
 
 # --- Footer ---
+
 
 class TestBuildFooterElements:
     def test_empty_data_renders_default_status(self) -> None:
@@ -239,6 +244,7 @@ class TestBuildFooterElements:
 
 # --- 推理面板 ---
 
+
 class TestBuildReasoningPanel:
     def test_without_elapsed(self) -> None:
         panel = _build_reasoning_panel("thinking content")
@@ -252,6 +258,7 @@ class TestBuildReasoningPanel:
 
 
 # --- 数字格式化 ---
+
 
 class TestCompact:
     def test_small_number(self) -> None:
@@ -283,6 +290,7 @@ class TestFormatElapsed:
 
 # --- 工具函数 ---
 
+
 class TestEscapeMd:
     def test_escapes_special_chars(self) -> None:
         result = _escape_md("a`b*c{d}e[f]g<h>i")
@@ -304,6 +312,7 @@ class TestLongestBacktickRun:
 
 
 # --- 完整卡片构建 ---
+
 
 class TestBuildStreamingCardV2:
     def test_structure(self) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,8 +6,6 @@ import os
 from typing import Any
 from unittest.mock import patch
 
-import pytest
-
 from hermes_lark_streaming.config import Config
 
 
@@ -132,7 +130,9 @@ class TestFeishuBaseURL:
 
     def test_from_env(self) -> None:
         cfg = _make_config({})
-        with patch.dict(os.environ, {"FEISHU_APP_ID": "id", "FEISHU_APP_SECRET": "s", "FEISHU_BASE_URL": "https://env.com"}):
+        with patch.dict(
+            os.environ, {"FEISHU_APP_ID": "id", "FEISHU_APP_SECRET": "s", "FEISHU_BASE_URL": "https://env.com"}
+        ):
             assert cfg.feishu_base_url == "https://env.com"
 
 
@@ -150,10 +150,12 @@ class TestPlatformCfg:
             assert result["app_id"] == "lark_id"
 
     def test_feishu_before_lark(self) -> None:
-        cfg = _make_config({
-            "feishu": {"app_id": "feishu_id", "app_secret": "fs"},
-            "lark": {"app_id": "lark_id", "app_secret": "ls"},
-        })
+        cfg = _make_config(
+            {
+                "feishu": {"app_id": "feishu_id", "app_secret": "fs"},
+                "lark": {"app_id": "lark_id", "app_secret": "ls"},
+            }
+        )
         with patch.dict(os.environ, {}, clear=True):
             result = cfg._platform_cfg()
             assert result["app_id"] == "feishu_id"

--- a/tests/test_flush.py
+++ b/tests/test_flush.py
@@ -9,7 +9,6 @@ import pytest
 
 from hermes_lark_streaming.flush import (
     BATCH_AFTER_GAP_MS,
-    CARDKIT_MS,
     LONG_GAP_MS,
     FlushController,
 )
@@ -184,7 +183,7 @@ class TestWaitForFlush:
             await flush_event.wait()
 
         # 启动一个阻塞的 flush
-        asyncio.create_task(ctrl._do_flush(slow_flush))
+        _task = asyncio.create_task(ctrl._do_flush(slow_flush))
         await asyncio.sleep(0.02)
         assert ctrl._flush_in_progress
 
@@ -223,7 +222,7 @@ class TestMarkCompleted:
         async def blocking_flush() -> None:
             await flush_event.wait()
 
-        asyncio.create_task(ctrl._do_flush(blocking_flush))
+        _task = asyncio.create_task(ctrl._do_flush(blocking_flush))
         await asyncio.sleep(0.02)
 
         waiter = asyncio.create_task(ctrl.wait_for_flush())
@@ -255,7 +254,7 @@ class TestReflush:
         assert ctrl._flush_in_progress
 
         # 再次尝试 flush → 应设置 reflush 标志
-        task2 = asyncio.create_task(ctrl._do_flush(slow_flush))
+        asyncio.create_task(ctrl._do_flush(slow_flush))
         await asyncio.sleep(0.02)
         assert ctrl._needs_reflush
 

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -58,21 +58,25 @@ class TestVerify:
 
     def test_verify_fails_on_missing_handler(self, tmp_path: Path) -> None:
         p = tmp_path / "run.py"
-        p.write_text(textwrap.dedent("""\
+        p.write_text(
+            textwrap.dedent("""\
             async def _stream_delta_cb(text):
                 pass
             async def progress_callback(event_type):
                 pass
-        """))
+        """)
+        )
         with pytest.raises(PatcherError, match="_handle_message_with_agent"):
             _patcher(p).verify_target()
 
     def test_verify_fails_on_missing_callback(self, tmp_path: Path) -> None:
         p = tmp_path / "run.py"
-        p.write_text(textwrap.dedent("""\
+        p.write_text(
+            textwrap.dedent("""\
             async def _handle_message_with_agent(source, event):
                 self.hooks.emit("agent:end", {})
-        """))
+        """)
+        )
         with pytest.raises(PatcherError, match="Missing injection targets"):
             _patcher(p).verify_target()
 

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from hermes_lark_streaming.text import (
     TextState,
     extract_thinking_content,

--- a/tests/test_tooluse.py
+++ b/tests/test_tooluse.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-import json
 from unittest.mock import patch
 
 import pytest
 
 from hermes_lark_streaming.tooluse import (
-    ToolStep,
     ToolUseTracker,
     _basename_only,
     _build_display_block,
@@ -77,7 +75,7 @@ class TestSanitizeDetail:
     def test_command_sanitizer_strips_html(self) -> None:
         result = _sanitize_detail("<b>bold</b> text", "command")
         assert "<b>" not in result
-        assert "bold text" == result
+        assert result == "bold text"
 
     def test_command_sanitizer_redacts_secrets(self) -> None:
         result = _sanitize_detail("run with token=secret", "command")
@@ -204,7 +202,7 @@ class TestBuildDisplayBlock:
         assert '"key"' in result["content"]
 
     def test_json_array_string(self) -> None:
-        result = _build_display_block('[1, 2, 3]')
+        result = _build_display_block("[1, 2, 3]")
         assert result is not None
         assert result["language"] == "json"
 


### PR DESCRIPTION
## Summary
- Add ruff (lint + format) and mypy (type check) to dev dependencies
- Configure ruff rules (E,F,W,I,UP,B,SIM,RUF) and mypy settings in pyproject.toml
- Fix all ruff lint issues and mypy type errors across all source files
- Format all files with ruff format
- Add ruff → mypy → pytest steps to CI workflow

## Test plan
- [x] `ruff check .` — All checks passed
- [x] `ruff format --check .` — All files formatted
- [x] `mypy hermes_lark_streaming/` — Success: no issues found in 13 source files
- [x] `pytest tests/ -v` — 251 passed