### PR TITLE
fix: handle streaming closed (300309) and correct complete failure state

### DIFF
--- a/hermes_lark_streaming/controller.py
+++ b/hermes_lark_streaming/controller.py
@@ -31,6 +31,7 @@ from .feishu import (
     CARDKIT_CONTENT_FAILED,
     CARDKIT_ELEMENT_LIMIT,
     CARDKIT_RATE_LIMITED,
+    CARDKIT_STREAMING_CLOSED,
     FeishuAPIError,
     FeishuClient,
     FeishuClientConfig,
@@ -492,6 +493,11 @@ class StreamCardController:
                 _logger.info("rate limited, skipping frame")
                 return
 
+            if e.code == CARDKIT_STREAMING_CLOSED:
+                _logger.info("streaming mode closed, skipping update: msg=%s",
+                             session.message_id[:12])
+                return
+
             if e.code == CARDKIT_CONTENT_FAILED:
                 sub_code = e.extract_sub_code()
                 if sub_code == CARDKIT_ELEMENT_LIMIT:
@@ -631,7 +637,7 @@ class StreamCardController:
             "cardkit complete failed after 3 attempts: card_id=%s card_msg_id=%s seq=%d",
             session.card_id, session.card_msg_id, session.sequence,
         )
-        session.state = COMPLETED
+        session.state = FAILED
         return False
 
     def _cleanup(self, message_id: str) -> None:

--- a/hermes_lark_streaming/feishu.py
+++ b/hermes_lark_streaming/feishu.py
@@ -66,6 +66,7 @@ class FeishuAPIError(RuntimeError):
 CARDKIT_RATE_LIMITED = 230020       # 频控
 CARDKIT_CONTENT_FAILED = 230099     # 卡片内容创建失败（通用码，需检查子错误）
 CARDKIT_ELEMENT_LIMIT = 11310       # 子码: 卡片元素数量超限
+CARDKIT_STREAMING_CLOSED = 300309   # 卡片流式模式已关闭
 MSG_NOT_FOUND = 1000023             # 消息不存在/已删除
 
 


### PR DESCRIPTION
## Summary

- Add `CARDKIT_STREAMING_CLOSED` constant for error code 300309, gracefully skip update instead of logging full warning traceback
- Fix `_do_complete` retry exhaustion incorrectly setting `session.state = COMPLETED` instead of `FAILED`

Closes #7

## Test plan

- [x] 251 existing tests pass