### PR TITLE
feat: cron card delivery for Feishu/Lark

### DIFF
--- a/.github/workflows/hermes-check.yml
+++ b/.github/workflows/hermes-check.yml
@@ -18,11 +18,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Fetch Hermes run.py
+      - name: Fetch Hermes sources
         run: |
           curl -fsSL "https://raw.githubusercontent.com/NousResearch/hermes-agent/main/gateway/run.py" -o hermes_run.py
           if [ ! -s hermes_run.py ]; then
             echo "::error::Failed to fetch run.py"
+            exit 1
+          fi
+          curl -fsSL "https://raw.githubusercontent.com/NousResearch/hermes-agent/main/cron/scheduler.py" -o hermes_scheduler.py
+          if [ ! -s hermes_scheduler.py ]; then
+            echo "::error::Failed to fetch scheduler.py"
             exit 1
           fi
 
@@ -40,9 +45,12 @@ jobs:
         run: |
           python -c "
           import pathlib
-          from hermes_lark_streaming.patcher import Patcher
+          from hermes_lark_streaming.patcher import Patcher, CronPatcher
           p = Patcher(pathlib.Path('hermes_run.py'))
           p.verify_target()
+          cp = CronPatcher(pathlib.Path('hermes_scheduler.py'))
+          cp.verify_target()
+          print('Both targets compatible.')
           "
 
       - name: Open issue on failure
@@ -52,7 +60,7 @@ jobs:
           script: |
             const label = 'hermes-compat';
             const title = 'Hermes compatibility check failed';
-            const body = `The daily Hermes \`gateway/run.py\` compatibility check failed.\n\nPlease check if Hermes has updated function names or injection anchors.\n\nWorkflow run: ${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const body = `The daily Hermes compatibility check failed.\n\nPlease check if Hermes has updated function names or injection anchors in \`gateway/run.py\` or \`cron/scheduler.py\`.\n\nWorkflow run: ${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
 
             // Ensure label exists
             try {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project
 
-Hermes Gateway plugin that injects hooks into `~/.hermes/hermes-agent/gateway/run.py` via AST patching to provide real-time streaming Feishu/Lark CardKit v2.0 cards with typewriter effect.
+Hermes Gateway plugin that injects hooks into `~/.hermes/hermes-agent/gateway/run.py` and `cron/scheduler.py` via AST patching to provide real-time streaming Feishu/Lark CardKit v2.0 cards with typewriter effect.
 
 ## Commands
 
@@ -11,9 +11,9 @@ Hermes Gateway plugin that injects hooks into `~/.hermes/hermes-agent/gateway/ru
 HERMES_PYTHON=~/.hermes/hermes-agent/venv/bin/python3
 
 $HERMES_PYTHON -m hermes_lark_streaming verify     # Check compatibility (safe, no file changes)
-$HERMES_PYTHON -m hermes_lark_streaming install    # Inject hooks into run.py
+$HERMES_PYTHON -m hermes_lark_streaming install    # Inject hooks into run.py and cron/scheduler.py
 $HERMES_PYTHON -m hermes_lark_streaming uninstall  # Remove hooks
-$HERMES_PYTHON -m hermes_lark_streaming restore    # Restore run.py from .hermes_lark.bak
+$HERMES_PYTHON -m hermes_lark_streaming restore    # Restore from .hermes_lark.bak backup
 $HERMES_PYTHON -m hermes_lark_streaming status     # Show patch status
 
 # Install for development
@@ -45,6 +45,10 @@ gateway/run.py (Hermes)
        ├─ on_message_completed  → controller.on_completed()
        └─ on_message_aborted    → controller.on_aborted()
 
+cron/scheduler.py (Hermes)
+  └─ CronPatcher (patcher.py) injects on_cron_deliver into _deliver_result
+       └─ intercepts feishu/lark targets → build_cron_card → send_card_to_chat
+
 StreamCardController (singleton, controller.py)
   ├─ CardSession per message (state machine: IDLE→CREATING→STREAMING→COMPLETED/FAILED/ABORTED)
   │   └─ linear mode: CardSession.linear + CardSession.linear_state (LinearState)
@@ -72,7 +76,7 @@ Card templates (cardkit.py) — builds Feishu card JSON
 
 ## Key Constraints
 
-- Hermes `>= 0.11.0` (2026.4.23) required. `patcher.py` targets specific function names in Hermes's `gateway/run.py` (`_handle_message_with_agent`, `progress_callback`, `_stream_delta_cb`, `_interim_assistant_cb`). If Hermes changes these, `verify` will catch it.
+- Hermes `>= 0.11.0` (2026.4.23) required. `patcher.py` targets specific function names in Hermes's `gateway/run.py` (`_handle_message_with_agent`, `progress_callback`, `_stream_delta_cb`, `_interim_assistant_cb`) and `cron/scheduler.py` (`_deliver_result`). If Hermes changes these, `verify` will catch it.
 - The interrupt hook is injected at the `"Restart typing indicator"` comment in `_run_agent`. It fires when `was_interrupted and next_message_id` are both truthy. The `_interrupt_map` redirects `on_completed(old_id)` to the new session, handling nested interrupts (A→B→C).
 - The `_thinking_hook` has a `not already_streamed` guard (patcher.py:103) — thinking deltas are skipped once answer streaming has begun.
 - The NORMALIZE hook (`on_feishu_normalize`) is injected at `source = event.source` in `_handle_message`, before any other processing. It detects Feishu quoted messages with a false `thread_id` (set by the Feishu adapter but absent in raw event) and clears it, preventing `_reply_anchor_for_event` from returning the wrong ID.

