### PR TITLE
feat: add CRON_DELIVER hook for CardKit cron message rendering

### DIFF
--- a/hermes_lark_streaming/__main__.py
+++ b/hermes_lark_streaming/__main__.py
@@ -54,6 +54,15 @@ def _get_patcher() -> Patcher | None:
         return None
 
 
+def _get_cron_patcher():
+    from .patcher import CronPatcher, PatcherError
+    try:
+        return CronPatcher()
+    except PatcherError as e:
+        print(f"Error: {e}")
+        return None
+
+
 def _cmd_install() -> int:
     patcher = _get_patcher()
     if patcher is None:
@@ -61,23 +70,29 @@ def _cmd_install() -> int:
 
     if patcher.is_patched():
         print("Already patched.")
-        return 0
+    else:
+        print("Verifying target compatibility...")
+        try:
+            patcher.verify_target()
+        except Exception as e:
+            print(f"Verification failed: {e}")
+            return 1
+        print("Target compatible.")
 
-    print("Verifying target compatibility...")
-    try:
-        patcher.verify_target()
-    except Exception as e:
-        print(f"Verification failed: {e}")
-        return 1
-    print("Target compatible.")
+        print("Applying patch...")
+        try:
+            patcher.apply()
+        except Exception as e:
+            print(f"Patch failed: {e}")
+            return 1
+        print("Patch applied successfully.")
 
-    print("Applying patch...")
-    try:
-        patcher.apply()
-    except Exception as e:
-        print(f"Patch failed: {e}")
-        return 1
-    print("Patch applied successfully.")
+    cp = _get_cron_patcher()
+    if cp is not None and not cp.is_patched():
+        cp.verify_target()
+        cp.apply()
+        print("Cron hook applied.")
+
     return 0
 
 
@@ -88,15 +103,20 @@ def _cmd_uninstall() -> int:
 
     if not patcher.is_patched():
         print("Not patched.")
-        return 0
+    else:
+        print("Removing patch...")
+        try:
+            patcher.remove()
+        except Exception as e:
+            print(f"Remove failed: {e}")
+            return 1
+        print("Patch removed.")
 
-    print("Removing patch...")
-    try:
-        patcher.remove()
-    except Exception as e:
-        print(f"Remove failed: {e}")
-        return 1
-    print("Patch removed.")
+    cp = _get_cron_patcher()
+    if cp is not None and cp.is_patched():
+        cp.remove()
+        print("Cron hook removed.")
+
     return 0
 
 
@@ -133,6 +153,10 @@ def _cmd_status() -> int:
             label = begin.replace("# HERMES_LARK_", "").replace("_BEGIN", "").lower()
             print(f"  {label}: {'installed' if found else 'missing'}")
 
+    cp = _get_cron_patcher()
+    if cp is not None:
+        print(f"Cron hook: {'installed' if cp.is_patched() else 'not installed'}")
+
     # Check config
     from .config import Config
 
@@ -155,6 +179,12 @@ def _cmd_verify() -> int:
         print(f"Incompatible: {e}")
         return 1
     print("Compatible.")
+
+    cp = _get_cron_patcher()
+    if cp is None:
+        return 1
+    cp.verify_target()
+    print("Cron target compatible.")
     return 0
 
 

--- a/hermes_lark_streaming/controller.py
+++ b/hermes_lark_streaming/controller.py
@@ -396,6 +396,35 @@ class StreamCardController:
         self._fire_and_forget(self._do_complete(session), session._loop)
         return True
 
+    def on_cron_deliver(
+        self,
+        platform_name: str,
+        chat_id: str,
+        content: str,
+    ) -> bool:
+        """Wrap cron markdown content as a static CardKit card and send to chat.
+
+        Returns True if card was sent (cron skips default delivery),
+        False for non-Feishu platforms or on failure (cron falls back).
+        """
+        if platform_name.lower() not in ("feishu", "lark"):
+            return False
+        if not self.enabled or not content or not chat_id:
+            return False
+        try:
+            asyncio.run(self._send_static_card(chat_id, content))
+            return True
+        except Exception:
+            _logger.exception("on_cron_deliver failed")
+            return False
+
+    async def _send_static_card(self, chat_id: str, content: str) -> None:
+        await self._ensure_init()
+        assert self._client is not None
+        from .cardkit import build_complete_card
+        card = build_complete_card(text=content, has_cardkit=True)
+        await self._client.send_card_to_chat(chat_id, card)
+
     def _schedule_card_update(self, session: CardSession) -> None:
         if session.state == IDLE or session.state in _TERMINAL:
             return

