### PR TITLE
fix: apply markdown table downgrade to all render paths

### DIFF
--- a/hermes_lark_streaming/cardkit.py
+++ b/hermes_lark_streaming/cardkit.py
@@ -550,7 +550,7 @@ def build_streaming_card(
             ),
         })
 
-    elements.append({"tag": "markdown", "content": text or " "})
+    elements.append({"tag": "markdown", "content": _downgrade_tables(optimize_markdown_style(text)) if text else " "})
 
     return {
         "config": {

--- a/hermes_lark_streaming/controller.py
+++ b/hermes_lark_streaming/controller.py
@@ -18,6 +18,7 @@ from typing import Any, Coroutine
 from .cardkit import (
     STREAMING_ELEMENT_ID,
     TOOL_PANEL_ELEMENT_ID,
+    _downgrade_tables,
     build_complete_card,
     build_im_fallback_card,
     build_streaming_card,
@@ -465,7 +466,7 @@ class StreamCardController:
 
         try:
             if session.use_cardkit and session.card_id:
-                optimized = optimize_markdown_style(display)
+                optimized = _downgrade_tables(optimize_markdown_style(display))
                 session.sequence += 1
                 await self._client.cardkit_stream_element(
                     session.card_id,


### PR DESCRIPTION
Feishu does not support native markdown table rendering.

`_downgrade_tables()` was previously only applied in `build_complete_card` (final card), leaving **streaming** and **IM fallback** paths unhandled — tables in those paths would render incorrectly or cause CardKit errors.

## Changes

- `controller.py`: apply `_downgrade_tables()` after `optimize_markdown_style()` in the CardKit streaming update path
- `cardkit.py`: apply `_downgrade_tables()` + `optimize_markdown_style()` in `build_streaming_card()` for the IM PATCH fallback path

## Result

All 3 render paths now consistently downgrade excess tables to fenced code blocks:
- ✅ CardKit streaming (real-time updates)
- ✅ IM PATCH fallback (degraded mode)
- ✅ Final complete card (already working)