### PR TITLE
feat: add linear mode for sequential card display

### DIFF
--- a/hermes_lark_streaming/cardkit.py
+++ b/hermes_lark_streaming/cardkit.py
@@ -76,7 +76,9 @@ def _loading_element() -> dict:
     }
 
 
-def _build_tool_panel(steps: list[dict], elapsed_ms: float = 0, *, expanded: bool = True) -> dict:
+def _build_tool_panel(
+    steps: list[dict], elapsed_ms: float = 0, *, expanded: bool = True,
+) -> dict:
     en_t, zh_t = _T["tool_use"]
     en_parts, zh_parts = [en_t], [zh_t]
     if steps:
@@ -472,29 +474,33 @@ def build_complete_card(
     is_aborted: bool = False,
     footer_fields: list[list[str]] | None = None,
     footer_show_label: bool = True,
+    show_footer: bool = True,
+    reasoning_expanded: bool = False,
 ) -> dict[str, Any]:
     """完成态卡片 — 含 header、reasoning 面板、footer."""
     elements: list[dict] = []
 
     if reasoning_text:
-        elements.append(_build_reasoning_panel(reasoning_text, reasoning_elapsed_ms))
+        elements.append(_build_reasoning_panel(reasoning_text, reasoning_elapsed_ms, expanded=reasoning_expanded))
 
     if tool_steps:
         elements.append(_build_tool_panel(tool_steps, tool_elapsed_ms, expanded=False))
 
-    content = _downgrade_tables(optimize_markdown_style(text or _T["done"][0]))
-    for chunk in _split_long_text(content):
-        elements.append({"tag": "markdown", "content": chunk})
+    content = _downgrade_tables(optimize_markdown_style(text or (_T["done"][0] if show_footer else "")))
+    if content.strip():
+        for chunk in _split_long_text(content):
+            elements.append({"tag": "markdown", "content": chunk})
 