--- a/hermes_lark_streaming/feishu.py
+++ b/hermes_lark_streaming/feishu.py
@@ -124,6 +124,27 @@ class FeishuClient:
             return str(resp.data.message_id)
         raise FeishuAPIError("reply_card: response missing message_id")
 
+    async def send_card_to_chat(self, chat_id: str, card: dict[str, Any]) -> str:
+        """Send a standalone card to a chat (not a reply). Returns message_id."""
+        from lark_oapi.api.im.v1 import CreateMessageRequest, CreateMessageRequestBody
+        request = (
+            CreateMessageRequest.builder()
+            .receive_id_type("chat_id")
+            .request_body(
+                CreateMessageRequestBody.builder()
+                .receive_id(chat_id)
+                .msg_type("interactive")
+                .content(self._dumps(card))
+                .build()
+            )
+            .build()
+        )
+        resp = await self._client.im.v1.message.acreate(request)
+        self._check(resp, "send_card_to_chat")
+        if resp.data and resp.data.message_id:
+            return str(resp.data.message_id)
+        raise FeishuAPIError("send_card_to_chat: response missing message_id")
+
     async def reply_card_by_id(self, message_id: str, card_id: str) -> str:
         """通过 card_id 回复 CardKit 卡片消息，返回 message_id."""
         request = (

--- a/hermes_lark_streaming/patch.py
+++ b/hermes_lark_streaming/patch.py
@@ -122,3 +122,20 @@ def on_message_interrupted(
         new_message_id=new_message_id,
         chat_id=chat_id,
     )
+
+
+@_safe_hook(default_return=False)
+def on_cron_deliver(
+    *,
+    ctrl: Any,
+    message_id: str = "",
+    platform_name: str,
+    chat_id: str,
+    content: str,
+) -> bool:
+    """[Hook 8] cron delivery — wrap as card for Feishu."""
+    return ctrl.on_cron_deliver(
+        platform_name=platform_name,
+        chat_id=chat_id,
+        content=content,
+    )

--- a/hermes_lark_streaming/patcher.py
+++ b/hermes_lark_streaming/patcher.py
@@ -12,7 +12,7 @@ _logger = logging.getLogger("hermes_lark_streaming")
 
 PREFIX = "HERMES_LARK"
 
-_HOOK_NAMES = ["START", "COMPLETE", "TOOL", "ANSWER", "THINKING", "ABORT", "INTERRUPT"]
+_HOOK_NAMES = ["START", "COMPLETE", "TOOL", "ANSWER", "THINKING", "ABORT", "INTERRUPT", "CRON_DELIVER"]
 MARKERS: list[tuple[str, str]] = [(f"# {PREFIX}_{n}_BEGIN", f"# {PREFIX}_{n}_END") for n in _HOOK_NAMES]
 
 MK_START, MK_START_END = MARKERS[0]
@@ -22,10 +22,12 @@ MK_ANSWER, MK_ANSWER_END = MARKERS[3]
 MK_THINKING, MK_THINKING_END = MARKERS[4]
 MK_ABORT, MK_ABORT_END = MARKERS[5]
 MK_INTERRUPT, MK_INTERRUPT_END = MARKERS[6]
+MK_CRON_DELIVER, MK_CRON_DELIVER_END = MARKERS[7]
 
 _BACKUP_SUFFIX = ".hermes_lark.bak"
 
 _RUN_PATH = Path.home() / ".hermes" / "hermes-agent" / "gateway" / "run.py"
+_CRON_PATH = Path.home() / ".hermes" / "hermes-agent" / "cron" / "scheduler.py"
 
 
 def _make_hook(indent: str, begin: str, end: str, body_lines: list[str]) -> str:
@@ -161,6 +163,26 @@ def _interrupt_hook(indent: str) -> str:
             "            new_message_id=next_message_id,",
             "            chat_id=source.chat_id,",
             "        )",
+            "except Exception:",
+            "    pass",
+        ],
+    )
+
+
+def _cron_deliver_hook(indent: str) -> str:
+    """Inject CRON_DELIVER hook after 'delivered = False', before live adapter path."""
+    return _make_hook(
+        indent,
+        MK_CRON_DELIVER,
+        MK_CRON_DELIVER_END,
+        [
+            "try:",
+            "    from hermes_lark_streaming.patch import on_cron_deliver",
+            "    if on_cron_deliver(message_id=\"\", platform_name=platform_name,",
+            "                       chat_id=chat_id,",
+            "                       content=cleaned_delivery_content):",
+            "        delivered = True",
+            "        continue",
             "except Exception:",
             "    pass",
         ],
@@ -381,3 +403,74 @@ def _safe_indent(lines: list[str], lineno: int) -> str:
         if lines[i].strip():
             return lines[i][: len(lines[i]) - len(lines[i].lstrip())]
     return ""
+
+
+class CronPatcher:
+    """Inject CRON_DELIVER hook into cron/scheduler.py's _deliver_result."""
+
+    def __init__(self, cron_path: Path = _CRON_PATH) -> None:
+        self.cron_path = cron_path
+        if not cron_path.exists():
+            raise PatcherError(f"scheduler.py not found: {cron_path}")
+
+    def is_patched(self) -> bool:
+        return MK_CRON_DELIVER in self.cron_path.read_text(encoding="utf-8")
+
+    def verify_target(self) -> None:
+        content = self.cron_path.read_text(encoding="utf-8")
+        if "delivered = False" not in content:
+            raise PatcherError(
+                "Cannot find 'delivered = False' anchor in scheduler.py"
+            )
+
+    def apply(self) -> None:
+        if self.is_patched():
+            return
+        self.verify_target()
+        self._backup()
+        content = self.cron_path.read_text(encoding="utf-8")
+        lines = content.splitlines(keepends=True)
+
+        inject_idx = None
+        for i, line in enumerate(lines):
+            if line.strip() == "delivered = False":
+                inject_idx = i
+                break
+        if inject_idx is None:
+            raise PatcherError("Cannot find 'delivered = False' anchor")
+
+        indent = "        "
+        hook = _cron_deliver_hook(indent)
+        lines[inject_idx + 1:inject_idx + 1] = hook.splitlines(keepends=True)
+        self.cron_path.write_text("".join(lines), encoding="utf-8")
+
+    def remove(self) -> None:
+        content = self.cron_path.read_text(encoding="utf-8")
+        content = _remove_block(content, MK_CRON_DELIVER, MK_CRON_DELIVER_END)
+        self.cron_path.write_text(content, encoding="utf-8")
+
+    def restore(self) -> None:
+        backup = self.cron_path.with_suffix(self.cron_path.suffix + _BACKUP_SUFFIX)
+        if not backup.exists():
+            raise PatcherError(f"No backup found: {backup}")
+        shutil.copy2(backup, self.cron_path)
+
+    def _backup(self) -> None:
+        backup = self.cron_path.with_suffix(self.cron_path.suffix + _BACKUP_SUFFIX)
+        if not backup.exists():
+            shutil.copy2(self.cron_path, backup)
+
+
+def _remove_block(content: str, begin: str, end: str) -> str:
+    lines = content.splitlines(keepends=True)
+    begin_idx = end_idx = None
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped == begin:
+            begin_idx = i
+        if stripped == end:
+            end_idx = i
+            break
+    if begin_idx is not None and end_idx is not None:
+        return "".join(lines[:begin_idx] + lines[end_idx + 1:])
+    return content


### PR DESCRIPTION
- New 8th hook CRON_DELIVER intercepts cron outbound in scheduler.py
- FeishuClient.send_card_to_chat() — standalone card via CreateMessage API
- StreamCardController.on_cron_deliver() wraps markdown as static card
- CronPatcher injects hook after 'delivered = False', before live adapter
- Unified CLI: install/uninstall handles gateway + cron hooks together