--- a/README.en.md
+++ b/README.en.md
@@ -24,6 +24,7 @@ Inspired by [openclaw-lark](https://github.com/larksuite/openclaw-lark) and [her
 - **Message guard** — Auto-terminates updates when message is deleted/recalled
 - **Image resolution** — Detects markdown image references, downloads and re-uploads as Feishu img_key
 - **Abort handling** — Gracefully handles `/stop` command and message interrupts with aborted state card and automatic new session
+- **Cron card delivery** — Delivers scheduled job results as Feishu cards, preserving Markdown rendering
 - **i18n** — Built-in Chinese/English bilingual card text (status, tool panel, thinking labels, etc.) that auto-switches based on Feishu client language
 
 ---
@@ -134,7 +135,7 @@ HERMES_PYTHON=~/.hermes/hermes-agent/venv/bin/python3
 $HERMES_PYTHON -m hermes_lark_streaming verify     # Verify compatibility (no file changes)
 $HERMES_PYTHON -m hermes_lark_streaming install    # Inject hooks
 $HERMES_PYTHON -m hermes_lark_streaming uninstall  # Remove hooks
-$HERMES_PYTHON -m hermes_lark_streaming restore    # Restore original run.py from backup
+$HERMES_PYTHON -m hermes_lark_streaming restore    # Restore original files from backup
 $HERMES_PYTHON -m hermes_lark_streaming status     # Show status
 ```
 
@@ -167,7 +168,7 @@ $HERMES_PYTHON -m pip uninstall hermes-lark-streaming
 
 ## How It Works
 
-The plugin injects hook calls into `gateway/run.py` via AST patching. All business logic lives in the `hermes_lark_streaming` package:
+The plugin injects hook calls into `gateway/run.py` and `cron/scheduler.py` via AST patching. All business logic lives in the `hermes_lark_streaming` package:
 
 | Hook | Injection Target | Description |
 |------|-----------------|-------------|
@@ -181,6 +182,7 @@ The plugin injects hook calls into `gateway/run.py` via AST patching. All busine
 | `on_message_aborted` | Before stale `return None` | Handles `/stop` abort |
 | `on_message_interrupted` | Before recursive `_run_agent` call | Handles message interrupts, terminates old card and creates new session |
 | `on_message_completed` | Before `return response` | Sends completion card |
+| `on_cron_deliver` | After `delivered = False` in `_deliver_result` | Intercepts Feishu cron delivery, sends as card |
 
 **Message flow:**
 
@@ -217,7 +219,7 @@ If a message is deleted/recalled, UnavailableGuard auto-terminates further updat
 
 ## Notes
 
-- `install` modifies `~/.hermes/hermes-agent/gateway/run.py` and creates a `.hermes_lark.bak` backup
+- `install` modifies `~/.hermes/hermes-agent/gateway/run.py` and `cron/scheduler.py`, and creates `.hermes_lark.bak` backups
 - Re-run `verify` + `install` after Hermes updates
 - The plugin complements the built-in Feishu adapter: plugin handles streaming cards, built-in adapter handles message routing
 - Only affects Feishu/Lark platform — other platforms are unaffected

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - **消息保护** — 消息被删除/撤回后自动终止更新，避免无效 API 调用
 - **图片解析** — 自动识别 markdown 图片引用，下载上传后替换为飞书 img_key
 - **中断处理** — 处理 `/stop` 命令和消息打断，展示中断状态卡片并自动开启新会话
+- **Cron 卡片推送** — 定时任务结果以飞书卡片形式推送，保留 Markdown 渲染
 - **多语言** — 卡片文本（状态、工具面板、思考标签等）内置中英双语，根据飞书客户端语言自动切换
 
 ---
@@ -134,7 +135,7 @@ HERMES_PYTHON=~/.hermes/hermes-agent/venv/bin/python3
 $HERMES_PYTHON -m hermes_lark_streaming verify     # 验证兼容性（不修改文件）
 $HERMES_PYTHON -m hermes_lark_streaming install    # 注入 hook
 $HERMES_PYTHON -m hermes_lark_streaming uninstall  # 移除 hook
-$HERMES_PYTHON -m hermes_lark_streaming restore    # 从备份恢复原始 run.py
+$HERMES_PYTHON -m hermes_lark_streaming restore    # 从备份恢复原始文件
 $HERMES_PYTHON -m hermes_lark_streaming status     # 查看状态
 ```
 
@@ -167,7 +168,7 @@ $HERMES_PYTHON -m pip uninstall hermes-lark-streaming
 
 ## 工作原理
 
-插件通过 AST 注入在 `gateway/run.py` 插入 hook 调用，所有业务逻辑在 `hermes_lark_streaming` 包内完成：
+插件通过 AST 注入在 `gateway/run.py` 和 `cron/scheduler.py` 插入 hook 调用，所有业务逻辑在 `hermes_lark_streaming` 包内完成：
 
 | Hook | 注入位置 | 说明 |
 |------|----------|------|
@@ -181,6 +182,7 @@ $HERMES_PYTHON -m pip uninstall hermes-lark-streaming
 | `on_message_aborted` | stale `return None` 之前 | 处理 `/stop` 中断 |
 | `on_message_interrupted` | `_run_agent` 递归调用前 | 处理消息打断，终止旧卡片并创建新会话 |
 | `on_message_completed` | `return response` 之前 | 发送终态卡片 |
+| `on_cron_deliver` | `_deliver_result` 中 `delivered = False` 之后 | 拦截飞书 Cron 推送，以卡片形式发送 |
 
 **消息处理流程：**
 
@@ -217,7 +219,7 @@ $HERMES_PYTHON -m pip uninstall hermes-lark-streaming
 
 ## 注意事项
 
-- `install` 会修改 `~/.hermes/hermes-agent/gateway/run.py`，自动创建 `.hermes_lark.bak` 备份
+- `install` 会修改 `~/.hermes/hermes-agent/gateway/run.py` 和 `cron/scheduler.py`，自动创建 `.hermes_lark.bak` 备份
 - Hermes 更新后需重新运行 `verify` + `install`
 - 插件与 Hermes 内置飞书适配器互补工作：插件负责流式卡片，内置适配器负责消息收发
 - 仅对飞书平台生效，其他平台不受影响

--- a/hermes_lark_streaming/__main__.py
+++ b/hermes_lark_streaming/__main__.py
@@ -6,7 +6,7 @@ import sys
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .patcher import Patcher
+    from .patcher import CronPatcher, Patcher
 
 
 def main() -> int:
@@ -37,11 +37,11 @@ def _print_usage() -> None:
     print("Usage: python -m hermes_lark_streaming <command>")
     print()
     print("Commands:")
-    print("  install    Apply AST patch to gateway/run.py")
-    print("  uninstall  Remove AST patch from gateway/run.py")
-    print("  restore    Restore run.py from backup")
+    print("  install    Apply AST patch to gateway/run.py and cron/scheduler.py")
+    print("  uninstall  Remove AST patch")
+    print("  restore    Restore from backup")
     print("  status     Show current patch status")
-    print("  verify     Verify run.py compatibility without patching")
+    print("  verify     Verify compatibility without patching")
 
 
 def _get_patcher() -> Patcher | None:
@@ -54,6 +54,15 @@ def _get_patcher() -> Patcher | None:
         return None
 
 
+def _get_cron_patcher() -> CronPatcher | None:
+    from .patcher import CronPatcher, PatcherError
+
+    try:
+        return CronPatcher()
+    except PatcherError:
+        return None
+
+
 def _cmd_install() -> int:
     patcher = _get_patcher()
     if patcher is None:
@@ -61,23 +70,32 @@ def _cmd_install() -> int:
 
     if patcher.is_fully_patched():
         print("Already patched.")
-        return 0
+    else:
+        print("Verifying target compatibility...")
+        try:
+            patcher.verify_target()
+        except Exception as e:
+            print(f"Verification failed: {e}")
+            return 1
+        print("Target compatible.")
 
-    print("Verifying target compatibility...")
-    try:
-        patcher.verify_target()
-    except Exception as e:
-        print(f"Verification failed: {e}")
-        return 1
-    print("Target compatible.")
+        print("Applying patch...")
+        try:
+            patcher.apply()
+        except Exception as e:
+            print(f"Patch failed: {e}")
+            return 1
+        print("Patch applied successfully.")
 
-    print("Applying patch...")
-    try:
-        patcher.apply()
-    except Exception as e:
-        print(f"Patch failed: {e}")
-        return 1
-    print("Patch applied successfully.")
+    cron_patcher = _get_cron_patcher()
+    if cron_patcher is not None and not cron_patcher.is_patched():
+        try:
+            cron_patcher.verify_target()
+            cron_patcher.apply()
+            print("Cron hook applied.")
+        except Exception as e:
+            print(f"Cron hook skipped: {e}")
+
     return 0
 
 
@@ -85,6 +103,14 @@ def _cmd_uninstall() -> int:
     patcher = _get_patcher()
     if patcher is None:
         return 1
+
+    cron_patcher = _get_cron_patcher()
+    if cron_patcher is not None and cron_patcher.is_patched():
+        try:
+            cron_patcher.remove()
+            print("Cron hook removed.")
+        except Exception as e:
+            print(f"Cron hook remove failed: {e}")
 
     if not patcher.is_patched():
         print("Not patched.")
@@ -104,6 +130,14 @@ def _cmd_restore() -> int:
     patcher = _get_patcher()
     if patcher is None:
         return 1
+
+    cron_patcher = _get_cron_patcher()
+    if cron_patcher is not None:
+        try:
+            cron_patcher.restore()
+            print("Cron hook restored.")
+        except Exception:
+            pass
 
     print("Restoring from backup...")
     try:
@@ -133,6 +167,10 @@ def _cmd_status() -> int:
             label = begin.replace("# HERMES_LARK_", "").replace("_BEGIN", "").lower()
             print(f"  {label}: {'installed' if found else 'missing'}")
 
+    cron_patcher = _get_cron_patcher()
+    if cron_patcher is not None:
+        print(f"Cron hook: {'installed' if cron_patcher.is_patched() else 'not installed'}")
+
     # Check config
     from .config import Config
 
@@ -155,6 +193,17 @@ def _cmd_verify() -> int:
         print(f"Incompatible: {e}")
         return 1
     print("Compatible.")
+
+    cron_patcher = _get_cron_patcher()
+    if cron_patcher is not None:
+        print(f"Cron target: {cron_patcher.cron_path}")
+        try:
+            cron_patcher.verify_target()
+        except Exception as e:
+            print(f"Cron incompatible: {e}")
+            return 1
+        print("Cron target compatible.")
+
     return 0
 
 

--- a/hermes_lark_streaming/cardkit.py
+++ b/hermes_lark_streaming/cardkit.py
@@ -596,3 +596,21 @@ def build_linear_complete_card(
         card["config"]["summary"] = {"content": summary}
     card["body"] = {"elements": elements}
     return card
+
+
+def build_cron_card(content: str) -> dict[str, Any]:
+    """Cron 推送用的极简静态卡片 — schema 2.0，仅 markdown 内容."""
+    card: dict[str, Any] = {
+        "schema": "2.0",
+        "config": {"wide_screen_mode": True, "locales": _LOCALES},
+        "body": {"elements": []},
+    }
+    if not content.strip():
+        return card
+    summary = content[:120].replace("\n", " ").replace("```", "").strip()
+    if summary:
+        card["config"]["summary"] = {"content": summary}
+    for chunk in _split_long_text(optimize_markdown_style(content)):
+        if chunk.strip():
+            card["body"]["elements"].append({"tag": "markdown", "content": chunk})
+    return card

--- a/hermes_lark_streaming/controller.py
+++ b/hermes_lark_streaming/controller.py
@@ -464,6 +464,27 @@ class StreamCardController(ControllerMixin, LinearControllerMixin):
         self._complete_session(session)
         return True
 
+    def on_cron_deliver(
+        self,
+        *,
+        chat_id: str,
+        content: str,
+        loop: asyncio.AbstractEventLoop,
+    ) -> bool:
+        """Cron 推送 — 包装为静态卡片发送，成功返回 True."""
+        if not self.enabled or not content or not chat_id:
+            return False
+        future = asyncio.run_coroutine_threadsafe(
+            self._do_cron_deliver(chat_id, content), loop
+        )
+        try:
+            future.result(timeout=30)
+            _logger.info("cron card delivered: chat=%s len=%d", chat_id[:12], len(content))
+            return True
+        except Exception:
+            _logger.warning("cron card delivery failed", exc_info=True)
+            return False
+
     def defer_background_review(
         self,
         *,

--- a/hermes_lark_streaming/controller_mixin.py
+++ b/hermes_lark_streaming/controller_mixin.py
@@ -14,6 +14,7 @@ from .cardkit import (
     TOOL_PANEL_ELEMENT_ID,
     _build_tool_panel,
     build_complete_card,
+    build_cron_card,
     build_im_fallback_card,
     build_streaming_card,
     build_streaming_card_v2,
@@ -374,3 +375,9 @@ class ControllerMixin:
         )
         session.state = FAILED
         return False
+
+    async def _do_cron_deliver(self, chat_id: str, content: str) -> None:
+        await self._ensure_init()
+        assert self._client is not None
+        card = build_cron_card(content)
+        await self._client.send_card_to_chat(chat_id, card)

--- a/hermes_lark_streaming/feishu.py
+++ b/hermes_lark_streaming/feishu.py
@@ -29,6 +29,8 @@ from lark_oapi.api.cardkit.v1 import (
 from lark_oapi.api.im.v1 import (
     CreateImageRequest,
     CreateImageRequestBody,
+    CreateMessageRequest,
+    CreateMessageRequestBody,
     PatchMessageRequest,
     PatchMessageRequestBody,
     ReplyMessageRequest,
@@ -110,6 +112,26 @@ class FeishuClient:
     @staticmethod
     def _dumps(obj: Any) -> str:
         return json.dumps(obj, ensure_ascii=False)
+
+    async def send_card_to_chat(self, chat_id: str, card: dict[str, Any]) -> str:
+        """发送独立卡片到聊天（非回复），返回 message_id."""
+        request = (
+            CreateMessageRequest.builder()
+            .receive_id_type("chat_id")
+            .request_body(
+                CreateMessageRequestBody.builder()
+                .receive_id(chat_id)
+                .msg_type("interactive")
+                .content(self._dumps(card))
+                .build()
+            )
+            .build()
+        )
+        resp = await self._client.im.v1.message.acreate(request)
+        self._check(resp, "send_card_to_chat")
+        if resp.data and resp.data.message_id:
+            return str(resp.data.message_id)
+        raise FeishuAPIError("send_card_to_chat: response missing message_id")
 
     async def reply_card(self, message_id: str, card: dict[str, Any]) -> str:
         """回复消息，返回 message_id."""

--- a/hermes_lark_streaming/patch.py
+++ b/hermes_lark_streaming/patch.py
@@ -198,3 +198,22 @@ def on_message_interrupted(
         chat_id=chat_id,
         anchor_id=anchor_id,
     )
+
+
+def on_cron_deliver(
+    *,
+    chat_id: str,
+    content: str,
+    loop: Any = None,
+) -> bool:
+    """[注入点 10] cron 推送 — 包装为飞书卡片发送."""
+    if loop is None:
+        return False
+    try:
+        ctrl = get_controller()
+        if not ctrl.enabled:
+            return False
+        return bool(ctrl.on_cron_deliver(chat_id=chat_id, content=content, loop=loop))
+    except Exception as exc:
+        _logger.warning("on_cron_deliver error: %s", exc, exc_info=True)
+        return False

--- a/hermes_lark_streaming/patcher.py
+++ b/hermes_lark_streaming/patcher.py
@@ -40,6 +40,10 @@ MK_INTERRUPT, MK_INTERRUPT_END = MARKERS[9]
 _BACKUP_SUFFIX = ".hermes_lark.bak"
 
 _RUN_PATH = Path.home() / ".hermes" / "hermes-agent" / "gateway" / "run.py"
+_CRON_PATH = Path.home() / ".hermes" / "hermes-agent" / "cron" / "scheduler.py"
+
+MK_CRON_DELIVER = f"# {PREFIX}_CRON_DELIVER_BEGIN"
+MK_CRON_DELIVER_END = f"# {PREFIX}_CRON_DELIVER_END"
 
 
 def _make_hook(indent: str, begin: str, end: str, body_lines: list[str]) -> str:
@@ -253,6 +257,39 @@ def _interrupt_hook(indent: str) -> str:
     )
 
 
+def _cron_deliver_hook(indent: str) -> str:
+    return _make_hook(
+        indent,
+        MK_CRON_DELIVER,
+        MK_CRON_DELIVER_END,
+        [
+            "try:",
+            "    if platform_name.lower() in ('feishu', 'lark'):",
+            "        from hermes_lark_streaming.patch import on_cron_deliver",
+            "        if on_cron_deliver(chat_id=chat_id, content=cleaned_delivery_content.strip(), loop=loop):",
+            "            delivered = True",
+            "            continue",
+            "except Exception:",
+            "    pass",
+        ],
+    )
+
+
+def _remove_block(content: str, begin: str, end: str) -> str:
+    lines = content.splitlines(keepends=True)
+    begin_idx = end_idx = None
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped == begin:
+            begin_idx = i
+        if stripped == end:
+            end_idx = i
+            break
+    if begin_idx is not None and end_idx is not None:
+        return "".join(lines[:begin_idx] + lines[end_idx + 1 :])
+    return content
+
+
 class PatcherError(RuntimeError):
     pass
 
@@ -339,7 +376,7 @@ class Patcher:
         content = self.run_path.read_text(encoding="utf-8")
         if self.is_patched():
             for begin, end in self.MARKERS:
-                content = self._remove_block(content, begin, end)
+                content = _remove_block(content, begin, end)
         else:
             self._backup()
         content = self._inject_all(content)
@@ -350,7 +387,7 @@ class Patcher:
         if not any(begin in content for begin, _ in self.MARKERS):
             return
         for begin, end in self.MARKERS:
-            content = self._remove_block(content, begin, end)
+            content = _remove_block(content, begin, end)
         self.run_path.write_text(content, encoding="utf-8")
 
     def restore(self) -> None:
@@ -406,21 +443,6 @@ class Patcher:
             lines[idx:idx] = hook.splitlines(keepends=True)
 
         return "".join(lines)
-
-    def _remove_block(self, content: str, begin: str, end: str) -> str:
-        lines = content.splitlines(keepends=True)
-        begin_idx = end_idx = None
-        for i, line in enumerate(lines):
-            stripped = line.strip()
-            if stripped == begin:
-                begin_idx = i
-            if stripped == end:
-                end_idx = i
-                break
-
-        if begin_idx is not None and end_idx is not None:
-            return "".join(lines[:begin_idx] + lines[end_idx + 1 :])
-        return content
 
 
 def _find_func_body(tree: ast.Module, lines: list[str], name: str) -> tuple[int, str] | None:
@@ -528,3 +550,60 @@ def _safe_indent(lines: list[str], lineno: int) -> str:
         if lines[i].strip():
             return lines[i][: len(lines[i]) - len(lines[i].lstrip())]
     return ""
+
+
+class CronPatcher:
+    """注入 CRON_DELIVER hook 到 cron/scheduler.py 的 _deliver_result."""
+
+    def __init__(self, cron_path: Path = _CRON_PATH) -> None:
+        self.cron_path = cron_path
+        if not cron_path.exists():
+            raise PatcherError(f"scheduler.py not found: {cron_path}")
+
+    def is_patched(self) -> bool:
+        return MK_CRON_DELIVER in self.cron_path.read_text(encoding="utf-8")
+
+    def verify_target(self) -> None:
+        content = self.cron_path.read_text(encoding="utf-8")
+        if "delivered = False" not in content:
+            raise PatcherError("Cannot find 'delivered = False' anchor in scheduler.py")
+        if "cleaned_delivery_content" not in content:
+            raise PatcherError("Cannot find 'cleaned_delivery_content' in scheduler.py")
+
+    def apply(self) -> None:
+        if self.is_patched():
+            return
+        self.verify_target()
+        self._backup()
+        lines = self.cron_path.read_text(encoding="utf-8").splitlines(keepends=True)
+
+        inject_idx = None
+        for i, line in enumerate(lines):
+            if line.strip() == "delivered = False":
+                inject_idx = i
+                break
+        if inject_idx is None:
+            raise PatcherError("Cannot find 'delivered = False' anchor")
+
+        indent = _safe_indent(lines, inject_idx)
+        hook = _cron_deliver_hook(indent)
+        lines[inject_idx + 1 : inject_idx + 1] = hook.splitlines(keepends=True)
+        self.cron_path.write_text("".join(lines), encoding="utf-8")
+
+    def remove(self) -> None:
+        content = self.cron_path.read_text(encoding="utf-8")
+        if MK_CRON_DELIVER not in content:
+            return
+        content = _remove_block(content, MK_CRON_DELIVER, MK_CRON_DELIVER_END)
+        self.cron_path.write_text(content, encoding="utf-8")
+
+    def restore(self) -> None:
+        backup = self.cron_path.with_suffix(self.cron_path.suffix + _BACKUP_SUFFIX)
+        if not backup.exists():
+            raise PatcherError(f"No backup found: {backup}")
+        shutil.copy2(backup, self.cron_path)
+
+    def _backup(self) -> None:
+        backup = self.cron_path.with_suffix(self.cron_path.suffix + _BACKUP_SUFFIX)
+        if not backup.exists():
+            shutil.copy2(self.cron_path, backup)

--- a/tests/test_cardkit.py
+++ b/tests/test_cardkit.py
@@ -583,3 +583,34 @@ class TestBuildLinearCompleteCard:
         )
         summary = card["config"].get("summary", {}).get("content", "")
         assert len(summary) <= 120
+
+
+class TestBuildCronCard:
+    def test_basic_card_structure(self) -> None:
+        from hermes_lark_streaming.cardkit import build_cron_card
+
+        card = build_cron_card("Hello **world**")
+        assert card["schema"] == "2.0"
+        assert card["body"]["elements"][0]["tag"] == "markdown"
+        assert "Hello **world**" in card["body"]["elements"][0]["content"]
+
+    def test_summary_from_content(self) -> None:
+        from hermes_lark_streaming.cardkit import build_cron_card
+
+        card = build_cron_card("Line 1\nLine 2\n" + "x" * 200)
+        summary = card["config"]["summary"]["content"]
+        assert summary.startswith("Line 1 Line 2")
+        assert len(summary) <= 120
+
+    def test_empty_content(self) -> None:
+        from hermes_lark_streaming.cardkit import build_cron_card
+
+        card = build_cron_card("")
+        assert card["body"]["elements"] == []
+
+    def test_table_content_preserved(self) -> None:
+        from hermes_lark_streaming.cardkit import build_cron_card
+
+        content = "| A | B |\n|---|---|\n| 1 | 2 |"
+        card = build_cron_card(content)
+        assert "| A | B |" in card["body"]["elements"][0]["content"]

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -938,3 +938,63 @@ class TestLinearOnThinking:
 
         assert len(session.linear_state.segments) == 1
         assert session.linear_state.segments[0].type == "reasoning"
+
+
+class TestCronDeliver:
+    def test_returns_false_when_disabled(self) -> None:
+        ctrl = StreamCardController()
+        ctrl._cfg = MagicMock()
+        ctrl._cfg.enabled = False
+        assert ctrl.on_cron_deliver(chat_id="c1", content="text", loop=MagicMock()) is False
+
+    def test_returns_false_on_empty_content(self) -> None:
+        ctrl = StreamCardController()
+        ctrl._cfg = MagicMock()
+        ctrl._cfg.enabled = True
+        assert ctrl.on_cron_deliver(chat_id="c1", content="", loop=MagicMock()) is False
+
+    def test_sends_card_on_success(self) -> None:
+        import threading
+
+        ctrl = StreamCardController()
+        ctrl._cfg = MagicMock()
+        ctrl._cfg.enabled = True
+
+        mock_client = AsyncMock()
+        mock_client.send_card_to_chat.return_value = "msg_123"
+        ctrl._client = mock_client
+        ctrl._initialized = True
+
+        loop = asyncio.new_event_loop()
+        threading.Thread(target=loop.run_forever, daemon=True).start()
+        try:
+            result = ctrl.on_cron_deliver(chat_id="c1", content="hello", loop=loop)
+            assert result is True
+            mock_client.send_card_to_chat.assert_called_once()
+            args = mock_client.send_card_to_chat.call_args[0]
+            assert args[0] == "c1"
+            card = args[1]
+            assert card["schema"] == "2.0"
+            assert "hello" in card["body"]["elements"][0]["content"]
+        finally:
+            loop.call_soon_threadsafe(loop.stop)
+
+    def test_returns_false_on_send_failure(self) -> None:
+        import threading
+
+        ctrl = StreamCardController()
+        ctrl._cfg = MagicMock()
+        ctrl._cfg.enabled = True
+
+        mock_client = AsyncMock()
+        mock_client.send_card_to_chat.side_effect = RuntimeError("API error")
+        ctrl._client = mock_client
+        ctrl._initialized = True
+
+        loop = asyncio.new_event_loop()
+        threading.Thread(target=loop.run_forever, daemon=True).start()
+        try:
+            result = ctrl.on_cron_deliver(chat_id="c1", content="hello", loop=loop)
+            assert result is False
+        finally:
+            loop.call_soon_threadsafe(loop.stop)

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -11,10 +11,19 @@ import shutil
 import textwrap
 import urllib.request
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from hermes_lark_streaming.patcher import MARKERS, Patcher, PatcherError
+from hermes_lark_streaming.patcher import (
+    MARKERS,
+    MK_CRON_DELIVER,
+    MK_CRON_DELIVER_END,
+    CronPatcher,
+    Patcher,
+    PatcherError,
+    _remove_block,
+)
 
 RUN_SRC = Path.home() / ".hermes" / "hermes-agent" / "gateway" / "run.py"
 RUN_BAK = RUN_SRC.with_suffix(RUN_SRC.suffix + ".hermes_lark.bak")
@@ -22,7 +31,11 @@ SAMPLES_DIR = Path(__file__).parent / "samples"
 SAMPLE_RUN = SAMPLES_DIR / "run.py"
 
 _RUN_URL = "https://raw.githubusercontent.com/NousResearch/hermes-agent/main/gateway/run.py"
+_CRON_URL = "https://raw.githubusercontent.com/NousResearch/hermes-agent/main/cron/scheduler.py"
 
+CRON_SRC = Path.home() / ".hermes" / "hermes-agent" / "cron" / "scheduler.py"
+CRON_BAK = CRON_SRC.with_suffix(CRON_SRC.suffix + ".hermes_lark.bak")
+SAMPLE_CRON = SAMPLES_DIR / "scheduler.py"
 
 def _ensure_sample() -> Path:
     src = RUN_BAK if RUN_BAK.exists() else RUN_SRC
@@ -48,8 +61,35 @@ def run_copy(tmp_path: Path) -> Path:
     return dst
 
 
+def _ensure_cron_sample() -> Path:
+    src = CRON_BAK if CRON_BAK.exists() else CRON_SRC
+    SAMPLES_DIR.mkdir(parents=True, exist_ok=True)
+    if src.exists():
+        shutil.copy2(src, SAMPLE_CRON)
+        return SAMPLE_CRON
+    try:
+        urllib.request.urlretrieve(_CRON_URL, SAMPLE_CRON)
+    except Exception as exc:
+        pytest.skip(f"scheduler.py not found locally and download failed: {exc}")
+    if not SAMPLE_CRON.exists() or SAMPLE_CRON.stat().st_size == 0:
+        pytest.skip("scheduler.py download returned empty file")
+    return SAMPLE_CRON
+
+
+@pytest.fixture()
+def scheduler_copy(tmp_path: Path) -> Path:
+    src = _ensure_cron_sample()
+    dst = tmp_path / "scheduler.py"
+    shutil.copy2(src, dst)
+    return dst
+
+
 def _patcher(path: Path) -> Patcher:
     return Patcher(run_path=path)
+
+
+def _cron_patcher(path: Path) -> CronPatcher:
+    return CronPatcher(cron_path=path)
 
 
 class TestVerify:
@@ -147,7 +187,7 @@ class TestApplyRemove:
         patcher = _patcher(run_copy)
         patcher.apply()
         begin, end = next(pair for pair in MARKERS if "BACKGROUND_REVIEW" in pair[0])
-        content = patcher._remove_block(run_copy.read_text(encoding="utf-8"), begin, end)
+        content = _remove_block(run_copy.read_text(encoding="utf-8"), begin, end)
         run_copy.write_text(content, encoding="utf-8")
 
         patcher.apply()
@@ -204,3 +244,119 @@ class TestBackupRestore:
         patcher = _patcher(run_copy)
         with pytest.raises(PatcherError, match="No backup found"):
             patcher.restore()
+
+
+# --- CronPatcher ---
+
+
+class TestCronVerify:
+    def test_verify_passes(self, scheduler_copy: Path) -> None:
+        _cron_patcher(scheduler_copy).verify_target()
+
+    def test_verify_fails_missing_delivered_false(self, tmp_path: Path) -> None:
+        p = tmp_path / "scheduler.py"
+        p.write_text("cleaned_delivery_content = ''\n")
+        with pytest.raises(PatcherError, match="delivered = False"):
+            _cron_patcher(p).verify_target()
+
+    def test_verify_fails_missing_cleaned_content(self, tmp_path: Path) -> None:
+        p = tmp_path / "scheduler.py"
+        p.write_text("    delivered = False\n")
+        with pytest.raises(PatcherError, match="cleaned_delivery_content"):
+            _cron_patcher(p).verify_target()
+
+
+class TestCronApplyRemove:
+    def test_apply_injects_markers(self, scheduler_copy: Path) -> None:
+        cp = _cron_patcher(scheduler_copy)
+        cp.apply()
+        content = scheduler_copy.read_text(encoding="utf-8")
+        assert MK_CRON_DELIVER in content
+        assert MK_CRON_DELIVER_END in content
+
+    def test_apply_produces_valid_python(self, scheduler_copy: Path) -> None:
+        cp = _cron_patcher(scheduler_copy)
+        cp.apply()
+        content = scheduler_copy.read_text(encoding="utf-8")
+        compile(content, str(scheduler_copy), "exec")
+
+    def test_apply_idempotent(self, scheduler_copy: Path) -> None:
+        cp = _cron_patcher(scheduler_copy)
+        cp.apply()
+        first = scheduler_copy.read_text(encoding="utf-8")
+        cp.apply()
+        assert scheduler_copy.read_text(encoding="utf-8") == first
+
+    def test_remove_restores_original(self, scheduler_copy: Path) -> None:
+        cp = _cron_patcher(scheduler_copy)
+        original = scheduler_copy.read_text(encoding="utf-8")
+        cp.apply()
+        cp.remove()
+        assert scheduler_copy.read_text(encoding="utf-8") == original
+
+    def test_remove_on_unpatched_is_noop(self, scheduler_copy: Path) -> None:
+        cp = _cron_patcher(scheduler_copy)
+        original = scheduler_copy.read_text(encoding="utf-8")
+        cp.remove()
+        assert scheduler_copy.read_text(encoding="utf-8") == original
+
+    def test_injected_hook_references_on_cron_deliver(self, scheduler_copy: Path) -> None:
+        cp = _cron_patcher(scheduler_copy)
+        cp.apply()
+        content = scheduler_copy.read_text(encoding="utf-8")
+        assert "on_cron_deliver" in content
+        assert "platform_name.lower()" in content
+        assert "delivered = True" in content
+
+
+class TestCronBackupRestore:
+    def test_backup_created_on_apply(self, scheduler_copy: Path) -> None:
+        cp = _cron_patcher(scheduler_copy)
+        cp.apply()
+        backup = scheduler_copy.with_suffix(scheduler_copy.suffix + ".hermes_lark.bak")
+        assert backup.exists()
+
+    def test_restore_recovers_original(self, scheduler_copy: Path) -> None:
+        cp = _cron_patcher(scheduler_copy)
+        original = scheduler_copy.read_text(encoding="utf-8")
+        cp.apply()
+        cp.restore()
+        assert scheduler_copy.read_text(encoding="utf-8") == original
+
+    def test_restore_fails_without_backup(self, scheduler_copy: Path) -> None:
+        cp = _cron_patcher(scheduler_copy)
+        with pytest.raises(PatcherError, match="No backup found"):
+            cp.restore()
+
+
+class TestOnCronDeliverHook:
+    def test_returns_false_when_disabled(self) -> None:
+        from hermes_lark_streaming.patch import on_cron_deliver
+
+        with patch("hermes_lark_streaming.patch.get_controller") as mock_get:
+            ctrl = MagicMock()
+            ctrl.enabled = False
+            mock_get.return_value = ctrl
+            assert on_cron_deliver(chat_id="c1", content="text", loop=MagicMock()) is False
+
+    def test_returns_false_when_no_loop(self) -> None:
+        from hermes_lark_streaming.patch import on_cron_deliver
+
+        with patch("hermes_lark_streaming.patch.get_controller") as mock_get:
+            ctrl = MagicMock()
+            ctrl.enabled = True
+            mock_get.return_value = ctrl
+            assert on_cron_deliver(chat_id="c1", content="text", loop=None) is False
+
+    def test_delegates_to_controller(self) -> None:
+        from hermes_lark_streaming.patch import on_cron_deliver
+
+        loop = MagicMock()
+        with patch("hermes_lark_streaming.patch.get_controller") as mock_get:
+            ctrl = MagicMock()
+            ctrl.enabled = True
+            ctrl.on_cron_deliver.return_value = True
+            mock_get.return_value = ctrl
+            result = on_cron_deliver(chat_id="c1", content="hello", loop=loop)
+            assert result is True
+            ctrl.on_cron_deliver.assert_called_once_with(chat_id="c1", content="hello", loop=loop)


### PR DESCRIPTION
## Summary
- Inject CRON_DELIVER hook into `cron/scheduler.py` to intercept feishu/lark cron targets and send CardKit v2.0 static cards instead of plain text
- `CronPatcher` class in `patcher.py` mirrors existing `Patcher` pattern: verify/apply/remove/restore with backup
- CLI `install`/`uninstall`/`status`/`verify`/`restore` handle both gateway and cron targets
- CI `hermes-check` workflow now verifies compatibility with both `run.py` and `scheduler.py`

Closes #15.

## Files changed
- **patcher.py**: `_cron_deliver_hook`, `_remove_block` (module-level), `CronPatcher` class
- **patch.py**: `on_cron_deliver` hook (manual try/except, no `_safe_hook` — cron has no `message_id`)
- **controller.py**: `on_cron_deliver` sync entry point using `run_coroutine_threadsafe`
- **controller_mixin.py**: `_do_cron_deliver` async impl
- **cardkit.py**: `build_cron_card` — minimal schema 2.0 markdown card
- **feishu.py**: `send_card_to_chat` via `CreateMessageRequest`
- **__main__.py**: CLI integration for both patchers
- **tests**: 23 new test cases across test_patcher/test_cardkit/test_controller

## Test plan
- [x] ruff + mypy pass
- [x] 361 tests pass
- [x] `verify` confirms both targets compatible
- [x] `install` / `status` / `uninstall` cycle tested locally
- [x] Cron delivery end-to-end test (needs Hermes cron tick with feishu creds)