-    elements.extend(
-        _build_footer_elements(
-            footer_data,
-            is_error,
-            is_aborted,
-            fields=footer_fields,
-            show_label=footer_show_label,
+    if show_footer:
+        elements.extend(
+            _build_footer_elements(
+                footer_data,
+                is_error,
+                is_aborted,
+                fields=footer_fields,
+                show_label=footer_show_label,
+            )
         )
-    )
 
     summary = (text or reasoning_text or "")[:120]
     summary = summary.replace("\n", " ").replace("```", "").strip()

--- a/hermes_lark_streaming/config.py
+++ b/hermes_lark_streaming/config.py
@@ -24,6 +24,12 @@ class Config:
         return bool(sec.get("enabled", False))
 
     @property
+    def linear(self) -> bool:
+        """线性模式：工具调用和回复顺序展示为独立卡片."""
+        sec = self._streaming_sec()
+        return bool(sec.get("linear", False))
+
+    @property
     def show_reasoning(self) -> bool:
         """是否展示推理过程（display.platforms.feishu.show_reasoning → display.show_reasoning）.
 

--- a/hermes_lark_streaming/controller.py
+++ b/hermes_lark_streaming/controller.py
@@ -23,6 +23,10 @@ from .controller_mixin import (
     ABORTED,
     FAILED,
     IDLE,
+    L_ANSWER,
+    L_IDLE,
+    L_TOOL,
+    STREAMING,
     ControllerMixin,
 )
 from .feishu import (
@@ -44,7 +48,13 @@ class CardSession:
     """单条消息的卡片会话状态."""
 
     __slots__ = (
+        "_linear_lock",
+        "_linear_phase",
         "_loop",
+        "_segment_start",
+        "_tool_card_id",
+        "_tool_card_msg_id",
+        "_tool_start_idx",
         "card_id",
         "card_msg_id",
         "chat_id",
@@ -54,6 +64,7 @@ class CardSession:
         "guard",
         "image_resolver",
         "last_tool_use_update",
+        "linear",
         "message_id",
         "reasoning_dirty",
         "reasoning_panel_added",
@@ -72,10 +83,13 @@ class CardSession:
         message_id: str,
         chat_id: str,
         loop: asyncio.AbstractEventLoop,
+        *,
+        linear: bool = False,
     ) -> None:
         self.message_id = message_id
         self.chat_id = chat_id
         self.state = IDLE
+        self.linear = linear
         self.card_msg_id: str | None = None
         self.card_id: str | None = None
         self.use_cardkit: bool = False
@@ -100,6 +114,13 @@ class CardSession:
 
         self.image_resolver: ImageResolver | None = None
         self.tool_panel_added = False
+
+        self._linear_lock = asyncio.Lock()
+        self._linear_phase = L_IDLE
+        self._segment_start = 0
+        self._tool_card_id: str | None = None
+        self._tool_card_msg_id: str | None = None
+        self._tool_start_idx = 0
 
 
 class StreamCardController(ControllerMixin):
@@ -196,11 +217,15 @@ class StreamCardController(ControllerMixin):
         if loop is None:
             _logger.warning("no event loop available, skipping: msg=%s", message_id[:12])
             return
-        session = CardSession(message_id, chat_id, loop)
+        linear = self._cfg.linear
+        session = CardSession(message_id, chat_id, loop, linear=linear)
         self._sessions[message_id] = session
-        _logger.info("session created: msg=%s chat=%s", message_id[:12], chat_id[:12])
+        _logger.info("session created: msg=%s chat=%s linear=%s", message_id[:12], chat_id[:12], linear)
 
-        self._fire_and_forget(self._do_create_card(session), loop)
+        if linear:
+            session.state = STREAMING
+        else:
+            self._fire_and_forget(self._do_create_card(session), loop)
 
     def on_thinking(self, *, message_id: str, text: str) -> None:
         """思考内容增量."""
@@ -221,7 +246,12 @@ class StreamCardController(ControllerMixin):
                 session.reasoning_text = split["reasoning_text"] or ""
                 if not session.reasoning_start:
                     session.reasoning_start = time.time()
-            session.text.on_partial(split["answer_text"] or "")
+            answer_text = split["answer_text"] or ""
+            if answer_text:
+                if session.linear and session._linear_phase in (L_IDLE, L_TOOL):
+                    self._linear_enter_answer(session, answer_text)
+                    return
+                session.text.on_partial(answer_text)
 
         self._schedule_card_update(session)
 
@@ -239,13 +269,20 @@ class StreamCardController(ControllerMixin):
             session.reasoning_start = time.time()
             _logger.info("reasoning started: msg=%s", message_id[:12])
 
+        if session.linear:
+            if session._linear_phase == L_IDLE:
+                session._linear_phase = L_ANSWER
+                self._fire_and_forget(self._do_create_answer_card(session), session._loop)
+            elif session._linear_phase == L_ANSWER and session.use_cardkit and session.card_id:
+                self._schedule_reasoning_update(session)
+        else:
+            if session.use_cardkit and session.card_id:
+                self._schedule_reasoning_update(session)
+            else:
+                self._schedule_card_update(session)
+
         session.reasoning_text += text
         session.reasoning_dirty = True
-
-        if session.use_cardkit and session.card_id:
-            self._schedule_reasoning_update(session)
-        else:
-            self._schedule_card_update(session)
 
     def on_tool_update(
         self,
@@ -262,7 +299,9 @@ class StreamCardController(ControllerMixin):
         if session is None or session.guard.should_skip("on_tool_update"):
             return
 
-        if status in ("running", "started", "tool.started"):
+        is_started = status in ("running", "started", "tool.started")
+
+        if is_started:
             session.tool_use.record_start(tool_name, detail)
         else:
             is_error = status in ("error", "failed")
@@ -271,6 +310,20 @@ class StreamCardController(ControllerMixin):
                 error=detail if is_error else "",
                 output="" if is_error else detail,
             )
+
+        if session.linear:
+            if is_started:
+                if session._linear_phase == L_ANSWER:
+                    session._linear_phase = L_TOOL
+                    self._fire_and_forget(self._do_answer_to_tool(session), session._loop)
+                elif session._linear_phase == L_TOOL:
+                    self._fire_and_forget(self._do_update_tool_card(session), session._loop)
+                elif session._linear_phase == L_IDLE:
+                    session._linear_phase = L_TOOL
+                    self._fire_and_forget(self._do_create_tool_card(session), session._loop)
+            elif session._linear_phase == L_TOOL:
+                self._fire_and_forget(self._do_update_tool_card(session), session._loop)
+            return
 
         if session.use_cardkit and session.card_id:
             self._schedule_tool_use_status_update(session)
@@ -293,6 +346,10 @@ class StreamCardController(ControllerMixin):
 
         answer_text = split.get("answer_text") or strip_reasoning_tags(text)
         if not answer_text:
+            return
+
+        if session.linear:
+            self._linear_answer(session, answer_text)
             return
 
         session.text.on_partial(answer_text)
@@ -336,14 +393,19 @@ class StreamCardController(ControllerMixin):
         if new_message_id not in self._sessions:
             loop = self._get_loop()
             if loop is not None:
-                session = CardSession(new_message_id, chat_id, loop)
+                linear = self._cfg.linear
+                session = CardSession(new_message_id, chat_id, loop, linear=linear)
                 self._sessions[new_message_id] = session
                 _logger.info(
-                    "on_interrupted: create new msg=%s chat=%s",
+                    "on_interrupted: create new msg=%s chat=%s linear=%s",
                     new_message_id[:12],
                     chat_id[:12],
+                    linear,
                 )
-                self._fire_and_forget(self._do_create_card(session), loop)
+                if linear:
+                    session.state = STREAMING
+                else:
+                    self._fire_and_forget(self._do_create_card(session), loop)
 
         self._interrupt_map[old_message_id] = new_message_id
         for key, val in list(self._interrupt_map.items()):
@@ -405,6 +467,25 @@ class StreamCardController(ControllerMixin):
 
         self._fire_and_forget(self._do_complete(session), session._loop)
         return True
+
+    def _linear_enter_answer(self, session: CardSession, answer_text: str) -> None:
+        """线性模式：进入回答阶段，从 L_IDLE/L_TOOL 过渡到 L_ANSWER."""
+        prev_phase = session._linear_phase
+        session._segment_start = len(session.text.display_text)
+        session.text.on_partial(answer_text)
+        session._linear_phase = L_ANSWER
+        if prev_phase == L_TOOL:
+            self._fire_and_forget(self._do_tool_to_answer(session), session._loop)
+        else:
+            self._fire_and_forget(self._do_create_answer_card(session), session._loop)
+
+    def _linear_answer(self, session: CardSession, answer_text: str) -> None:
+        """线性模式 on_answer 路由."""
+        if session._linear_phase in (L_IDLE, L_TOOL):
+            self._linear_enter_answer(session, answer_text)
+            return
+        session.text.on_partial(answer_text)
+        self._schedule_card_update(session)
 
     def _schedule_card_update(self, session: CardSession) -> None:
         if session.state == IDLE or session.state in _TERMINAL:

--- a/hermes_lark_streaming/controller_mixin.py
+++ b/hermes_lark_streaming/controller_mixin.py
@@ -13,11 +13,13 @@ from .cardkit import (
     STREAMING_ELEMENT_ID,
     TOOL_PANEL_ELEMENT_ID,
     _build_tool_panel,
+    _loading_element,
     build_complete_card,
     build_im_fallback_card,
     build_streaming_card,
     build_streaming_card_v2,
 )
+from .cardkit_i18n import _LOCALES
 from .cardkit_md import (
     _downgrade_tables,
     optimize_markdown_style,
@@ -48,6 +50,10 @@ ABORTED = "aborted"
 
 _TERMINAL = {COMPLETED, FAILED, ABORTED}
 
+L_IDLE = "l_idle"
+L_ANSWER = "l_answer"
+L_TOOL = "l_tool"
+
 
 class ControllerMixin:
     """异步卡片 API 操作 — 由 StreamCardController 继承."""
@@ -72,28 +78,7 @@ class ControllerMixin:
                     on_image_resolved=lambda: self._schedule_card_update(session),
                 )
 
-            try:
-                card = build_streaming_card_v2(
-                    show_tool_use=False, show_reasoning=self._cfg.show_reasoning
-                )
-                card_id = await self._client.cardkit_create(card)
-                card_msg_id = await self._client.reply_card_by_id(
-                    session.message_id,
-                    card_id,
-                )
-                session.card_id = card_id
-                session.card_msg_id = card_msg_id
-                session.use_cardkit = True
-                session.flush.set_throttle(CARDKIT_MS)
-            except FeishuAPIError:
-                card = build_im_fallback_card()
-                card_msg_id = await self._client.reply_card(
-                    session.message_id,
-                    card,
-                )
-                session.card_msg_id = card_msg_id
-                session.use_cardkit = False
-                session.flush.set_throttle(PATCH_MS)
+            await self._create_and_reply_card(session)
 
             session.flush.set_card_message_ready(True)
             if session.state == CREATING:
@@ -108,6 +93,30 @@ class ControllerMixin:
             _logger.exception("_do_create_card failed")
             session.state = FAILED
 
+    async def _create_and_reply_card(self, session: CardSession) -> None:
+        """CardKit 优先 + IM fallback 的创建 + 回复逻辑."""
+        assert self._client is not None
+        try:
+            card = build_streaming_card_v2(
+                show_tool_use=False, show_reasoning=self._cfg.show_reasoning,
+            )
+            card_id = await self._client.cardkit_create(card)
+            card_msg_id = await self._client.reply_card_by_id(
+                session.message_id, card_id,
+            )
+            session.card_id = card_id
+            session.card_msg_id = card_msg_id
+            session.use_cardkit = True
+            session.flush.set_throttle(CARDKIT_MS)
+        except FeishuAPIError:
+            card = build_im_fallback_card()
+            card_msg_id = await self._client.reply_card(
+                session.message_id, card,
+            )
+            session.card_msg_id = card_msg_id
+            session.use_cardkit = False
+            session.flush.set_throttle(PATCH_MS)
+
     async def _do_update_card(self, session: CardSession) -> None:
         if session.state not in (CREATING, STREAMING):
             return
@@ -116,80 +125,93 @@ class ControllerMixin:
         if session.guard.should_skip("_do_update_card"):
             return
 
-        display = session.text.display_text
-        if not session.text.is_dirty(display) and not session.reasoning_dirty:
+        full_display = session.text.display_text
+        if not session.text.is_dirty(full_display) and not session.reasoning_dirty:
             _logger.info(
                 "update_card skipped (not dirty): msg=%s len=%d",
                 session.message_id[:12],
-                len(display),
+                len(full_display),
             )
             return
 
-        if session.image_resolver:
-            display = session.image_resolver.resolve_images(display)
-
-        _logger.info(
-            "update_card: msg=%s seq=%d len=%d cardkit=%s",
-            session.message_id[:12],
-            session.sequence + 1,
-            len(display),
-            session.use_cardkit,
-        )
-
+        lock = session._linear_lock if session.linear else None
+        if lock:
+            await lock.acquire()
         try:
-            assert self._client is not None
-            if session.use_cardkit and session.card_id:
-                if session.reasoning_dirty and session.reasoning_panel_added:
-                    reasoning_content = optimize_markdown_style(session.reasoning_text) or " "
+            if session.linear and session._linear_phase != L_ANSWER:
+                return
+
+            display = full_display[session._segment_start:] if session.linear else full_display
+
+            if session.image_resolver:
+                display = session.image_resolver.resolve_images(display)
+
+            _logger.info(
+                "update_card: msg=%s seq=%d len=%d cardkit=%s",
+                session.message_id[:12],
+                session.sequence + 1,
+                len(display),
+                session.use_cardkit,
+            )
+
+            try:
+                assert self._client is not None
+                if session.use_cardkit and session.card_id:
+                    if session.reasoning_dirty and session.reasoning_panel_added:
+                        reasoning_content = optimize_markdown_style(session.reasoning_text) or " "
+                        session.sequence += 1
+                        await self._client.cardkit_stream_element(
+                            session.card_id,
+                            REASONING_TEXT_ELEMENT_ID,
+                            reasoning_content,
+                            sequence=session.sequence,
+                        )
+                        session.reasoning_dirty = False
+
+                    optimized = _downgrade_tables(optimize_markdown_style(display))
                     session.sequence += 1
                     await self._client.cardkit_stream_element(
                         session.card_id,
-                        REASONING_TEXT_ELEMENT_ID,
-                        reasoning_content,
+                        STREAMING_ELEMENT_ID,
+                        optimized or " ",
                         sequence=session.sequence,
                     )
-                    session.reasoning_dirty = False
+                else:
+                    tool_steps = [] if session.linear else session.tool_use.build_display_steps()
+                    card = build_streaming_card(
+                        tool_steps=tool_steps,
+                        reasoning_text=session.reasoning_text if self._cfg.show_reasoning else "",
+                        text=display,
+                    )
+                    assert session.card_msg_id is not None
+                    await self._client.update_card(session.card_msg_id, card)
 
-                optimized = _downgrade_tables(optimize_markdown_style(display))
-                session.sequence += 1
-                await self._client.cardkit_stream_element(
-                    session.card_id,
-                    STREAMING_ELEMENT_ID,
-                    optimized or " ",
-                    sequence=session.sequence,
-                )
-            else:
-                tool_steps = session.tool_use.build_display_steps()
-                card = build_streaming_card(
-                    tool_steps=tool_steps,
-                    reasoning_text=session.reasoning_text if self._cfg.show_reasoning else "",
-                    text=display,
-                )
-                await self._client.update_card(session.card_msg_id, card)
-
-            session.text.mark_flushed(display)
-            session.reasoning_dirty = False
-        except FeishuAPIError as e:
-            if session.guard.terminate("_do_update_card", e):
-                return
-
-            if e.code == CARDKIT_RATE_LIMITED:
-                _logger.info("rate limited, skipping frame")
-                return
-
-            if e.code == CARDKIT_STREAMING_CLOSED:
-                _logger.info("streaming mode closed, skipping update: msg=%s", session.message_id[:12])
-                return
-
-            if e.code == CARDKIT_CONTENT_FAILED:
-                sub_code = e.extract_sub_code()
-                if sub_code == CARDKIT_ELEMENT_LIMIT:
-                    _logger.warning("card element limit exceeded, disabling CardKit streaming")
-                    session.use_cardkit = False
-                    session.flush.set_throttle(PATCH_MS)
+                session.text.mark_flushed(full_display)
+                session.reasoning_dirty = False
+            except FeishuAPIError as e:
+                if session.guard.terminate("_do_update_card", e):
                     return
 
-            _logger.warning("card update failed: %s", e, exc_info=True)
+                if e.code == CARDKIT_RATE_LIMITED:
+                    _logger.info("rate limited, skipping frame")
+                    return
+
+                if e.code == CARDKIT_STREAMING_CLOSED:
+                    _logger.info("streaming mode closed, skipping update: msg=%s", session.message_id[:12])
+                    return
+
+                if e.code == CARDKIT_CONTENT_FAILED:
+                    sub_code = e.extract_sub_code()
+                    if sub_code == CARDKIT_ELEMENT_LIMIT:
+                        _logger.warning("card element limit exceeded, disabling CardKit streaming")
+                        session.use_cardkit = False
+                        session.flush.set_throttle(PATCH_MS)
+                        return
+
+                _logger.warning("card update failed: %s", e, exc_info=True)
+        finally:
+            if lock:
+                lock.release()
 
     async def _do_tool_use_status_update(self, session: CardSession) -> None:
         if not session.card_id or session.state in _TERMINAL:
@@ -244,8 +266,16 @@ class ControllerMixin:
             return
         if not session.reasoning_dirty:
             return
+
+        lock = session._linear_lock if session.linear else None
+        if lock:
+            await lock.acquire()
         try:
+            if session.linear and session._linear_phase != L_ANSWER:
+                return
+
             assert self._client is not None
+            assert session.card_id is not None
             content = optimize_markdown_style(session.reasoning_text) or " "
 
             session.sequence += 1
@@ -265,9 +295,14 @@ class ControllerMixin:
             session.reasoning_dirty = False
         except Exception as e:
             _logger.debug("reasoning update failed: %s", e, exc_info=True)
+        finally:
+            if lock:
+                lock.release()
 
     async def _do_complete(self, session: CardSession) -> bool:
         try:
+            if session.linear:
+                return await self._do_linear_complete_inner(session)
             return await self._do_complete_inner(session)
         finally:
             self._cleanup(session.message_id)
@@ -280,6 +315,8 @@ class ControllerMixin:
         session.flush.mark_completed()
 
         display = session.text.display_text
+        if session.linear:
+            display = display[session._segment_start:]
         _logger.info(
             "do_complete: msg=%s state=%s display_len=%d cardkit=%s seq=%d",
             session.message_id[:12],
@@ -304,7 +341,7 @@ class ControllerMixin:
             text=display,
             reasoning_text=session.reasoning_text if self._cfg.show_reasoning else "",
             reasoning_elapsed_ms=reasoning_elapsed_ms,
-            tool_steps=session.tool_use.build_display_steps(),
+            tool_steps=[] if session.linear else session.tool_use.build_display_steps(),
             tool_elapsed_ms=session.tool_use.elapsed_ms,
             footer_data=session.footer,
             has_cardkit=session.use_cardkit,
@@ -312,6 +349,7 @@ class ControllerMixin:
             is_aborted=is_aborted,
             footer_fields=self._cfg.footer_fields,
             footer_show_label=self._cfg.footer_show_label,
+            reasoning_expanded=session.linear,
         )
 
         for attempt in range(3):
@@ -371,3 +409,255 @@ class ControllerMixin:
         )
         session.state = FAILED
         return False
+
+    # ── 线性模式异步操作 ──
+
+    async def _do_create_answer_card(self, session: CardSession) -> None:
+        """线性模式：创建回答卡（回复用户消息）."""
+        async with session._linear_lock:
+            if session._linear_phase != L_ANSWER:
+                return
+            try:
+                await self._linear_open_answer_card(session)
+            except Exception:
+                _logger.exception("_do_create_answer_card failed")
+                session.state = FAILED
+
+    async def _linear_open_answer_card(self, session: CardSession) -> None:
+        """线性模式：初始化并创建回答卡 + flush 积累内容."""
+        await self._ensure_init()
+        assert self._client is not None
+        if session.image_resolver is None and self._client:
+            session.image_resolver = ImageResolver(
+                client=self._client,
+                on_image_resolved=lambda: self._schedule_card_update(session),
+            )
+        await self._create_and_reply_card(session)
+        session.flush.set_card_message_ready(True)
+        _logger.info(
+            "linear answer card opened: msg=%s cardkit=%s card_id=%s",
+            session.message_id[:12],
+            session.use_cardkit,
+            (session.card_id or "")[:12],
+        )
+        await self._flush_answer_card_content(session)
+
+    async def _flush_answer_card_content(self, session: CardSession) -> None:
+        """创建回答卡后 flush 积累的 reasoning + answer 文本."""
+        assert self._client is not None
+        display = session.text.display_text[session._segment_start:]
+        if session.use_cardkit and session.card_id:
+            if not session.reasoning_panel_added and self._cfg.show_reasoning and session.reasoning_text:
+                content = optimize_markdown_style(session.reasoning_text) or " "
+                session.sequence += 1
+                await self._client.cardkit_stream_element(
+                    session.card_id, REASONING_TEXT_ELEMENT_ID, content, sequence=session.sequence,
+                )
+                session.reasoning_panel_added = True
+                session.reasoning_dirty = False
+            if display:
+                optimized = _downgrade_tables(optimize_markdown_style(display))
+                session.sequence += 1
+                await self._client.cardkit_stream_element(
+                    session.card_id, STREAMING_ELEMENT_ID, optimized or " ", sequence=session.sequence,
+                )
+                session.text.mark_flushed(session.text.display_text)
+        elif not session.use_cardkit and session.card_msg_id and display:
+            card = build_streaming_card(text=display)
+            await self._client.update_card(session.card_msg_id, card)
+            session.text.mark_flushed(session.text.display_text)
+
+    async def _do_answer_to_tool(self, session: CardSession) -> None:
+        """线性模式：回答→工具过渡 — 关闭回答卡，创建工具卡."""
+        async with session._linear_lock:
+            if session._linear_phase != L_TOOL:
+                return
+            try:
+                await self._close_answer_card(session)
+                await self._create_tool_card_locked(session)
+            except Exception:
+                _logger.exception("_do_answer_to_tool failed")
+
+    async def _do_create_tool_card(self, session: CardSession) -> None:
+        """线性模式：L_IDLE→L_TOOL 直接创建工具卡（无回答卡需要关闭）."""
+        async with session._linear_lock:
+            if session._linear_phase != L_TOOL:
+                return
+            try:
+                await self._create_tool_card_locked(session)
+            except Exception:
+                _logger.exception("_do_create_tool_card failed")
+
+    def _build_tool_card_json(self, session: CardSession) -> dict[str, Any] | None:
+        """构建工具卡 JSON，无步骤时返回 None."""
+        display_steps = session.tool_use.build_display_steps(session._tool_start_idx)
+        if not display_steps:
+            return None
+        panel = _build_tool_panel(display_steps, session.tool_use.elapsed_ms)
+        return {
+            "schema": "2.0",
+            "config": {"locales": _LOCALES},
+            "body": {"elements": [panel, _loading_element()]},
+        }
+
+    async def _create_tool_card_locked(self, session: CardSession) -> None:
+        """创建工具卡（send_card_by_id），假设 lock 已持有."""
+        await self._ensure_init()
+        assert self._client is not None
+        card = self._build_tool_card_json(session)
+        if card is None:
+            return
+        card_id = await self._client.cardkit_create(card)
+        card_msg_id = await self._client.send_card_by_id(session.chat_id, card_id)
+        session._tool_card_id = card_id
+        session._tool_card_msg_id = card_msg_id
+        _logger.info(
+            "linear tool card created: msg=%s card_id=%s",
+            session.message_id[:12],
+            card_id[:12],
+        )
+
+    async def _do_update_tool_card(self, session: CardSession) -> None:
+        """线性模式：更新工具卡内容."""
+        async with session._linear_lock:
+            if session._linear_phase != L_TOOL:
+                return
+            if not session._tool_card_id:
+                return
+            try:
+                assert self._client is not None
+                card = self._build_tool_card_json(session)
+                if card is None:
+                    return
+                session.sequence += 1
+                await self._client.cardkit_update(
+                    session._tool_card_id, card, sequence=session.sequence,
+                )
+            except Exception as e:
+                _logger.debug("linear tool card update failed: %s", e, exc_info=True)
+
+    async def _do_tool_to_answer(self, session: CardSession) -> None:
+        """线性模式：工具→回答过渡 — 关闭工具卡，创建新回答卡."""
+        async with session._linear_lock:
+            if session._linear_phase != L_ANSWER:
+                return
+            try:
+                await self._close_tool_card(session)
+                await self._linear_open_answer_card(session)
+            except Exception:
+                _logger.exception("_do_tool_to_answer failed")
+                session.state = FAILED
+
+    async def _close_answer_card(self, session: CardSession) -> None:
+        """关闭回答卡：cardkit_close_streaming + cardkit_update 静态内容."""
+        if not session.card_id:
+            return
+        card_id = session.card_id
+        full_display = session.text.display_text
+        segment_text = full_display[session._segment_start:]
+        if session.image_resolver:
+            segment_text = session.image_resolver.resolve_images(segment_text)
+        reasoning_text = session.reasoning_text if self._cfg.show_reasoning else ""
+        reasoning_elapsed = (time.time() - session.reasoning_start) * 1000 if session.reasoning_start else 0
+        card = build_complete_card(
+            text=segment_text,
+            reasoning_text=reasoning_text,
+            reasoning_elapsed_ms=reasoning_elapsed,
+            has_cardkit=bool(session.use_cardkit and card_id),
+            show_footer=False,
+            reasoning_expanded=True,
+        )
+        try:
+            assert self._client is not None
+            if session.use_cardkit and card_id:
+                session.sequence += 1
+                await self._client.cardkit_close_streaming(card_id, sequence=session.sequence)
+                session.sequence += 1
+                await self._client.cardkit_update(card_id, card, sequence=session.sequence)
+            elif session.card_msg_id:
+                await self._client.update_card(session.card_msg_id, card)
+            _logger.info(
+                "linear answer card closed: msg=%s len=%d reasoning=%d",
+                session.message_id[:12],
+                len(segment_text),
+                len(reasoning_text),
+            )
+        except Exception:
+            _logger.exception("_close_answer_card failed")
+            if session.use_cardkit and card_id and self._client:
+                try:
+                    session.sequence += 1
+                    await self._client.cardkit_close_streaming(card_id, sequence=session.sequence)
+                except Exception:
+                    _logger.debug("best-effort close_streaming also failed", exc_info=True)
+
+        session.card_id = None
+        session.card_msg_id = None
+        session.use_cardkit = False
+        session.flush.set_card_message_ready(False)
+        session.reasoning_panel_added = False
+        session.reasoning_text = ""
+        session.reasoning_start = 0.0
+
+    async def _close_tool_card(self, session: CardSession) -> None:
+        """关闭工具卡：最终静态更新 + 清除状态."""
+        if not session._tool_card_id:
+            return
+        tool_card_id = session._tool_card_id
+        display_steps = session.tool_use.build_display_steps(session._tool_start_idx)
+        if display_steps:
+            try:
+                assert self._client is not None
+                panel = _build_tool_panel(display_steps, session.tool_use.elapsed_ms, expanded=True)
+                card = {
+                    "schema": "2.0",
+                    "config": {"locales": _LOCALES},
+                    "body": {"elements": [panel]},
+                }
+                session.sequence += 1
+                await self._client.cardkit_update(tool_card_id, card, sequence=session.sequence)
+            except Exception:
+                _logger.debug("tool card close failed", exc_info=True)
+
+        if session.tool_use._session is not None:
+            session._tool_start_idx = len(session.tool_use._session.steps)
+
+        session._tool_card_id = None
+        session._tool_card_msg_id = None
+        _logger.info(
+            "linear tool card closed: msg=%s steps=%d",
+            session.message_id[:12],
+            len(display_steps),
+        )
+
+    async def _do_linear_complete_inner(self, session: CardSession) -> bool:
+        """线性模式完成：关闭活跃卡片 + 构建最终态."""
+        if session.guard.should_skip("_do_linear_complete"):
+            return False
+
+        await session.flush.wait_for_flush()
+        session.flush.mark_completed()
+
+        async with session._linear_lock:
+            if session._linear_phase == L_TOOL:
+                await self._close_tool_card(session)
+
+            if not session.card_id and not session.card_msg_id:
+                display = session.text.display_text
+                if display:
+                    try:
+                        await self._linear_open_answer_card(session)
+                    except Exception:
+                        _logger.exception("linear complete: failed to create answer card")
+                        session.state = FAILED
+                        return False
+                else:
+                    _logger.info("linear complete: no card and no text, msg=%s", session.message_id[:12])
+                    session.state = COMPLETED
+                    return True
+
+            if not session.card_id and not session.card_msg_id:
+                session.state = COMPLETED
+                return True
+
+        return await self._do_complete_inner(session)

--- a/hermes_lark_streaming/feishu.py
+++ b/hermes_lark_streaming/feishu.py
@@ -29,6 +29,8 @@ from lark_oapi.api.cardkit.v1 import (
 from lark_oapi.api.im.v1 import (
     CreateImageRequest,
     CreateImageRequestBody,
+    CreateMessageRequest,
+    CreateMessageRequestBody,
     PatchMessageRequest,
     PatchMessageRequestBody,
     ReplyMessageRequest,
@@ -142,6 +144,26 @@ class FeishuClient:
         if resp.data and resp.data.message_id:
             return str(resp.data.message_id)
         raise FeishuAPIError("reply_card_by_id: response missing message_id")
+
+    async def send_card_by_id(self, chat_id: str, card_id: str) -> str:
+        """发送 CardKit 卡片到 chat（非回复），返回 message_id."""
+        request = (
+            CreateMessageRequest.builder()
+            .receive_id_type("chat_id")
+            .request_body(
+                CreateMessageRequestBody.builder()
+                .receive_id(chat_id)
+                .msg_type("interactive")
+                .content(self._dumps({"type": "card", "data": {"card_id": card_id}}))
+                .build()
+            )
+            .build()
+        )
+        resp = await self._client.im.v1.message.acreate(request)
+        self._check(resp, "send_card_by_id")
+        if resp.data and resp.data.message_id:
+            return str(resp.data.message_id)
+        raise FeishuAPIError("send_card_by_id: response missing message_id")
 
     async def update_card(self, message_id: str, card: dict[str, Any]) -> None:
         """PATCH 更新已发送的卡片（IM 降级通道）."""

--- a/hermes_lark_streaming/tooluse.py
+++ b/hermes_lark_streaming/tooluse.py
@@ -240,13 +240,14 @@ class ToolUseTracker:
             )
         )
 
-    def record_end(self, name: str, *, error: str = "", output: str = "") -> None:
-        """通过名字匹配最近的一个 running 步骤来结束."""
+    def record_end(self, name: str, *, error: str = "", output: str = "") -> int | None:
+        """通过名字匹配最近的一个 running 步骤来结束，返回步骤下标."""
         if self._session is None:
-            return
+            return None
         desc = _resolve_tool_descriptor(name)
         sanitizer = desc.get("sanitizer") if desc else None
-        for step in reversed(self._session.steps):
+        for idx in range(len(self._session.steps) - 1, -1, -1):
+            step = self._session.steps[idx]
             if step.name == name and step.status == "running":
                 step.status = "error" if error else "success"
                 step.error = error
@@ -256,7 +257,7 @@ class ToolUseTracker:
                     step.error_block = _build_display_block(error, "text", sanitizer=sanitizer)
                 elif output:
                     step.result_block = _build_display_block(output, "json", sanitizer=sanitizer)
-                return
+                return idx
         self._session.steps.append(
             ToolStep(
                 name=name,
@@ -269,13 +270,14 @@ class ToolUseTracker:
                 result_block=_build_display_block(output, "json", sanitizer=sanitizer) if output else None,
             )
         )
+        return len(self._session.steps) - 1
 
-    def build_display_steps(self) -> list[dict[str, Any]]:
+    def build_display_steps(self, offset: int = 0) -> list[dict[str, Any]]:
         """构建用于卡片渲染的步骤列表 — 与 openclaw 结构对齐."""
         if self._session is None:
             return []
         steps = []
-        for s in self._session.steps:
+        for s in self._session.steps[offset:]:
             desc = _resolve_tool_descriptor(s.name)
             base_title = desc["title"] if desc else _humanize_tool_name(s.name)
             if s.elapsed_ms > 0:

--- a/tests/test_cardkit.py
+++ b/tests/test_cardkit.py
@@ -431,6 +431,52 @@ class TestBuildImFallbackCard:
         assert len(card["elements"]) >= 1
 
 
+class TestBuildCompleteCardShowFooter:
+    def test_without_footer_no_hr(self) -> None:
+        card = build_complete_card(text="hello", show_footer=False, footer_data={})
+        tags = [e.get("tag") for e in card["elements"]]
+        assert "hr" not in tags
+
+    def test_with_footer_has_hr(self) -> None:
+        card = build_complete_card(text="hello", show_footer=True, footer_data={})
+        tags = [e.get("tag") for e in card["elements"]]
+        assert "hr" in tags
+
+    def test_empty_text_without_footer_no_elements(self) -> None:
+        card = build_complete_card(text="", show_footer=False, footer_data={})
+        assert card["elements"] == []
+
+    def test_empty_text_with_footer_has_fallback_content(self) -> None:
+        card = build_complete_card(text="", show_footer=True, footer_data={})
+        assert len(card["elements"]) >= 2
+
+
+class TestBuildCompleteCardReasoningExpanded:
+    def test_expanded_true(self) -> None:
+        card = build_complete_card(
+            text="hello",
+            reasoning_text="thinking...",
+            reasoning_elapsed_ms=100,
+            reasoning_expanded=True,
+        )
+        panel = card["elements"][0]
+        assert panel.get("expanded") is True
+
+    def test_expanded_false(self) -> None:
+        card = build_complete_card(
+            text="hello",
+            reasoning_text="thinking...",
+            reasoning_elapsed_ms=100,
+            reasoning_expanded=False,
+        )
+        panel = card["elements"][0]
+        assert panel.get("expanded") is False
+
+    def test_no_reasoning_no_panel(self) -> None:
+        card = build_complete_card(text="hello", reasoning_text="", reasoning_expanded=True)
+        assert all(e.get("element_id") != REASONING_ELEMENT_ID for e in card["elements"])
+
+
 class TestBuildCompleteCard:
     def test_basic_v1(self) -> None:
         card = build_complete_card(text="done", has_cardkit=False)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -100,6 +100,24 @@ class TestCardDurationSec:
         assert cfg.card_duration_sec == 600
 
 
+class TestLinear:
+    def test_linear_true(self) -> None:
+        cfg = _make_config({"streaming": {"enabled": True, "linear": True}})
+        assert cfg.linear is True
+
+    def test_linear_false(self) -> None:
+        cfg = _make_config({"streaming": {"linear": False}})
+        assert cfg.linear is False
+
+    def test_linear_missing(self) -> None:
+        cfg = _make_config({"streaming": {"enabled": True}})
+        assert cfg.linear is False
+
+    def test_no_streaming_section(self) -> None:
+        cfg = _make_config({})
+        assert cfg.linear is False
+
+
 class TestFeishuAppId:
     def test_from_env(self) -> None:
         cfg = _make_config({})

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -1,0 +1,720 @@
+"""线性模式测试 — 状态机转换、卡片生命周期、多轮流程."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from hermes_lark_streaming.config import Config
+from hermes_lark_streaming.controller import StreamCardController
+from hermes_lark_streaming.controller_mixin import (
+    ABORTED,
+    L_ANSWER,
+    L_IDLE,
+    L_TOOL,
+    STREAMING,
+)
+
+
+def _make_config(raw: dict[str, Any]) -> Config:
+    cfg = Config()
+    cfg._raw = raw
+    cfg._reload = lambda: raw
+    return cfg
+
+
+def _make_mock_client() -> MagicMock:
+    client = MagicMock()
+    client.cardkit_create = AsyncMock(return_value="card_mock")
+    client.reply_card_by_id = AsyncMock(return_value="msg_mock")
+    client.reply_card = AsyncMock(return_value="msg_mock")
+    client.send_card_by_id = AsyncMock(return_value="tool_msg_mock")
+    client.cardkit_stream_element = AsyncMock()
+    client.cardkit_close_streaming = AsyncMock()
+    client.cardkit_update = AsyncMock()
+    client.cardkit_update_element = AsyncMock()
+    client.update_card = AsyncMock()
+    return client
+
+
+def _make_linear_ctrl(*, show_reasoning: bool = False) -> StreamCardController:
+    raw: dict[str, Any] = {
+        "streaming": {"enabled": True, "linear": True},
+        "feishu": {"app_id": "app", "app_secret": "secret"},
+    }
+    if show_reasoning:
+        raw["display"] = {"platforms": {"feishu": {"show_reasoning": True}}}
+    ctrl = StreamCardController()
+    ctrl._cfg._raw = raw
+    ctrl._cfg._reload = lambda: raw
+    ctrl._initialized = True
+    ctrl._client = _make_mock_client()
+    return ctrl
+
+
+async def _drain() -> None:
+    for _ in range(10):
+        await asyncio.sleep(0)
+
+
+# ── 线性模式初始化 ──
+
+
+class TestLinearInit:
+    @pytest.mark.asyncio
+    async def test_session_created_with_linear(self) -> None:
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+        s = ctrl._sessions["msg1"]
+        assert s.linear is True
+        assert s._linear_phase == L_IDLE
+        assert s.state == STREAMING
+
+    @pytest.mark.asyncio
+    async def test_no_card_created_on_start(self) -> None:
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+        await _drain()
+        assert ctrl._client.cardkit_create.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_fields_initialized(self) -> None:
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+        s = ctrl._sessions["msg1"]
+        assert s._segment_start == 0
+        assert s._tool_start_idx == 0
+        assert s._tool_card_id is None
+        assert s._tool_card_msg_id is None
+
+
+# ── 状态机转换 ──
+
+
+class TestLinearPhaseTransition:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "trigger_fn",
+        [
+            # on_answer → L_ANSWER
+            lambda ctrl: ctrl.on_answer(message_id="msg1", text="Hello"),
+            # on_thinking → L_ANSWER (answer_text 非空)
+            lambda ctrl: ctrl.on_thinking(message_id="msg1", text="partial answer"),
+            # on_reasoning → L_ANSWER (show_reasoning=True)
+            lambda ctrl: ctrl.on_reasoning(message_id="msg1", text="thinking..."),
+        ],
+    )
+    async def test_idle_to_answer(self, trigger_fn: Any) -> None:
+        ctrl = _make_linear_ctrl(show_reasoning=True)
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+        trigger_fn(ctrl)
+        assert ctrl._sessions["msg1"]._linear_phase == L_ANSWER
+
+    @pytest.mark.asyncio
+    async def test_idle_to_tool_directly(self) -> None:
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+        ctrl.on_tool_update(message_id="msg1", tool_name="read", status="started", detail="f.py")
+        assert ctrl._sessions["msg1"]._linear_phase == L_TOOL
+
+    @pytest.mark.asyncio
+    async def test_answer_to_tool(self) -> None:
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+        ctrl.on_answer(message_id="msg1", text="Checking")
+        ctrl.on_tool_update(message_id="msg1", tool_name="read", status="started", detail="f.py")
+        assert ctrl._sessions["msg1"]._linear_phase == L_TOOL
+
+    @pytest.mark.asyncio
+    async def test_tool_to_answer(self) -> None:
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+        ctrl.on_answer(message_id="msg1", text="Part1")
+        ctrl.on_tool_update(message_id="msg1", tool_name="read", status="started", detail="f.py")
+        ctrl.on_answer(message_id="msg1", text=" Part2")
+        s = ctrl._sessions["msg1"]
+        assert s._linear_phase == L_ANSWER
+        assert s._segment_start == 5  # len("Part1")
+
+    @pytest.mark.asyncio
+    async def test_consecutive_tools_same_phase(self) -> None:
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+        ctrl.on_tool_update(message_id="msg1", tool_name="read", status="started", detail="a.py")
+        ctrl.on_tool_update(message_id="msg1", tool_name="read", status="completed", detail="ok")
+        ctrl.on_tool_update(message_id="msg1", tool_name="exec", status="started", detail="cmd")
+        s = ctrl._sessions["msg1"]
+        assert s._linear_phase == L_TOOL
+        assert len(s.tool_use._session.steps) == 2  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio
+    async def test_answer_continuation_appends_text(self) -> None:
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+        ctrl.on_answer(message_id="msg1", text="Hello")
+        ctrl.on_answer(message_id="msg1", text=" World")
+        s = ctrl._sessions["msg1"]
+        assert s._linear_phase == L_ANSWER
+        assert s.text.display_text == "Hello World"
+
+    @pytest.mark.asyncio
+    async def test_on_reasoning_in_answer_does_not_change_phase(self) -> None:
+        ctrl = _make_linear_ctrl(show_reasoning=True)
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+        ctrl.on_answer(message_id="msg1", text="Hello")
+        ctrl.on_reasoning(message_id="msg1", text="more thought")
+        s = ctrl._sessions["msg1"]
+        assert s._linear_phase == L_ANSWER
+
+    @pytest.mark.asyncio
+    async def test_on_answer_ignored_in_terminal_state(self) -> None:
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+        ctrl._sessions["msg1"].state = "completed"
+        ctrl.on_answer(message_id="msg1", text="too late")
+        s = ctrl._sessions["msg1"]
+        assert s.text.display_text == ""
+
+
+# ── 多轮完整流程 ──
+
+
+class TestLinearMultiRound:
+    @pytest.mark.asyncio
+    async def test_answer_tool_answer(self) -> None:
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+
+        ctrl.on_answer(message_id="msg1", text="Let me read")
+        s = ctrl._sessions["msg1"]
+        assert s._linear_phase == L_ANSWER
+        assert s._segment_start == 0
+
+        ctrl.on_tool_update(message_id="msg1", tool_name="read", status="started", detail="f.py")
+        assert s._linear_phase == L_TOOL
+
+        ctrl.on_tool_update(message_id="msg1", tool_name="read", status="completed", detail="ok")
+        assert s._linear_phase == L_TOOL
+
+        ctrl.on_answer(message_id="msg1", text=" Here is the result")
+        assert s._linear_phase == L_ANSWER
+        assert s._segment_start == 11  # len("Let me read")
+
+    @pytest.mark.asyncio
+    async def test_two_tool_rounds(self) -> None:
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+
+        ctrl.on_answer(message_id="msg1", text="Start")
+        ctrl.on_tool_update(message_id="msg1", tool_name="read", status="started", detail="a.py")
+        ctrl.on_tool_update(message_id="msg1", tool_name="read", status="completed", detail="ok")
+        ctrl.on_answer(message_id="msg1", text=" Mid")
+        ctrl.on_tool_update(message_id="msg1", tool_name="exec", status="started", detail="cmd")
+        ctrl.on_tool_update(message_id="msg1", tool_name="exec", status="completed", detail="done")
+        ctrl.on_answer(message_id="msg1", text=" End")
+
+        s = ctrl._sessions["msg1"]
+        assert s._linear_phase == L_ANSWER
+        assert s.text.display_text == "Start Mid End"
+        assert len(s.tool_use._session.steps) == 2  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio
+    async def test_tool_answer_tool_without_initial_answer(self) -> None:
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+
+        ctrl.on_tool_update(message_id="msg1", tool_name="read", status="started", detail="f.py")
+        assert ctrl._sessions["msg1"]._linear_phase == L_TOOL
+
+        ctrl.on_answer(message_id="msg1", text="Thinking")
+        assert ctrl._sessions["msg1"]._linear_phase == L_ANSWER
+        assert ctrl._sessions["msg1"]._segment_start == 0
+
+        ctrl.on_tool_update(message_id="msg1", tool_name="exec", status="started", detail="cmd")
+        assert ctrl._sessions["msg1"]._linear_phase == L_TOOL
+
+
+# ── 异步卡片操作 ──
+
+
+class TestLinearCardCreation:
+    @pytest.mark.asyncio
+    async def test_answer_card_created_via_reply(self) -> None:
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+        ctrl.on_answer(message_id="msg1", text="Hello")
+        await _drain()
+
+        client = ctrl._client
+        client.cardkit_create.assert_called()
+        client.reply_card_by_id.assert_called_once()
+        s = ctrl._sessions["msg1"]
+        assert s.card_id == "card_mock"
+        assert s.card_msg_id == "msg_mock"
+
+    @pytest.mark.asyncio
+    async def test_tool_card_created_via_send(self) -> None:
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+        ctrl.on_tool_update(message_id="msg1", tool_name="read", status="started", detail="f.py")
+        await _drain()
+
+        client = ctrl._client
+        client.send_card_by_id.assert_called_once()
+        s = ctrl._sessions["msg1"]
+        assert s._tool_card_id == "card_mock"
+        assert s._tool_card_msg_id == "tool_msg_mock"
+
+    @pytest.mark.asyncio
+    async def test_answer_to_tool_transitions_cards(self) -> None:
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+        ctrl.on_answer(message_id="msg1", text="Checking")
+        await _drain()
+
+        ctrl.on_tool_update(message_id="msg1", tool_name="read", status="started", detail="f.py")
+        await _drain()
+
+        s = ctrl._sessions["msg1"]
+        assert s._linear_phase == L_TOOL
+        assert s.card_id is None
+        assert s.card_msg_id is None
+        assert s._tool_card_id is not None
+
+    @pytest.mark.asyncio
+    async def test_tool_to_answer_transitions_cards(self) -> None:
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+        ctrl.on_answer(message_id="msg1", text="Start")
+        await _drain()
+
+        ctrl.on_tool_update(message_id="msg1", tool_name="read", status="started", detail="f.py")
+        await _drain()
+
+        ctrl.on_answer(message_id="msg1", text=" More")
+        await _drain()
+
+        s = ctrl._sessions["msg1"]
+        assert s._linear_phase == L_ANSWER
+        assert s._tool_card_id is None
+        assert s.card_id is not None
+
+    @pytest.mark.asyncio
+    async def test_tool_start_idx_advanced_after_close(self) -> None:
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+
+        ctrl.on_tool_update(message_id="msg1", tool_name="read", status="started", detail="a.py")
+        ctrl.on_tool_update(message_id="msg1", tool_name="read", status="completed", detail="ok")
+        await _drain()
+
+        ctrl.on_answer(message_id="msg1", text="Result")
+        await _drain()
+
+        assert ctrl._sessions["msg1"]._tool_start_idx == 1
+
+    @pytest.mark.asyncio
+    async def test_second_tool_round_offset(self) -> None:
+        """第二轮工具调用只显示新步骤."""
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+
+        # 第一轮
+        ctrl.on_answer(message_id="msg1", text="A1")
+        ctrl.on_tool_update(message_id="msg1", tool_name="read", status="started", detail="a.py")
+        ctrl.on_tool_update(message_id="msg1", tool_name="read", status="completed", detail="ok")
+        await _drain()
+
+        # 回答 → 关闭工具卡
+        ctrl.on_answer(message_id="msg1", text=" A2")
+        await _drain()
+
+        # 第二轮工具
+        ctrl.on_tool_update(message_id="msg1", tool_name="exec", status="started", detail="cmd")
+        await _drain()
+
+        s = ctrl._sessions["msg1"]
+        assert s._tool_start_idx == 1  # read 已关闭
+        steps = s.tool_use.build_display_steps(s._tool_start_idx)
+        assert len(steps) == 1
+        assert steps[0]["name"] == "exec"
+
+    @pytest.mark.asyncio
+    async def test_segment_text_on_close(self) -> None:
+        """关闭回答卡时只发送当前段文本."""
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+
+        ctrl.on_answer(message_id="msg1", text="Round1")
+        await _drain()
+
+        # 进入工具 → 关闭回答卡
+        ctrl.on_tool_update(message_id="msg1", tool_name="read", status="started", detail="f.py")
+        await _drain()
+
+        client = ctrl._client
+        close_calls = client.cardkit_close_streaming.call_args_list
+        assert len(close_calls) >= 1
+        update_calls = client.cardkit_update.call_args_list
+        assert any("Round1" in str(c) for c in update_calls)
+
+
+# ── 完成 ──
+
+
+class TestLinearComplete:
+    @pytest.mark.asyncio
+    async def test_complete_in_answer_phase(self) -> None:
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+        ctrl.on_answer(message_id="msg1", text="Final answer")
+        await _drain()
+
+        result = ctrl.on_completed(
+            message_id="msg1", answer="Final answer", duration=1.0, model="test",
+        )
+        await _drain()
+
+        assert result is True
+        assert "msg1" not in ctrl._sessions
+
+    @pytest.mark.asyncio
+    async def test_complete_in_tool_phase(self) -> None:
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+        ctrl.on_answer(message_id="msg1", text="Partial")
+        await _drain()
+
+        ctrl.on_tool_update(message_id="msg1", tool_name="read", status="started", detail="f.py")
+        ctrl.on_tool_update(message_id="msg1", tool_name="read", status="completed", detail="ok")
+        await _drain()
+
+        result = ctrl.on_completed(
+            message_id="msg1", answer="Partial", duration=2.0, model="test",
+        )
+        await _drain()
+
+        assert result is True
+        assert "msg1" not in ctrl._sessions
+
+    @pytest.mark.asyncio
+    async def test_complete_no_cards_no_text(self) -> None:
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+
+        result = ctrl.on_completed(
+            message_id="msg1", answer="", duration=0.5, model="test",
+        )
+        await _drain()
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_complete_finalizes_with_footer(self) -> None:
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+        ctrl.on_answer(message_id="msg1", text="Done")
+        await _drain()
+
+        ctrl.on_completed(
+            message_id="msg1",
+            answer="Done",
+            duration=1.5,
+            model="claude-sonnet-4-20250514",
+            tokens={"input_tokens": 100, "output_tokens": 50},
+        )
+        await _drain()
+
+        client = ctrl._client
+        update_calls = client.cardkit_update.call_args_list
+        all_args = str(update_calls)
+        assert "claude-sonnet" in all_args or "Done" in all_args
+
+    @pytest.mark.asyncio
+    async def test_complete_after_multi_round(self) -> None:
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+
+        ctrl.on_answer(message_id="msg1", text="Start")
+        ctrl.on_tool_update(message_id="msg1", tool_name="read", status="started", detail="f.py")
+        ctrl.on_tool_update(message_id="msg1", tool_name="read", status="completed", detail="ok")
+        ctrl.on_answer(message_id="msg1", text=" Middle")
+        ctrl.on_tool_update(message_id="msg1", tool_name="exec", status="started", detail="cmd")
+        ctrl.on_tool_update(message_id="msg1", tool_name="exec", status="completed", detail="done")
+        ctrl.on_answer(message_id="msg1", text=" Final")
+        await _drain()
+
+        result = ctrl.on_completed(
+            message_id="msg1", answer="Start Middle Final", duration=3.0, model="test",
+        )
+        await _drain()
+
+        assert result is True
+
+
+# ── 推理相关 ──
+
+
+class TestLinearReasoning:
+    @pytest.mark.asyncio
+    async def test_thinking_mixed_reasoning_and_answer(self) -> None:
+        """on_thinking 含 <thinking>reasoning</thinking>answer 触发 L_ANSWER."""
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+        ctrl.on_thinking(message_id="msg1", text="<thinking>hmm</thinking>answer text")
+
+        s = ctrl._sessions["msg1"]
+        assert s._linear_phase == L_ANSWER
+        assert s.reasoning_text == "hmm"
+        assert "answer text" in s.text.display_text
+
+    @pytest.mark.asyncio
+    async def test_thinking_tags_still_triggers_answer(self) -> None:
+        """<thinking>hmm</thinking> 被 strip 后 answer_text 非空，仍然触发 L_ANSWER."""
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+        ctrl.on_thinking(message_id="msg1", text="<thinking>hmm</thinking>")
+
+        s = ctrl._sessions["msg1"]
+        assert s._linear_phase == L_ANSWER
+        assert s.reasoning_text == "hmm"
+
+    @pytest.mark.asyncio
+    async def test_thinking_reasoning_prefix_no_phase_change(self) -> None:
+        """Reasoning:\\n 前缀的整段文本都视为 reasoning，不触发 L_ANSWER."""
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+        ctrl.on_thinking(message_id="msg1", text="Reasoning:\nstep 1\n\nactual answer")
+
+        s = ctrl._sessions["msg1"]
+        assert s._linear_phase == L_IDLE
+        assert "step 1" in s.reasoning_text
+
+    @pytest.mark.asyncio
+    async def test_reasoning_flushed_into_answer_card(self) -> None:
+        """推理文本在回答卡创建时 flush 到 reasoning 面板."""
+        ctrl = _make_linear_ctrl(show_reasoning=True)
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+
+        ctrl.on_reasoning(message_id="msg1", text="thinking step 1")
+        ctrl.on_reasoning(message_id="msg1", text=" thinking step 2")
+        await _drain()
+
+        s = ctrl._sessions["msg1"]
+        assert s._linear_phase == L_ANSWER
+        assert "step 1" in s.reasoning_text
+        assert s.reasoning_panel_added is True
+
+        client = ctrl._client
+        stream_calls = client.cardkit_stream_element.call_args_list
+        reasoning_calls = [c for c in stream_calls if c[0][1] == "reasoning_text"]
+        assert len(reasoning_calls) >= 1
+
+    @pytest.mark.asyncio
+    async def test_reasoning_included_in_closed_card(self) -> None:
+        """关闭回答卡时 reasoning 包含在完成态卡片中."""
+        ctrl = _make_linear_ctrl(show_reasoning=True)
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+
+        ctrl.on_reasoning(message_id="msg1", text="deep thought")
+        ctrl.on_answer(message_id="msg1", text="Result")
+        await _drain()
+
+        ctrl.on_tool_update(message_id="msg1", tool_name="read", status="started", detail="f.py")
+        await _drain()
+
+        client = ctrl._client
+        update_calls = client.cardkit_update.call_args_list
+        all_content = str(update_calls)
+        assert "deep thought" in all_content
+
+    @pytest.mark.asyncio
+    async def test_reasoning_reset_between_rounds(self) -> None:
+        """多轮间 reasoning_text 在关闭回答卡后重置."""
+        ctrl = _make_linear_ctrl(show_reasoning=True)
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+
+        ctrl.on_reasoning(message_id="msg1", text="thought round 1")
+        ctrl.on_answer(message_id="msg1", text="Answer1")
+        await _drain()
+
+        ctrl.on_tool_update(message_id="msg1", tool_name="read", status="started", detail="f.py")
+        await _drain()
+
+        s = ctrl._sessions["msg1"]
+        assert s.reasoning_text == ""
+        assert s.reasoning_start == 0.0
+        assert s.reasoning_panel_added is False
+
+        ctrl.on_reasoning(message_id="msg1", text="thought round 2")
+        ctrl.on_answer(message_id="msg1", text=" Answer2")
+        await _drain()
+
+        assert s.reasoning_text == "thought round 2"
+        assert s.reasoning_panel_added is True
+
+    @pytest.mark.asyncio
+    async def test_reasoning_in_answer_schedules_update(self) -> None:
+        """L_ANSWER 且 card 已创建时，on_reasoning 调度 reasoning update."""
+        ctrl = _make_linear_ctrl(show_reasoning=True)
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+        ctrl.on_reasoning(message_id="msg1", text="initial")
+        await _drain()
+
+        s = ctrl._sessions["msg1"]
+        assert s.card_id is not None
+        assert s._linear_phase == L_ANSWER
+
+        ctrl.on_reasoning(message_id="msg1", text=" more thought")
+        assert s._linear_phase == L_ANSWER
+        assert s.reasoning_dirty is True
+        assert "more thought" in s.reasoning_text
+
+
+# ── /stop 中止 ──
+
+
+class TestLinearAbort:
+    @pytest.mark.asyncio
+    async def test_abort_sets_aborted_state(self) -> None:
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+        ctrl.on_answer(message_id="msg1", text="Working")
+        await _drain()
+
+        ctrl.on_aborted(message_id="msg1")
+        s = ctrl._sessions["msg1"]
+        assert s.state == ABORTED
+
+    @pytest.mark.asyncio
+    async def test_abort_in_answer_phase_closes_card(self) -> None:
+        """/stop 在回答阶段：关闭回答卡并 cleanup."""
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+        ctrl.on_answer(message_id="msg1", text="Partial answer")
+        await _drain()
+
+        assert ctrl._sessions["msg1"].card_id is not None
+
+        ctrl.on_aborted(message_id="msg1")
+        await _drain()
+
+        assert "msg1" not in ctrl._sessions
+
+    @pytest.mark.asyncio
+    async def test_abort_in_tool_phase_closes_tool_card(self) -> None:
+        """/stop 在工具阶段：先关工具卡再 cleanup."""
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+        ctrl.on_answer(message_id="msg1", text="Checking")
+        await _drain()
+
+        ctrl.on_tool_update(message_id="msg1", tool_name="read", status="started", detail="f.py")
+        await _drain()
+
+        assert ctrl._sessions["msg1"]._tool_card_id is not None
+
+        ctrl.on_aborted(message_id="msg1")
+        await _drain()
+
+        assert "msg1" not in ctrl._sessions
+
+    @pytest.mark.asyncio
+    async def test_abort_no_card_still_cleans_up(self) -> None:
+        """/stop 在 L_IDLE（未创建卡片）：仍正常 cleanup."""
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+
+        ctrl.on_aborted(message_id="msg1")
+        await _drain()
+
+        assert "msg1" not in ctrl._sessions
+
+    @pytest.mark.asyncio
+    async def test_abort_triggers_cardkit_close(self) -> None:
+        """/stop 后 cardkit_close_streaming 被调用."""
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="msg1", chat_id="chat1")
+        ctrl.on_answer(message_id="msg1", text="Text")
+        await _drain()
+
+        ctrl.on_aborted(message_id="msg1")
+        await _drain()
+
+        ctrl._client.cardkit_close_streaming.assert_called()
+
+
+# ── 新消息打断 ──
+
+
+class TestLinearInterrupt:
+    @pytest.mark.asyncio
+    async def test_interrupt_creates_linear_session(self) -> None:
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="old", chat_id="chat1")
+        ctrl.on_answer(message_id="old", text="Partial")
+
+        ctrl.on_interrupted(old_message_id="old", new_message_id="new", chat_id="chat1")
+
+        new_s = ctrl._sessions.get("new")
+        assert new_s is not None
+        assert new_s.linear is True
+        assert new_s.state == STREAMING
+
+    @pytest.mark.asyncio
+    async def test_interrupt_aborts_old_session(self) -> None:
+        """旧 session 状态设为 ABORTED 并触发 complete."""
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="old", chat_id="chat1")
+        ctrl.on_answer(message_id="old", text="Partial")
+        await _drain()
+
+        ctrl.on_interrupted(old_message_id="old", new_message_id="new", chat_id="chat1")
+        await _drain()
+
+        assert "old" not in ctrl._sessions
+        assert "new" in ctrl._sessions
+
+    @pytest.mark.asyncio
+    async def test_interrupt_in_tool_phase(self) -> None:
+        """打断发生在工具阶段：工具卡被关闭."""
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="old", chat_id="chat1")
+        ctrl.on_answer(message_id="old", text="Checking")
+        await _drain()
+
+        ctrl.on_tool_update(message_id="old", tool_name="read", status="started", detail="f.py")
+        await _drain()
+
+        assert ctrl._sessions["old"]._tool_card_id is not None
+
+        ctrl.on_interrupted(old_message_id="old", new_message_id="new", chat_id="chat1")
+        await _drain()
+
+        assert "old" not in ctrl._sessions
+
+    @pytest.mark.asyncio
+    async def test_interrupt_sets_interrupt_map(self) -> None:
+        """打断映射 old→new 被正确设置."""
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="old", chat_id="chat1")
+
+        ctrl.on_interrupted(old_message_id="old", new_message_id="new", chat_id="chat1")
+
+        assert ctrl._interrupt_map.get("old") == "new"
+
+    @pytest.mark.asyncio
+    async def test_interrupt_chain_redirects(self) -> None:
+        """连续打断 A→B→C：interrupt_map 链式更新."""
+        ctrl = _make_linear_ctrl()
+        ctrl.on_message_started(message_id="A", chat_id="chat1")
+
+        ctrl.on_interrupted(old_message_id="A", new_message_id="B", chat_id="chat1")
+        assert ctrl._interrupt_map.get("A") == "B"
+
+        ctrl.on_interrupted(old_message_id="B", new_message_id="C", chat_id="chat1")
+        assert ctrl._interrupt_map.get("A") == "C"
+        assert ctrl._interrupt_map.get("B") == "C"

