### PR TITLE
fix: defer background review until card completion

### DIFF
--- a/hermes_lark_streaming/__main__.py
+++ b/hermes_lark_streaming/__main__.py
@@ -59,7 +59,7 @@ def _cmd_install() -> int:
     if patcher is None:
         return 1
 
-    if patcher.is_patched():
+    if patcher.is_fully_patched():
         print("Already patched.")
         return 0
 

--- a/hermes_lark_streaming/controller.py
+++ b/hermes_lark_streaming/controller.py
@@ -13,8 +13,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections.abc import Coroutine
+from collections.abc import Callable, Coroutine
 from concurrent.futures import Future as ConcurrentFuture
+from threading import Lock
 from typing import TYPE_CHECKING, Any
 
 from .config import Config
@@ -51,6 +52,9 @@ class CardSession:
         "card_msg_id",
         "chat_id",
         "created_at",
+        "deferred_background_review_closed",
+        "deferred_background_review_lock",
+        "deferred_background_reviews",
         "flush",
         "footer",
         "guard",
@@ -95,6 +99,9 @@ class CardSession:
         self._loop = loop
         self.last_tool_use_update = 0.0
         self.created_at = time.time()
+        self.deferred_background_review_closed = False
+        self.deferred_background_reviews: list[tuple[str, Callable[[str], Any]]] = []
+        self.deferred_background_review_lock = Lock()
 
         self.guard = UnavailableGuard(
             reply_to_message_id=message_id,
@@ -438,6 +445,40 @@ class StreamCardController(ControllerMixin, LinearControllerMixin):
 
         self._complete_session(session)
         return True
+
+    def defer_background_review(
+        self,
+        *,
+        message_id: str,
+        text: str,
+        sender: Callable[[str], Any],
+    ) -> bool:
+        """暂存 Hermes background review 通知，等卡片收尾后再发送."""
+        if not self.enabled or not text or not callable(sender):
+            return False
+        session = self._get_active_session(message_id)
+        if session is None:
+            return False
+        with session.deferred_background_review_lock:
+            if session.deferred_background_review_closed:
+                return False
+            session.deferred_background_reviews.append((text, sender))
+        return True
+
+    def _flush_deferred_background_reviews(self, session: CardSession) -> None:
+        lock = getattr(session, "deferred_background_review_lock", None)
+        reviews = getattr(session, "deferred_background_reviews", None)
+        if lock is None or reviews is None:
+            return
+        with lock:
+            session.deferred_background_review_closed = True
+            pending = list(reviews)
+            reviews.clear()
+        for text, sender in pending:
+            try:
+                sender(text)
+            except Exception:
+                _logger.debug("background review sender failed", exc_info=True)
 
     def _schedule_card_update(self, session: CardSession) -> None:
         if session.state == IDLE or session.state in _TERMINAL:

--- a/hermes_lark_streaming/controller_linear_mixin.py
+++ b/hermes_lark_streaming/controller_linear_mixin.py
@@ -59,6 +59,7 @@ class LinearControllerMixin:
     _ensure_init: Callable[..., Coroutine[Any, Any, None]]
     _schedule_card_update: Callable[[CardSession], None]
     _cleanup: Callable[[str], None]
+    _flush_deferred_background_reviews: Callable[[CardSession], None]
     _do_complete_inner: Callable[..., Coroutine[Any, Any, bool]]
 
     def _schedule_linear_flush(self, session: CardSession) -> None:
@@ -382,6 +383,7 @@ class LinearControllerMixin:
         try:
             return await self._do_linear_complete_inner(session)
         finally:
+            self._flush_deferred_background_reviews(session)
             self._cleanup(session.message_id)
 
     async def _do_linear_complete_inner(self, session: CardSession) -> bool:

--- a/hermes_lark_streaming/controller_mixin.py
+++ b/hermes_lark_streaming/controller_mixin.py
@@ -57,6 +57,7 @@ class ControllerMixin:
     _ensure_init: Callable[[], Coroutine[Any, Any, None]]
     _schedule_card_update: Callable[[CardSession], None]
     _cleanup: Callable[[str], None]
+    _flush_deferred_background_reviews: Callable[[CardSession], None]
 
     async def _do_create_card(self, session: CardSession) -> None:
         if session.state != IDLE:
@@ -270,6 +271,7 @@ class ControllerMixin:
         try:
             return await self._do_complete_inner(session)
         finally:
+            self._flush_deferred_background_reviews(session)
             self._cleanup(session.message_id)
 
     async def _do_complete_inner(self, session: CardSession) -> bool:

--- a/hermes_lark_streaming/patch.py
+++ b/hermes_lark_streaming/patch.py
@@ -1,6 +1,6 @@
 """AST Patch 注入的 Hook 函数.
 
-这些函数从 gateway/run.py 的 8 个注入点被调用.
+这些函数从 gateway/run.py 的注入点被调用.
 它们只做一件事：检查配置 → 调用 controller.
 """
 
@@ -109,9 +109,22 @@ def on_reasoning_delta(*, ctrl: Any, message_id: str, text: str) -> bool:
     return True
 
 
+@_safe_hook(default_return=False, log_level="debug")
+def on_background_review_message(
+    *,
+    ctrl: Any,
+    message_id: str,
+    text: str,
+    sender: Callable[[str], Any],
+) -> bool:
+    """[注入点 7] background_review_callback — background.review."""
+    deferred: bool = ctrl.defer_background_review(message_id=message_id, text=text, sender=sender)
+    return deferred
+
+
 @_safe_hook()
 def on_message_aborted(*, ctrl: Any, message_id: str) -> None:
-    """[注入点 7] stale return None 前 — message.aborted."""
+    """[注入点 8] stale return None 前 — message.aborted."""
     ctrl.on_aborted(message_id=message_id)
 
 
@@ -123,7 +136,7 @@ def on_message_interrupted(
     new_message_id: str,
     chat_id: str,
 ) -> None:
-    """[注入点 8] interrupt 发生 — message.interrupted."""
+    """[注入点 9] interrupt 发生 — message.interrupted."""
     ctrl.on_interrupted(
         old_message_id=message_id,
         new_message_id=new_message_id,

--- a/hermes_lark_streaming/patcher.py
+++ b/hermes_lark_streaming/patcher.py
@@ -1,4 +1,4 @@
-"""AST Patcher — 在 Hermes gateway/run.py 中注入 8 处 Hook 调用."""
+"""AST Patcher — 在 Hermes gateway/run.py 中注入 Hook 调用."""
 
 from __future__ import annotations
 
@@ -12,7 +12,17 @@ _logger = logging.getLogger("hermes_lark_streaming")
 
 PREFIX = "HERMES_LARK"
 
-_HOOK_NAMES = ["START", "COMPLETE", "TOOL", "ANSWER", "THINKING", "REASONING", "ABORT", "INTERRUPT"]
+_HOOK_NAMES = [
+    "START",
+    "COMPLETE",
+    "TOOL",
+    "ANSWER",
+    "THINKING",
+    "REASONING",
+    "BACKGROUND_REVIEW",
+    "ABORT",
+    "INTERRUPT",
+]
 MARKERS: list[tuple[str, str]] = [(f"# {PREFIX}_{n}_BEGIN", f"# {PREFIX}_{n}_END") for n in _HOOK_NAMES]
 
 MK_START, MK_START_END = MARKERS[0]
@@ -21,8 +31,9 @@ MK_TOOL, MK_TOOL_END = MARKERS[2]
 MK_ANSWER, MK_ANSWER_END = MARKERS[3]
 MK_THINKING, MK_THINKING_END = MARKERS[4]
 MK_REASONING, MK_REASONING_END = MARKERS[5]
-MK_ABORT, MK_ABORT_END = MARKERS[6]
-MK_INTERRUPT, MK_INTERRUPT_END = MARKERS[7]
+MK_BACKGROUND_REVIEW, MK_BACKGROUND_REVIEW_END = MARKERS[6]
+MK_ABORT, MK_ABORT_END = MARKERS[7]
+MK_INTERRUPT, MK_INTERRUPT_END = MARKERS[8]
 
 _BACKUP_SUFFIX = ".hermes_lark.bak"
 
@@ -151,6 +162,30 @@ def _reasoning_hook(indent: str) -> str:
     )
 
 
+def _background_review_hook(indent: str) -> str:
+    return _make_hook(
+        indent,
+        MK_BACKGROUND_REVIEW,
+        MK_BACKGROUND_REVIEW_END,
+        [
+            "try:",
+            "    from hermes_lark_streaming.patch import on_background_review_message",
+            "    _lark_bg_review_sender = agent.background_review_callback",
+            "    def _lark_bg_review_callback(message):",
+            "        _lark_bg_review_deferred = on_background_review_message(",
+            "            message_id=event_message_id,",
+            "            text=message,",
+            "            sender=_lark_bg_review_sender,",
+            "        )",
+            "        if not _lark_bg_review_deferred:",
+            "            _lark_bg_review_sender(message)",
+            "    agent.background_review_callback = _lark_bg_review_callback",
+            "except Exception:",
+            "    pass",
+        ],
+    )
+
+
 def _abort_hook(indent: str) -> str:
     return _make_hook(
         indent,
@@ -203,6 +238,10 @@ class Patcher:
     def is_patched(self) -> bool:
         return MK_START in self.run_path.read_text(encoding="utf-8")
 
+    def is_fully_patched(self) -> bool:
+        content = self.run_path.read_text(encoding="utf-8")
+        return all(begin in content and end in content for begin, end in self.MARKERS)
+
     def verify_target(self) -> None:
         content = self.run_path.read_text(encoding="utf-8")
         tree = ast.parse(content)
@@ -249,13 +288,22 @@ class Patcher:
         if "agent.reasoning_config = reasoning_config" not in content:
             raise PatcherError("Cannot find reasoning_config anchor in run.py — Hermes version may be incompatible")
 
+        if "agent.background_review_callback = _bg_review_send" not in content:
+            raise PatcherError(
+                "Cannot find background_review_callback anchor in run.py — Hermes version may be incompatible"
+            )
+
     def apply(self) -> None:
-        if self.is_patched():
+        if self.is_fully_patched():
             return
 
         self.verify_target()
-        self._backup()
         content = self.run_path.read_text(encoding="utf-8")
+        if self.is_patched():
+            for begin, end in self.MARKERS:
+                content = self._remove_block(content, begin, end)
+        else:
+            self._backup()
         content = self._inject_all(content)
         self.run_path.write_text(content, encoding="utf-8")
 
@@ -291,6 +339,7 @@ class Patcher:
             ("answer", "answer", _find_func_body(tree, lines, "_stream_delta_cb")),
             ("thinking", "thinking", _find_func_body(tree, lines, "_interim_assistant_cb")),
             ("reasoning", "reasoning", _find_reasoning_site(tree, lines)),
+            ("background_review", "background_review", _find_background_review_site(tree, lines)),
         ]
 
         sites: list[tuple[int, str, str]] = []
@@ -310,6 +359,7 @@ class Patcher:
             "answer": _answer_hook,
             "thinking": _thinking_hook,
             "reasoning": _reasoning_hook,
+            "background_review": _background_review_hook,
         }
         for idx, indent, fn_name in sites:
             hook = _HOOK_FNS[fn_name](indent)
