### PR TITLE
fix: Feishu quoted message card shows only Done.

### DIFF
--- a/hermes_lark_streaming/patcher.py
+++ b/hermes_lark_streaming/patcher.py
@@ -52,7 +52,8 @@ def _start_hook(indent: str) -> str:
         [
             "try:",
             "    from hermes_lark_streaming.patch import on_message_started",
-            "    on_message_started(message_id=event.message_id, chat_id=source.chat_id)",
+            "    _lark_message_id = self._reply_anchor_for_event(event) or event.message_id",
+            "    on_message_started(message_id=_lark_message_id, chat_id=source.chat_id)",
             "except Exception:",
             "    pass",
         ],
@@ -67,8 +68,9 @@ def _complete_hook(indent: str) -> str:
         [
             "try:",
             "    from hermes_lark_streaming.patch import on_message_completed",
+            "    _lark_message_id = self._reply_anchor_for_event(event) or event.message_id",
             "    _lark_card_sent = on_message_completed(",
-            "        message_id=event.message_id,",
+            "        message_id=_lark_message_id,",
             "        answer=response,",
             "        duration=_response_time,",
             "        model=agent_result.get('model', ''),",

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -114,6 +114,18 @@ class TestApplyRemove:
         content = run_copy.read_text(encoding="utf-8")
         ast.parse(content)  # should not raise
 
+    def test_apply_uses_current_turn_message_id_for_card_session(self, run_copy: Path) -> None:
+        patcher = _patcher(run_copy)
+        patcher.apply()
+        content = run_copy.read_text(encoding="utf-8")
+
+        assert "_lark_message_id = self._reply_anchor_for_event(event) or event.message_id" in content
+        assert "on_message_started(message_id=_lark_message_id" in content
+        assert "on_message_completed(\n                    message_id=_lark_message_id" in content
+        assert "on_answer_delta(message_id=event_message_id" in content
+        assert "on_thinking_delta(message_id=event_message_id" in content
+        assert "on_reasoning_delta(message_id=event_message_id" in content
+
     def test_apply_idempotent(self, run_copy: Path) -> None:
         patcher = _patcher(run_copy)
         patcher.apply()


### PR DESCRIPTION
## Summary

- START/COMPLETE hooks now use `_reply_anchor_for_event(event)` for message ID, aligning with streaming callbacks that receive `event_message_id` from `_run_agent`
- Fixes quoted messages losing streaming deltas due to session ID mismatch

## Root cause

For Feishu quoted messages, `_reply_anchor_for_event(event)` returns the quoted message ID (`reply_to_message_id`), but START/COMPLETE hooks used `event.message_id` (the new message ID). Streaming callbacks inside `_run_agent` already used the reply anchor via `event_message_id`, causing a session ID mismatch — deltas were silently dropped.

Closes #24

## Test plan

- [x] ruff + mypy + 349 tests pass
- [ ] Live test: Feishu quoted message streams card content correctly