--- a/tests/test_tooluse.py
+++ b/tests/test_tooluse.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from unittest.mock import patch
 
 import pytest
@@ -255,6 +256,66 @@ class TestFencedBlock:
         assert result["fenced"].startswith("````")
 
 
+class TestBuildDisplayStepsOffset:
+    def test_offset_zero_returns_all(self) -> None:
+        tracker = ToolUseTracker()
+        tracker.record_start("read", "a.py")
+        tracker.record_end("read", output="ok")
+        tracker.record_start("exec", "cmd")
+        tracker.record_end("exec", output="done")
+        assert len(tracker.build_display_steps(offset=0)) == 2
+
+    def test_offset_skips_first(self) -> None:
+        tracker = ToolUseTracker()
+        tracker.record_start("read", "a.py")
+        tracker.record_end("read", output="ok")
+        tracker.record_start("exec", "cmd")
+        tracker.record_end("exec", output="done")
+        steps = tracker.build_display_steps(offset=1)
+        assert len(steps) == 1
+        assert steps[0]["name"] == "exec"
+
+    @pytest.mark.parametrize("offset", [2, 5])
+    def test_offset_out_of_range_returns_empty(self, offset: int) -> None:
+        tracker = ToolUseTracker()
+        tracker.record_start("read", "a.py")
+        tracker.record_end("read", output="ok")
+        tracker.record_start("exec", "cmd")
+        tracker.record_end("exec", output="done")
+        assert tracker.build_display_steps(offset=offset) == []
+
+    def test_no_session_returns_empty(self) -> None:
+        assert ToolUseTracker().build_display_steps(offset=0) == []
+
+
+class TestRecordEndReturnsIndex:
+    def test_returns_step_index(self) -> None:
+        tracker = ToolUseTracker()
+        tracker.record_start("read", "a.py")
+        assert tracker.record_end("read", output="ok") == 0
+
+    def test_returns_none_without_session(self) -> None:
+        assert ToolUseTracker().record_end("orphan", output="late") is None
+
+    def test_no_matching_start_appends(self) -> None:
+        tracker = ToolUseTracker()
+        tracker.record_start("other", "f.py")
+        idx = tracker.record_end("read", output="late result")
+        assert idx == 1
+
+    def test_multiple_steps_return_correct_index(self) -> None:
+        tracker = ToolUseTracker()
+        tracker.record_start("read", "a.py")
+        tracker.record_end("read", output="ok")
+        tracker.record_start("exec", "cmd")
+        assert tracker.record_end("exec", output="done") == 1
+
+    def test_error_step_returns_index(self) -> None:
+        tracker = ToolUseTracker()
+        tracker.record_start("exec", "cmd")
+        assert tracker.record_end("exec", error="boom") == 0
+
+
 class TestToolUseTracker:
     def test_empty_tracker(self) -> None:
         tracker = ToolUseTracker()
@@ -339,6 +400,7 @@ class TestToolUseTracker:
     def test_elapsed_ms_positive_after_start(self) -> None:
         tracker = ToolUseTracker()
         tracker.record_start("read", "f")
+        time.sleep(0.001)
         assert tracker.elapsed_ms > 0.0
 
     def test_detail_sanitized(self) -> None:


### PR DESCRIPTION
## Summary

- Linear state machine: `L_IDLE ↔ L_ANSWER ↔ L_TOOL` with per-card tool tracking
- Answer cards via `reply_card_by_id`, tool cards via `send_card_by_id`
- Card transitions: `_close_answer_card`, `_close_tool_card`, `_linear_open_answer_card`
- `_linear_lock` protects phase transitions from concurrent flush
- `ToolUseTracker.build_display_steps(offset)` for per-card tool slicing
- `build_complete_card` gains `show_footer` and `reasoning_expanded` params
- `FeishuClient.send_card_by_id` for non-reply card sending

## Test plan

- [x] 344 tests pass (276 existing + 68 new)