### PR TITLE
feat: linear multi-card split with tool step boundary support

### DIFF
--- a/hermes_lark_streaming/controller.py
+++ b/hermes_lark_streaming/controller.py
@@ -55,6 +55,7 @@ class CardSession:
         "deferred_background_review_closed",
         "deferred_background_review_lock",
         "deferred_background_reviews",
+        "element_count",
         "flush",
         "footer",
         "guard",
@@ -68,6 +69,8 @@ class CardSession:
         "reasoning_start",
         "reasoning_text",
         "sequence",
+        "split_disabled",
+        "split_index",
         "state",
         "text",
         "tool_panel_added",
@@ -113,6 +116,9 @@ class CardSession:
         self.tool_panel_added = False
         self.linear = False
         self.linear_state: LinearState | None = None
+        self.element_count: int = 0
+        self.split_disabled = False
+        self.split_index: int = 0
 
 
 class StreamCardController(ControllerMixin, LinearControllerMixin):

--- a/hermes_lark_streaming/controller_linear_mixin.py
+++ b/hermes_lark_streaming/controller_linear_mixin.py
@@ -1,4 +1,4 @@
-"""线性单卡模式的异步 API 编排 — 创建、刷新、完成."""
+"""线性单卡模式的异步 API 编排 — 创建、刷新、拆卡、完成."""
 
 from __future__ import annotations
 
@@ -50,6 +50,40 @@ if TYPE_CHECKING:
 
 _logger = logging.getLogger("hermes_lark_streaming")
 
+_ELEMENT_THRESHOLD = 180  # 拆卡阈值（飞书硬上限 200，预留 20 给 footer + 波动）
+_FOOTER_RESERVE = 2  # footer 元素预留（hr + markdown）
+
+
+def _estimate_segment_elements(seg: Segment, all_steps: list[dict[str, Any]]) -> int:
+    """估算单个 segment 新增的卡片元素数."""
+    if seg.type == "reasoning":
+        return 4  # collapsible_panel + plain_text + standard_icon + markdown
+    elif seg.type == "answer":
+        return 1
+    elif seg.type == "tool":
+        return _estimate_tool_elements(
+            seg.tool_offset,
+            _tool_segment_end(seg, all_steps),
+            all_steps,
+        )
+    return 0
+
+
+def _tool_segment_end(seg: Segment, all_steps: list[dict[str, Any]]) -> int:
+    return seg.tool_end_offset if seg.tool_end_offset else len(all_steps)
+
+
+def _estimate_tool_elements(start: int, end: int, all_steps: list[dict[str, Any]]) -> int:
+    """估算 tool panel 在 [start, end) step 区间内的元素数."""
+    steps = all_steps[start:end]
+    count = 3  # panel/header 基础元素
+    for step in steps:
+        count += 3  # title: div + standard_icon + lark_md
+        if step.get("detail"):
+            count += 2  # detail: div + plain_text
+        if step.get("result_block") or step.get("error_block"):
+            count += 2  # output: div + lark_md
+    return count
 
 class LinearControllerMixin:
     """线性模式专用方法 — 由 StreamCardController 继承."""
@@ -111,6 +145,7 @@ class LinearControllerMixin:
                 session.card_id = card_id
                 session.card_msg_id = card_msg_id
                 session.use_cardkit = True
+                session.element_count = 1  # loading element
                 session.flush.set_throttle(CARDKIT_MS)
             except FeishuAPIError:
                 _logger.info("linear CardKit create failed, falling back to non-linear")
@@ -151,7 +186,7 @@ class LinearControllerMixin:
             session.state = FAILED
 
     async def _do_linear_flush(self, session: CardSession) -> None:
-        """线性模式幂等 flush：按 segment 顺序处理结构性变更，再刷脏文本."""
+        """线性模式幂等 flush：按 segment 顺序处理结构性变更，超阈值时拆卡."""
         if session.state in _TERMINAL or not session.card_id:
             return
         linear_state = session.linear_state
@@ -165,50 +200,88 @@ class LinearControllerMixin:
         # ── 步骤 1: batch_update — 按 segment 顺序处理结构性变更 ──
         actions: list[dict[str, Any]] = []
         new_el_ids: set[str] = set()
+        new_el_estimates: dict[str, int] = {}
         updated_tool_segs: list[Segment] = []
+        new_el_total = 0
 
-        for seg in segments:
+        for i, seg in enumerate(segments):
+            if i < session.split_index:
+                continue
+
             if not seg.created:
-                new_el_ids.add(seg.el_id)
+                estimated = _estimate_segment_elements(seg, all_steps)
+                if (
+                    seg.type == "tool"
+                    and session.element_count + new_el_total + estimated + _FOOTER_RESERVE > _ELEMENT_THRESHOLD
+                    and not session.split_disabled
+                ):
+                    split_offset = self._find_tool_split_offset(
+                        session.element_count + new_el_total,
+                        seg,
+                        all_steps,
+                    )
+                    if split_offset is not None:
+                        linear_state.split_tool_segment(i, split_offset)
+                        estimated = _estimate_segment_elements(seg, all_steps)
+                if (
+                    session.element_count + new_el_total + estimated + _FOOTER_RESERVE > _ELEMENT_THRESHOLD
+                    and session.element_count + new_el_total > 1
+                    and not session.split_disabled
+                ):
+                    split_ok = await self._do_linear_split(
+                        session, i, actions, new_el_ids, new_el_estimates, updated_tool_segs,
+                    )
+                    if not split_ok:
+                        return
+                    actions = []
+                    new_el_ids = set()
+                    new_el_estimates = {}
+                    updated_tool_segs = []
+                    new_el_total = 0
+
                 if seg.type == "reasoning":
-                    panel = _build_reasoning_panel(
+                    el = _build_reasoning_panel(
                         " ",
                         seg.elapsed_ms,
                         expanded=True,
                         element_id=seg.el_id,
                         text_element_id=seg.text_el_id,
                     )
-                    actions.append({
-                        "action": "add_elements",
-                        "params": {
-                            "type": "insert_before",
-                            "target_element_id": _LOADING_ELEMENT_ID,
-                            "elements": [panel],
-                        },
-                    })
                 elif seg.type == "answer":
                     el = _streaming_element(element_id=seg.el_id)
-                    actions.append({
-                        "action": "add_elements",
-                        "params": {
-                            "type": "insert_before",
-                            "target_element_id": _LOADING_ELEMENT_ID,
-                            "elements": [el],
-                        },
-                    })
                 elif seg.type == "tool":
                     start = seg.tool_offset
                     end = seg.tool_end_offset if seg.tool_end_offset else len(all_steps)
-                    panel = _build_tool_panel(all_steps[start:end], element_id=seg.el_id)
-                    actions.append({
-                        "action": "add_elements",
-                        "params": {
-                            "type": "insert_before",
-                            "target_element_id": _LOADING_ELEMENT_ID,
-                            "elements": [panel],
-                        },
-                    })
+                    el = _build_tool_panel(all_steps[start:end], element_id=seg.el_id)
                     updated_tool_segs.append(seg)
+                new_el_ids.add(seg.el_id)
+                new_el_estimates[seg.el_id] = estimated
+                new_el_total += estimated
+                actions.append({
+                    "action": "add_elements",
+                    "params": {
+                        "type": "insert_before",
+                        "target_element_id": _LOADING_ELEMENT_ID,
+                        "elements": [el],
+                    },
+                })
+                if (
+                    seg.type == "tool"
+                    and i + 1 < len(segments)
+                    and segments[i + 1].type == "tool"
+                    and segments[i + 1].tool_offset == seg.tool_end_offset
+                    and not session.split_disabled
+                ):
+                    split_ok = await self._do_linear_split(
+                        session, i + 1, actions, new_el_ids, new_el_estimates, updated_tool_segs,
+                    )
+                    if not split_ok:
+                        return
+                    actions = []
+                    new_el_ids = set()
+                    new_el_estimates = {}
+                    updated_tool_segs = []
+                    new_el_total = 0
             elif seg.type == "reasoning" and seg.elapsed_ms > 0 and not seg.reasoning_finalized:
                 _logger.info(
                     "linear reasoning finalize: msg=%s el=%s elapsed=%.0fms seq=%d",
@@ -242,6 +315,27 @@ class LinearControllerMixin:
                     start, end = seg.tool_offset, seg.tool_end_offset
                 else:
                     start, end = seg.tool_offset, len(all_steps)
+                rollover = await self._maybe_rollover_tool_segment(
+                    session=session,
+                    linear_state=linear_state,
+                    index=i,
+                    seg=seg,
+                    all_steps=all_steps,
+                    actions=actions,
+                    new_el_ids=new_el_ids,
+                    new_el_estimates=new_el_estimates,
+                    updated_tool_segs=updated_tool_segs,
+                )
+                if rollover == "failed":
+                    return
+                if rollover == "split":
+                    actions = []
+                    new_el_ids = set()
+                    new_el_estimates = {}
+                    updated_tool_segs = []
+                    new_el_total = 0
+                    continue
+                estimate = _estimate_tool_elements(start, end, all_steps)
                 panel = _build_tool_panel(all_steps[start:end])
                 actions.append({
                     "action": "partial_update_element",
@@ -254,50 +348,15 @@ class LinearControllerMixin:
                     },
                 })
                 updated_tool_segs.append(seg)
+                new_el_estimates[seg.el_id] = estimate
 
-        if actions:
-            session.sequence += 1
-            _logger.info(
-                "linear flush: msg=%s seq=%d actions=%d",
-                session.message_id[:12],
-                session.sequence,
-                len(actions),
-            )
-            pre_flush_reasoning_elapsed = {
-                seg.el_id: seg.elapsed_ms for seg in segments if seg.type == "reasoning"
-            }
-            pre_flush_tool_offsets = {
-                seg.el_id: seg.tool_end_offset for seg in updated_tool_segs
-            }
-            try:
-                await self._client.cardkit_batch_update(
-                    session.card_id,
-                    actions,
-                    sequence=session.sequence,
-                )
-                for seg in segments:
-                    if seg.el_id in new_el_ids:
-                        seg.created = True
-                for seg in segments:
-                    if seg.type == "reasoning" and pre_flush_reasoning_elapsed.get(seg.el_id, 0) > 0:
-                        seg.reasoning_finalized = True
-                if new_el_ids:
-                    for seg in segments:
-                        if seg.el_id in new_el_ids or not seg.created:
-                            continue
-                        if seg.type in ("reasoning", "answer") and seg.text:
-                            seg.dirty = True
-                for seg in updated_tool_segs:
-                    offset_ok = pre_flush_tool_offsets.get(seg.el_id, -1) == seg.tool_end_offset
-                    if seg.created and offset_ok and seg.tool_end_offset > 0:
-                        seg.dirty = False
-            except FeishuAPIError as e:
-                _logger.warning("linear batch update failed: %s", e, exc_info=True)
-                self._handle_linear_flush_error(session, e)
-                return
+        if actions and not await self._do_linear_batch_update(
+            session, segments, actions, new_el_ids, new_el_estimates, updated_tool_segs,
+        ):
+            return
 
         # ── 步骤 2: stream_element 刷脏文本 ──
-        for seg in segments:
+        for seg in segments[session.split_index:]:
             if not seg.created or not seg.dirty:
                 continue
             try:
@@ -339,7 +398,221 @@ class LinearControllerMixin:
             except Exception as e:
                 _logger.debug("linear stream failed: %s el=%s", e, seg.el_id, exc_info=True)
 
-    def _handle_linear_flush_error(self, session: CardSession, e: FeishuAPIError) -> None:
+    async def _do_linear_batch_update(
+        self,
+        session: CardSession,
+        segments: list[Segment],
+        actions: list[dict[str, Any]],
+        new_el_ids: set[str],
+        new_el_estimates: dict[str, int],
+        updated_tool_segs: list[Segment],
+    ) -> bool:
+        """执行 batch_update 并处理快照/标记。返回 False 表示失败."""
+        assert self._client is not None
+        assert session.card_id is not None
+        session.sequence += 1
+        _logger.info(
+            "linear flush: msg=%s seq=%d actions=%d",
+            session.message_id[:12],
+            session.sequence,
+            len(actions),
+        )
+        pre_flush_reasoning_elapsed = {
+            seg.el_id: seg.elapsed_ms for seg in segments if seg.type == "reasoning"
+        }
+        pre_flush_tool_offsets = {
+            seg.el_id: seg.tool_end_offset for seg in updated_tool_segs
+        }
+        try:
+            await self._client.cardkit_batch_update(
+                session.card_id,
+                actions,
+                sequence=session.sequence,
+            )
+            for seg in segments:
+                if seg.el_id in new_el_ids:
+                    seg.created = True
+                    estimate = new_el_estimates.get(seg.el_id, 0)
+                    seg.element_estimate = estimate
+                    session.element_count += estimate
+            for seg in segments:
+                if seg.type == "reasoning" and pre_flush_reasoning_elapsed.get(seg.el_id, 0) > 0:
+                    seg.reasoning_finalized = True
+            if new_el_ids:
+                for seg in segments:
+                    if seg.el_id in new_el_ids or not seg.created:
+                        continue
+                    if seg.type in ("reasoning", "answer") and seg.text:
+                        seg.dirty = True
+            for seg in updated_tool_segs:
+                offset_ok = pre_flush_tool_offsets.get(seg.el_id, -1) == seg.tool_end_offset
+                if seg.el_id in new_el_estimates:
+                    estimate = new_el_estimates[seg.el_id]
+                    session.element_count += estimate - seg.element_estimate
+                    seg.element_estimate = estimate
+                if seg.created and offset_ok and seg.tool_end_offset > 0:
+                    seg.dirty = False
+        except FeishuAPIError as e:
+            _logger.warning("linear batch update failed: %s", e, exc_info=True)
+            self._handle_linear_flush_error(e)
+            return False
+        return True
+
+    def _find_tool_split_offset(
+        self,
+        base_count: int,
+        seg: Segment,
+        all_steps: list[dict[str, Any]],
+    ) -> int | None:
+        """寻找 tool step 拆分点，让当前卡保留尽可能多的 steps."""
+        start = seg.tool_offset
+        end = _tool_segment_end(seg, all_steps)
+        if end - start <= 1:
+            return None
+        for split_offset in range(end - 1, start, -1):
+            estimate = _estimate_tool_elements(start, split_offset, all_steps)
+            if base_count + estimate + _FOOTER_RESERVE <= _ELEMENT_THRESHOLD:
+                return split_offset
+        return None
+
+    async def _maybe_rollover_tool_segment(
+        self,
+        *,
+        session: CardSession,
+        linear_state: LinearState,
+        index: int,
+        seg: Segment,
+        all_steps: list[dict[str, Any]],
+        actions: list[dict[str, Any]],
+        new_el_ids: set[str],
+        new_el_estimates: dict[str, int],
+        updated_tool_segs: list[Segment],
+    ) -> str | None:
+        """按 tool step 边界拆分过大的 dirty tool segment."""
+        start = seg.tool_offset
+        end = _tool_segment_end(seg, all_steps)
+        estimate = _estimate_tool_elements(start, end, all_steps)
+        delta = estimate - seg.element_estimate
+        if (
+            delta <= 0
+            or session.element_count + delta + _FOOTER_RESERVE <= _ELEMENT_THRESHOLD
+            or session.split_disabled
+        ):
+            return None
+
+        split_offset = self._find_tool_split_offset(
+            session.element_count - seg.element_estimate,
+            seg,
+            all_steps,
+        )
+        if split_offset is None:
+            return None
+
+        old_estimate = _estimate_tool_elements(seg.tool_offset, split_offset, all_steps)
+        panel = _build_tool_panel(all_steps[seg.tool_offset:split_offset])
+        actions.append({
+            "action": "partial_update_element",
+            "params": {
+                "element_id": seg.el_id,
+                "partial_element": {
+                    "elements": panel["elements"],
+                    "header": panel["header"],
+                },
+            },
+        })
+        updated_tool_segs.append(seg)
+        new_el_estimates[seg.el_id] = old_estimate
+        linear_state.split_tool_segment(index, split_offset)
+        split_ok = await self._do_linear_split(
+            session, index + 1, actions, new_el_ids, new_el_estimates, updated_tool_segs,
+        )
+        if not split_ok:
+            return "failed"
+        return "split"
+
+    async def _do_linear_split(
+        self,
+        session: CardSession,
+        split_idx: int,
+        actions: list[dict[str, Any]],
+        new_el_ids: set[str],
+        new_el_estimates: dict[str, int],
+        updated_tool_segs: list[Segment],
+    ) -> bool:
+        """拆卡：先 flush pending actions，封旧卡，创建新卡。返回 False 表示失败需中断 flush."""
+        assert self._client is not None
+        old_card_id = session.card_id
+        assert old_card_id is not None
+        linear_state = session.linear_state
+        assert linear_state is not None
+        segments = linear_state.segments
+        all_steps = session.tool_use.build_display_steps()
+
+        if actions and not await self._do_linear_batch_update(
+            session, segments, actions, new_el_ids, new_el_estimates, updated_tool_segs,
+        ):
+            return False
+
+        seal_segments = [s for s in segments[:split_idx] if s.created]
+        if session.image_resolver:
+            for seg in seal_segments:
+                if seg.type == "answer" and seg.text:
+                    try:
+                        seg.text = await session.image_resolver.resolve_await(seg.text)
+                    except Exception:
+                        _logger.debug("linear seal image resolve failed: el=%s", seg.el_id, exc_info=True)
+
+        seal_card = build_linear_complete_card(
+            segments=seal_segments,
+            all_tool_steps=all_steps,
+            footer_fields=[],
+            footer_show_label=False,
+        )
+
+        try:
+            card = build_streaming_card_v2(
+                show_tool_use=False,
+                show_reasoning=False,
+                show_streaming_element=False,
+            )
+            new_card_id = await self._client.cardkit_create(card)
+            new_msg_id = await self._client.reply_card_by_id(session.message_id, new_card_id)
+        except Exception:
+            _logger.warning(
+                "linear split fallback: create next card failed, continue on current card",
+                exc_info=True,
+            )
+            # 拆卡失败时降级为继续写当前卡，并禁用后续拆卡重试以避免反复卡在同一边界。
+            session.split_disabled = True
+            return True
+
+        try:
+            session.sequence += 1
+            await self._client.cardkit_close_streaming(old_card_id, sequence=session.sequence)
+            session.sequence += 1
+            await self._client.cardkit_update(old_card_id, seal_card, sequence=session.sequence)
+        except Exception:
+            _logger.warning(
+                "linear seal failed for old card %s, continuing",
+                old_card_id[:12],
+                exc_info=True,
+            )
+
+        session.card_id = new_card_id
+        session.card_msg_id = new_msg_id
+        session.element_count = 1  # loading
+        session.sequence = 1
+        session.split_disabled = False
+        session.split_index = split_idx
+        _logger.info(
+            "linear split: msg=%s sealed=%d new_card=%s",
+            session.message_id[:12],
+            len(seal_segments),
+            new_card_id[:12],
+        )
+        return True
+
+    def _handle_linear_flush_error(self, e: FeishuAPIError) -> None:
         if e.code == CARDKIT_RATE_LIMITED:
             return
         if e.code == CARDKIT_STREAMING_CLOSED:
@@ -372,8 +645,12 @@ class LinearControllerMixin:
         if linear_state is not None:
             linear_state.finalize_segments(len(all_tool_steps))
 
+        active_segments = (
+            linear_state.segments[session.split_index:] if linear_state is not None else []
+        )
+
         if session.image_resolver:
-            for seg in (linear_state.segments if linear_state is not None else []):
+            for seg in active_segments:
                 if seg.type == "answer" and seg.text:
                     try:
                         seg.text = await session.image_resolver.resolve_await(seg.text)
@@ -381,7 +658,7 @@ class LinearControllerMixin:
                         _logger.debug("linear image resolve failed: el=%s", seg.el_id, exc_info=True)
 
         card = build_linear_complete_card(
-            segments=linear_state.segments if linear_state is not None else [],
+            segments=active_segments,
             all_tool_steps=all_tool_steps,
             footer_data=session.footer,
             is_error=is_error,

--- a/hermes_lark_streaming/linear.py
+++ b/hermes_lark_streaming/linear.py
@@ -13,6 +13,7 @@ class Segment:
         "dirty",
         "el_id",
         "elapsed_ms",
+        "element_estimate",
         "reasoning_finalized",
         "start_time",
         "text",
@@ -27,6 +28,7 @@ class Segment:
         self.el_id = el_id
         self.created = False
         self.dirty = True
+        self.element_estimate: int = 0
         self.text: str = ""
         self.text_el_id: str = ""
         self.tool_offset: int = 0
@@ -118,6 +120,24 @@ class LinearState:
                 seg.dirty = True
                 break
         self._new_tool(tool_step_count - 1)
+
+    def split_tool_segment(
+        self,
+        index: int,
+        split_tool_offset: int,
+    ) -> Segment:
+        """在 step 边界拆分一个 tool segment，返回承接后续 steps 的新 segment."""
+        seg = self.segments[index]
+        c = self._counter
+        self._counter += 1
+        new_seg = Segment("tool", f"tools_{c}")
+        new_seg.tool_offset = split_tool_offset
+        new_seg.tool_end_offset = seg.tool_end_offset
+        new_seg.start_time = seg.start_time
+        seg.tool_end_offset = split_tool_offset
+        seg.dirty = True
+        self.segments.insert(index + 1, new_seg)
+        return new_seg
 
     def finalize_segments(self, total_tool_count: int) -> None:
         """完成态调用：终结最后一个 tool segment + 补算最后一个 reasoning elapsed_ms."""

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from hermes_lark_streaming.controller import CardSession, StreamCardController
+from hermes_lark_streaming.controller_linear_mixin import _estimate_segment_elements
 from hermes_lark_streaming.controller_mixin import (
     COMPLETED,
     FAILED,
@@ -136,6 +137,39 @@ def _setup_ctrl(*, linear: bool = False) -> StreamCardController:
     ctrl._initialized = True
     ctrl._client = _mock_client()
     return ctrl
+
+
+def _capture_split_calls(
+    ctrl: StreamCardController,
+    *,
+    cards: list[str] | None = None,
+    messages: list[str] | None = None,
+    create_error: Exception | None = None,
+) -> list[tuple[str, str]]:
+    calls: list[tuple[str, str]] = []
+    client = ctrl._client
+    card_iter = iter(cards or ["card_next"])
+    message_iter = iter(messages or ["msg_next"])
+
+    client.cardkit_batch_update = AsyncMock(
+        side_effect=lambda card_id, *a, **k: calls.append(("batch", card_id))
+    )
+    if create_error is None:
+        client.cardkit_create = AsyncMock(
+            side_effect=lambda *a, **k: calls.append(("create", "")) or next(card_iter)
+        )
+    else:
+        client.cardkit_create = AsyncMock(side_effect=create_error)
+    client.reply_card_by_id = AsyncMock(
+        side_effect=lambda *a, **k: calls.append(("reply", "")) or next(message_iter)
+    )
+    client.cardkit_close_streaming = AsyncMock(
+        side_effect=lambda card_id, **k: calls.append(("close", card_id))
+    )
+    client.cardkit_update = AsyncMock(
+        side_effect=lambda card_id, *a, **k: calls.append(("seal", card_id))
+    )
+    return calls
 
 
 # ── Dispatch 测试 — 线性模式分流 ──
@@ -319,6 +353,237 @@ class TestDoLinearFlush:
         # step3: tool created
         tool_seg = session.linear_state.segments[2]
         assert tool_seg.created is True
+
+    @pytest.mark.asyncio
+    async def test_no_split_keeps_original_single_card_flow(self) -> None:
+        """低于阈值时仍是原来的单卡 flush：只 batch/stream 当前 card，不触发拆卡 API."""
+        ctrl = _setup_ctrl()
+        session = _make_session("msg_no_split", linear=True)
+        session.state = STREAMING
+        session.card_id = "card_no_split"
+        session.element_count = 1
+        session.linear_state.on_reasoning_delta("think")
+        session.linear_state.on_answer_delta("hello")
+        ctrl._sessions["msg_no_split"] = session
+
+        await ctrl._do_linear_flush(session)
+
+        assert session.split_index == 0
+        assert session.card_id == "card_no_split"
+        assert [s.created for s in session.linear_state.segments] == [True, True]
+        assert [s.dirty for s in session.linear_state.segments] == [False, False]
+        ctrl._client.cardkit_create.assert_not_called()
+        ctrl._client.reply_card_by_id.assert_not_called()
+        ctrl._client.cardkit_close_streaming.assert_not_called()
+        ctrl._client.cardkit_update.assert_not_called()
+        ctrl._client.cardkit_batch_update.assert_called_once()
+        assert ctrl._client.cardkit_stream_element.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_split_flushes_pending_actions_then_moves_to_next_card(self) -> None:
+        """超阈值时先把 pending segment 写入旧卡，再封旧卡并把后续 segment 写入新卡."""
+        ctrl = _setup_ctrl()
+        calls = _capture_split_calls(ctrl)
+
+        session = _make_session("msg_split", linear=True)
+        session.state = STREAMING
+        session.card_id = "card_old"
+        session.card_msg_id = "msg_old"
+        session.element_count = 174
+        session.linear_state.on_reasoning_delta("old")
+        session.linear_state.segments[0].created = True
+        session.linear_state.segments[0].dirty = False
+        session.linear_state.on_answer_delta("pending answer")
+        session.tool_use.record_start("read", "file")
+        session.linear_state.on_tool_event(1)
+        ctrl._sessions["msg_split"] = session
+
+        await ctrl._do_linear_flush(session)
+
+        assert calls == [
+            ("batch", "card_old"),
+            ("create", ""),
+            ("reply", ""),
+            ("close", "card_old"),
+            ("seal", "card_old"),
+            ("batch", "card_next"),
+        ]
+        assert session.card_id == "card_next"
+        assert session.card_msg_id == "msg_next"
+        assert session.split_index == 2
+        assert session.split_disabled is False
+        assert session.element_count > 1
+        assert [s.created for s in session.linear_state.segments] == [True, True, True]
+
+    @pytest.mark.asyncio
+    async def test_tool_growth_rolls_over_at_step_boundary(self) -> None:
+        """同一个 tool segment 增长超阈值时，在 step 边界拆到新卡继续更新."""
+        ctrl = _setup_ctrl()
+        calls = _capture_split_calls(
+            ctrl,
+            cards=["card_tool_next"],
+            messages=["msg_tool_next"],
+        )
+
+        session = _make_session("msg_tool_roll", linear=True)
+        session.state = STREAMING
+        session.card_id = "card_tool_old"
+        session.card_msg_id = "msg_tool_old"
+        session.tool_use.record_start("read", "file0")
+        session.linear_state.on_tool_event(1)
+        tool_seg = session.linear_state.segments[0]
+        tool_seg.created = True
+        tool_seg.element_estimate = _estimate_segment_elements(tool_seg, session.tool_use.build_display_steps())
+        session.element_count = 174
+
+        for idx in range(1, 4):
+            session.tool_use.record_start("read", f"file{idx}")
+        session.linear_state.on_tool_event(len(session.tool_use.build_display_steps()))
+        ctrl._sessions["msg_tool_roll"] = session
+
+        await ctrl._do_linear_flush(session)
+
+        assert calls == [
+            ("batch", "card_tool_old"),
+            ("create", ""),
+            ("reply", ""),
+            ("close", "card_tool_old"),
+            ("seal", "card_tool_old"),
+            ("batch", "card_tool_next"),
+        ]
+        assert session.card_id == "card_tool_next"
+        assert session.split_index == 1
+        assert len(session.linear_state.segments) == 2
+        assert session.linear_state.segments[0].tool_end_offset == 1
+        assert session.linear_state.segments[1].tool_offset == 1
+        assert session.linear_state.segments[1].created is True
+
+    @pytest.mark.asyncio
+    async def test_oversized_new_tool_segment_splits_across_multiple_cards(self) -> None:
+        """单次 flush 内 tool steps 很多时，未创建的 tool segment 也会连续分片拆卡."""
+        ctrl = _setup_ctrl()
+        calls = _capture_split_calls(
+            ctrl,
+            cards=["card_tool_page_2", "card_tool_page_3"],
+            messages=["msg_tool_page_2", "msg_tool_page_3"],
+        )
+
+        session = _make_session("msg_tool_many", linear=True)
+        session.state = STREAMING
+        session.card_id = "card_tool_page_1"
+        session.card_msg_id = "msg_tool_page_1"
+        session.element_count = 1
+        session.tool_use.record_start("check")
+        session.linear_state.on_tool_event(1)
+        for _ in range(127):
+            session.tool_use.record_start("check")
+        session.linear_state.on_tool_event(len(session.tool_use.build_display_steps()))
+        ctrl._sessions["msg_tool_many"] = session
+
+        await ctrl._do_linear_flush(session)
+
+        assert calls == [
+            ("batch", "card_tool_page_1"),
+            ("create", ""),
+            ("reply", ""),
+            ("close", "card_tool_page_1"),
+            ("seal", "card_tool_page_1"),
+            ("batch", "card_tool_page_2"),
+            ("create", ""),
+            ("reply", ""),
+            ("close", "card_tool_page_2"),
+            ("seal", "card_tool_page_2"),
+            ("batch", "card_tool_page_3"),
+        ]
+        assert session.card_id == "card_tool_page_3"
+        assert session.card_msg_id == "msg_tool_page_3"
+        assert session.split_index == 2
+        assert len(session.linear_state.segments) == 3
+        assert [s.tool_offset for s in session.linear_state.segments] == [0, 58, 116]
+        assert [s.tool_end_offset for s in session.linear_state.segments] == [58, 116, 0]
+        assert all(s.created for s in session.linear_state.segments)
+        assert session.linear_state.segments[-1].element_estimate + session.element_count <= 180
+
+    @pytest.mark.asyncio
+    async def test_tool_rollover_create_failure_falls_back_on_current_card(self) -> None:
+        """tool rollover 新卡创建失败后，在当前卡保留 step 分界并禁用后续拆卡重试."""
+        ctrl = _setup_ctrl()
+        batch_card_ids = _capture_split_calls(ctrl, create_error=RuntimeError("create failed"))
+        client = ctrl._client
+
+        session = _make_session("msg_tool_roll_fallback", linear=True)
+        session.state = STREAMING
+        session.card_id = "card_tool_current"
+        session.card_msg_id = "msg_tool_current"
+        session.tool_use.record_start("read", "file0")
+        session.linear_state.on_tool_event(1)
+        tool_seg = session.linear_state.segments[0]
+        tool_seg.created = True
+        tool_seg.element_estimate = _estimate_segment_elements(tool_seg, session.tool_use.build_display_steps())
+        session.element_count = 174
+
+        for idx in range(1, 4):
+            session.tool_use.record_start("read", f"file{idx}")
+        session.linear_state.on_tool_event(len(session.tool_use.build_display_steps()))
+        ctrl._sessions["msg_tool_roll_fallback"] = session
+
+        await ctrl._do_linear_flush(session)
+
+        assert session.card_id == "card_tool_current"
+        assert session.split_index == 0
+        assert session.split_disabled is True
+        assert len(session.linear_state.segments) == 2
+        assert session.linear_state.segments[0].tool_end_offset == 1
+        assert session.linear_state.segments[1].tool_offset == 1
+        assert session.linear_state.segments[1].created is True
+        assert batch_card_ids == [("batch", "card_tool_current"), ("batch", "card_tool_current")]
+        client.cardkit_close_streaming.assert_not_called()
+        client.cardkit_update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_split_create_failure_falls_back_to_current_card(self) -> None:
+        """新卡创建失败是有意降级：不推进 split_index，继续把后续内容写回当前卡."""
+        ctrl = _setup_ctrl()
+        batch_card_ids = _capture_split_calls(ctrl, create_error=RuntimeError("create failed"))
+        client = ctrl._client
+
+        session = _make_session("msg_split_fallback", linear=True)
+        session.state = STREAMING
+        session.card_id = "card_current"
+        session.card_msg_id = "msg_current"
+        session.element_count = 174
+        session.linear_state.on_reasoning_delta("old")
+        session.linear_state.segments[0].created = True
+        session.linear_state.segments[0].dirty = False
+        session.linear_state.on_answer_delta("pending answer")
+        session.tool_use.record_start("read", "file")
+        session.linear_state.on_tool_event(1)
+        ctrl._sessions["msg_split_fallback"] = session
+
+        await ctrl._do_linear_flush(session)
+
+        assert session.card_id == "card_current"
+        assert session.card_msg_id == "msg_current"
+        assert session.split_index == 0
+        assert session.split_disabled is True
+        assert session.element_count > 174
+        assert batch_card_ids == [("batch", "card_current"), ("batch", "card_current")]
+        assert session.linear_state.segments[2].created is True
+        client.cardkit_close_streaming.assert_not_called()
+        client.cardkit_update.assert_not_called()
+
+        client.cardkit_create.reset_mock()
+        session.linear_state.on_answer_delta(" after fallback")
+
+        await ctrl._do_linear_flush(session)
+
+        client.cardkit_create.assert_not_called()
+        assert batch_card_ids == [
+            ("batch", "card_current"),
+            ("batch", "card_current"),
+            ("batch", "card_current"),
+        ]
+        assert session.linear_state.segments[-1].created is True
 
     @pytest.mark.asyncio
     async def test_reasoning_finalized_snapshot(self) -> None:

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -6,6 +6,7 @@ import time
 
 import pytest
 
+from hermes_lark_streaming import linear as linear_module
 from hermes_lark_streaming.linear import LinearState, Segment
 
 
@@ -17,6 +18,7 @@ class TestSegmentDefaults:
             assert seg.el_id == el_id
             assert seg.created is False
             assert seg.dirty is True
+            assert seg.element_estimate == 0
             assert seg.text == ""
             assert seg.tool_offset == 0
             assert seg.tool_end_offset == 0
@@ -186,7 +188,10 @@ class TestMultiRound:
         assert state.segments[2].el_id == "tools_2"
         assert state.segments[3].el_id == "reasoning_3_panel"
 
-    def test_finalize_complex_scenario(self) -> None:
+    def test_finalize_complex_scenario(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        times = iter(float(i) for i in range(100, 108))
+        monkeypatch.setattr(linear_module.time, "time", lambda: next(times))
+
         state = LinearState()
         state.on_reasoning_delta("r1")
         state.on_answer_delta("a1")
@@ -200,4 +205,4 @@ class TestMultiRound:
         assert state.segments[0].elapsed_ms > 0  # r1 finalized by a1
         assert state.segments[2].tool_end_offset == 3  # tool1 finalized by tool2
         assert state.segments[4].tool_end_offset == 5  # tool2 finalized by finalize
-        assert state.segments[5].elapsed_ms > 0  # r2 finalized by finalize
+        assert state.segments[5].elapsed_ms > 0  # r2 finalized by a2


### PR DESCRIPTION
## Summary

- Detect element count approaching Feishu's 200-element hard limit (threshold: 180) during linear streaming flush
- Split card at segment boundary: flush pending actions, seal old card (no footer), create new streaming card
- For oversized tool panels, split at tool step boundary via `_find_tool_split_offset` + `split_tool_segment`
- Track `element_estimate` on Segment for incremental dirty tool panel growth detection
- `_maybe_rollover_tool_segment` handles the case where new tool steps push an existing panel over the limit
- `new_el_total` tracks pending elements within a flush cycle to prevent batch overflow
- `split_disabled` flag prevents retry loops when new card creation fails
- `_do_linear_complete_inner` renders only post-split segments on the active card
- Extract `_do_linear_batch_update` for reuse by flush and split flows
- `_handle_linear_flush_error` drops unused session parameter

Closes #14
Closes #21

## Test plan

- [x] ruff + mypy + 348 tests pass
- [x] Live test: 10-round multi-segment split (reasoning+answer+tool per round)
- [x] Live test: 80-step single tool panel split across 3 cards
- [x] Live test: 200-step single tool panel split across 7 cards