@@ -399,6 +449,13 @@ def _find_interrupt_site(tree: ast.Module, lines: list[str]) -> tuple[int, str] 
 def _find_reasoning_site(tree: ast.Module, lines: list[str]) -> tuple[int, str] | None:
     for i, line in enumerate(lines):
         if line.strip() == "agent.reasoning_config = reasoning_config":
+            return i + 1, _safe_indent(lines, i)
+    return None
+
+
+def _find_background_review_site(tree: ast.Module, lines: list[str]) -> tuple[int, str] | None:
+    for i, line in enumerate(lines):
+        if line.strip() == "agent.background_review_callback = _bg_review_send":
             return i + 1, _safe_indent(lines, i)
     return None
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -66,6 +66,44 @@ def test_prune_stale_sessions_ignores_none_key_and_prunes_valid_key() -> None:
     assert valid_stale_session.flush.completed
 
 
+@pytest.mark.asyncio
+async def test_background_review_deferred_until_complete() -> None:
+    ctrl = _setup_ctrl()
+    session = _make_session("msg_bg")
+    session.state = STREAMING
+    session.card_msg_id = "card_msg"
+    ctrl._sessions["msg_bg"] = session
+    sent: list[str] = []
+
+    assert ctrl.defer_background_review(message_id="msg_bg", text="review", sender=sent.append)
+    assert sent == []
+
+    await ctrl._do_complete(session)
+
+    assert sent == ["review"]
+    assert "msg_bg" not in ctrl._sessions
+
+
+def test_background_review_without_active_session_not_deferred() -> None:
+    ctrl = _setup_ctrl()
+    sent: list[str] = []
+
+    assert not ctrl.defer_background_review(message_id="missing", text="review", sender=sent.append)
+    assert sent == []
+
+
+def test_background_review_after_flush_not_deferred() -> None:
+    ctrl = _setup_ctrl()
+    session = _make_session("msg_bg")
+    ctrl._sessions["msg_bg"] = session
+    sent: list[str] = []
+
+    ctrl._flush_deferred_background_reviews(session)
+
+    assert not ctrl.defer_background_review(message_id="msg_bg", text="review", sender=sent.append)
+    assert sent == []
+
+
 # ── 辅助函数 ──
 
 

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -122,6 +122,19 @@ class TestApplyRemove:
         after_second = run_copy.read_text(encoding="utf-8")
         assert after_first == after_second
 
+    def test_apply_upgrades_partial_patch(self, run_copy: Path) -> None:
+        patcher = _patcher(run_copy)
+        patcher.apply()
+        begin, end = next(pair for pair in MARKERS if "BACKGROUND_REVIEW" in pair[0])
+        content = patcher._remove_block(run_copy.read_text(encoding="utf-8"), begin, end)
+        run_copy.write_text(content, encoding="utf-8")
+
+        patcher.apply()
+        upgraded = run_copy.read_text(encoding="utf-8")
+
+        assert upgraded.count(begin) == 1
+        assert upgraded.count(end) == 1
+
     def test_remove_restores_markers_free(self, run_copy: Path) -> None:
         patcher = _patcher(run_copy)
         original = run_copy.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- Add a background review hook around Hermes agent.background_review_callback while preserving the original sender fallback
- Defer self-improvement review messages when the matching Feishu/Lark streaming card session is still active
- Flush deferred review messages after both linear and non-linear card completion, with a closed guard to avoid late-race drops
- Upgrade partially patched installs by checking for the full marker set before skipping install

## Test plan

- [x] ruff pass
- [x] mypy pass
- [x] 342 tests pass
- [x] Patcher verify passes against Hermes 0.11.0, 0.12.0, 0.13.0, 0.14.0, and main