### PR TITLE
fix: Feishu quoted message card delivery with anchor_id

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project
 
-Hermes Gateway plugin that injects 8 hooks into `~/.hermes/hermes-agent/gateway/run.py` via AST patching to provide real-time streaming Feishu/Lark CardKit v2.0 cards with typewriter effect.
+Hermes Gateway plugin that injects 10 hooks into `~/.hermes/hermes-agent/gateway/run.py` via AST patching to provide real-time streaming Feishu/Lark CardKit v2.0 cards with typewriter effect.
 
 ## Commands
 
@@ -34,6 +34,7 @@ $HERMES_PYTHON -m pytest tests/ -v
 gateway/run.py (Hermes)
   └─ AST-injected hooks (patcher.py defines markers + injection logic)
        │
+       ├─ on_feishu_normalize   → patch.on_feishu_normalize() (inline, fixes false thread_id)
        ├─ on_message_started    → controller.on_message_started()
        ├─ on_tool_updated       → controller.on_tool_update()
        ├─ on_answer_delta       → controller.on_answer()
@@ -74,6 +75,8 @@ Card templates (cardkit.py) — builds Feishu card JSON
 - Hermes `>= 0.11.0` (2026.4.23) required. `patcher.py` targets specific function names in Hermes's `gateway/run.py` (`_handle_message_with_agent`, `progress_callback`, `_stream_delta_cb`, `_interim_assistant_cb`). If Hermes changes these, `verify` will catch it.
 - The interrupt hook is injected at the `"Restart typing indicator"` comment in `_run_agent`. It fires when `was_interrupted and next_message_id` are both truthy. The `_interrupt_map` redirects `on_completed(old_id)` to the new session, handling nested interrupts (A→B→C).
 - The `_thinking_hook` has a `not already_streamed` guard (patcher.py:103) — thinking deltas are skipped once answer streaming has begun.
+- The NORMALIZE hook (`on_feishu_normalize`) is injected at `source = event.source` in `_handle_message`, before any other processing. It detects Feishu quoted messages with a false `thread_id` (set by the Feishu adapter but absent in raw event) and clears it, preventing `_reply_anchor_for_event` from returning the wrong ID.
+- The `anchor_id` mechanism: for Feishu quoted messages, `_reply_anchor_for_event(event)` returns `reply_to_message_id` instead of `event.message_id`. The START hook passes both — `message_id` for session identity and streaming callback lookup, `anchor_id` for card delivery (reply target). Sessions are registered under both keys.
 - Reasoning display depends on upstream providing `<thinking>`/`<thought>`/`<antthinking>` tags or `Reasoning:\n` prefix in text. Native API reasoning blocks (Anthropic extended thinking, DeepSeek reasoning_content) are available via `on_reasoning_delta` hook when `display.platforms.feishu.show_reasoning` is enabled.
 - CardKit v2.0 elements (collapsible_panel, streaming_mode) only work with `"schema": "2.0"` cards. IM fallback path uses v1 card format.
 - Linear mode (default) uses a single card for the entire message lifecycle: elements are dynamically created in event arrival order. Non-linear mode creates a streaming card then replaces it with a completion card. When linear CardKit creation fails, it falls back to non-linear mode.

--- a/README.en.md
+++ b/README.en.md
@@ -172,10 +172,11 @@ $HERMES_PYTHON -m pip uninstall hermes-lark-streaming
 
 ## How It Works
 
-The plugin injects **9 hook calls** into `gateway/run.py` via AST patching. All business logic lives in the `hermes_lark_streaming` package:
+The plugin injects **10 hook calls** into `gateway/run.py` via AST patching. All business logic lives in the `hermes_lark_streaming` package:
 
 | Hook | Injection Target | Description |
 |------|-----------------|-------------|
+| `on_feishu_normalize` | After `source = event.source` in `_handle_message` | Fixes false thread_id on Feishu quoted messages |
 | `on_message_started` | Top of `_handle_message_with_agent` | Creates card session and placeholder card |
 | `on_tool_updated` | `progress_callback` | Displays tool call status in real-time |
 | `on_answer_delta` | `_stream_delta_cb` | Streams answer text to the card |

--- a/README.md
+++ b/README.md
@@ -172,10 +172,11 @@ $HERMES_PYTHON -m pip uninstall hermes-lark-streaming
 
 ## 工作原理
 
-插件通过 AST 注入在 `gateway/run.py` 的 **9 个位置**插入 hook 调用，所有业务逻辑在 `hermes_lark_streaming` 包内完成：
+插件通过 AST 注入在 `gateway/run.py` 的 **10 个位置**插入 hook 调用，所有业务逻辑在 `hermes_lark_streaming` 包内完成：
 
 | Hook | 注入位置 | 说明 |
 |------|----------|------|
+| `on_feishu_normalize` | `_handle_message` 中 `source = event.source` 之后 | 修正飞书引用消息的虚假 thread_id |
 | `on_message_started` | `_handle_message_with_agent` 函数体开头 | 创建卡片会话，发送占位卡片 |
 | `on_tool_updated` | `progress_callback` 内部 | 实时展示工具调用状态 |
 | `on_answer_delta` | `_stream_delta_cb` 内部 | 流式更新回答文本 |

--- a/hermes_lark_streaming/controller.py
+++ b/hermes_lark_streaming/controller.py
@@ -48,6 +48,7 @@ class CardSession:
 
     __slots__ = (
         "_loop",
+        "anchor_id",
         "card_id",
         "card_msg_id",
         "chat_id",
@@ -85,6 +86,7 @@ class CardSession:
         loop: asyncio.AbstractEventLoop,
     ) -> None:
         self.message_id = message_id
+        self.anchor_id: str | None = None
         self.chat_id = chat_id
         self.state = IDLE
         self.card_msg_id: str | None = None
@@ -199,6 +201,7 @@ class StreamCardController(ControllerMixin, LinearControllerMixin):
         *,
         message_id: str | None,
         chat_id: str,
+        anchor_id: str | None = None,
     ) -> None:
         """消息处理开始 — 创建会话 + 发占位卡片."""
         if not self.enabled:
@@ -217,7 +220,10 @@ class StreamCardController(ControllerMixin, LinearControllerMixin):
             return
         session = CardSession(message_id, chat_id, loop)
         self._sessions[message_id] = session
-        _logger.info("session created: msg=%s chat=%s", message_id[:12], chat_id[:12])
+        if anchor_id and anchor_id != message_id:
+            session.anchor_id = anchor_id
+            self._sessions[anchor_id] = session
+        _logger.info("session created: msg=%s chat=%s anchor=%s", message_id[:12], chat_id[:12], (anchor_id or "")[:12])
 
         if self._cfg.linear:
             self._fire_and_forget(self._do_create_linear_card(session), loop)
@@ -361,6 +367,7 @@ class StreamCardController(ControllerMixin, LinearControllerMixin):
         old_message_id: str,
         new_message_id: str,
         chat_id: str,
+        anchor_id: str | None = None,
     ) -> None:
         """用户发送新消息导致前一条消息被中断 — abort A + create B."""
         if not self.enabled:
@@ -379,12 +386,17 @@ class StreamCardController(ControllerMixin, LinearControllerMixin):
         if new_message_id not in self._sessions:
             loop = self._get_loop()
             if loop is not None:
+                reply_anchor_id = anchor_id if anchor_id and anchor_id != new_message_id else None
                 session = CardSession(new_message_id, chat_id, loop)
+                session.anchor_id = reply_anchor_id
                 self._sessions[new_message_id] = session
+                if reply_anchor_id:
+                    self._sessions[reply_anchor_id] = session
                 _logger.info(
-                    "on_interrupted: create new msg=%s chat=%s",
+                    "on_interrupted: create new msg=%s chat=%s anchor=%s",
                     new_message_id[:12],
                     chat_id[:12],
+                    (reply_anchor_id or new_message_id)[:12],
                 )
                 if self._cfg.linear:
                     self._fire_and_forget(self._do_create_linear_card(session), loop)
@@ -514,6 +526,9 @@ class StreamCardController(ControllerMixin, LinearControllerMixin):
         session = self._sessions.pop(message_id, None)
         if session is None:
             return
+        anchor = getattr(session, "anchor_id", None)
+        if anchor and self._sessions.get(anchor) is session:
+            del self._sessions[anchor]
         stale_keys = [k for k, v in self._interrupt_map.items() if v == message_id]
         for k in stale_keys:
             del self._interrupt_map[k]

--- a/hermes_lark_streaming/controller_linear_mixin.py
+++ b/hermes_lark_streaming/controller_linear_mixin.py
@@ -132,6 +132,7 @@ class LinearControllerMixin:
             assert self._client is not None
 
             try:
+                reply_to_message_id = session.anchor_id or session.message_id
                 card = build_streaming_card_v2(
                     show_tool_use=False,
                     show_reasoning=False,
@@ -139,7 +140,7 @@ class LinearControllerMixin:
                 )
                 card_id = await self._client.cardkit_create(card)
                 card_msg_id = await self._client.reply_card_by_id(
-                    session.message_id,
+                    reply_to_message_id,
                     card_id,
                 )
                 session.card_id = card_id
@@ -151,7 +152,7 @@ class LinearControllerMixin:
                 _logger.info("linear CardKit create failed, falling back to non-linear")
                 card = build_im_fallback_card()
                 card_msg_id = await self._client.reply_card(
-                    session.message_id,
+                    reply_to_message_id,
                     card,
                 )
                 session.card_msg_id = card_msg_id
@@ -576,7 +577,7 @@ class LinearControllerMixin:
                 show_streaming_element=False,
             )
             new_card_id = await self._client.cardkit_create(card)
-            new_msg_id = await self._client.reply_card_by_id(session.message_id, new_card_id)
+            new_msg_id = await self._client.reply_card_by_id(session.anchor_id or session.message_id, new_card_id)
         except Exception:
             _logger.warning(
                 "linear split fallback: create next card failed, continue on current card",

--- a/hermes_lark_streaming/controller_mixin.py
+++ b/hermes_lark_streaming/controller_mixin.py
@@ -74,12 +74,13 @@ class ControllerMixin:
                 )
 
             try:
+                reply_to_message_id = session.anchor_id or session.message_id
                 card = build_streaming_card_v2(
                     show_tool_use=False, show_reasoning=self._cfg.show_reasoning
                 )
                 card_id = await self._client.cardkit_create(card)
                 card_msg_id = await self._client.reply_card_by_id(
-                    session.message_id,
+                    reply_to_message_id,
                     card_id,
                 )
                 session.card_id = card_id
@@ -89,7 +90,7 @@ class ControllerMixin:
             except FeishuAPIError:
                 card = build_im_fallback_card()
                 card_msg_id = await self._client.reply_card(
-                    session.message_id,
+                    reply_to_message_id,
                     card,
                 )
                 session.card_msg_id = card_msg_id

--- a/hermes_lark_streaming/patch.py
+++ b/hermes_lark_streaming/patch.py
@@ -39,10 +39,64 @@ def _safe_hook(
     return decorator
 
 
+def on_feishu_normalize(
+    *,
+    message_id: str,
+    source: Any,
+    event: Any,
+    reply_anchor_id: str | None = None,
+) -> None:
+    """[注入点 0] _handle_message source 赋值后 — 修正飞书引用消息的虚假 thread_id."""
+    ctrl = get_controller()
+    if not ctrl.enabled:
+        return
+
+    platform = getattr(getattr(source, "platform", None), "value", "")
+    if platform != "feishu":
+        return
+
+    raw = getattr(event, "raw_message", None)
+    raw_event = raw.get("event") if isinstance(raw, dict) else None
+    if raw_event is None:
+        raw_event = getattr(raw, "event", None)
+
+    raw_message = None
+    if isinstance(raw_event, dict):
+        raw_message = raw_event.get("message")
+    elif raw_event is not None:
+        raw_message = getattr(raw_event, "message", None)
+    if raw_message is None and isinstance(raw, dict):
+        raw_message = raw.get("message")
+    if raw_message is None:
+        raw_message = raw
+
+    real_thread_id = None
+    if isinstance(raw_message, dict):
+        real_thread_id = raw_message.get("thread_id")
+    else:
+        real_thread_id = getattr(raw_message, "thread_id", None)
+
+    reply_to = getattr(event, "reply_to_message_id", None)
+    source_thread_id = getattr(source, "thread_id", None)
+
+    _logger.info(
+        "feishu inbound ids: msg=%s anchor=%s source_thread=%s raw_thread=%s reply_to=%s",
+        message_id,
+        reply_anchor_id,
+        source_thread_id,
+        real_thread_id,
+        reply_to,
+    )
+
+    if reply_to and source_thread_id and not real_thread_id:
+        source.thread_id = None
+        event.source = source
+
+
 @_safe_hook()
-def on_message_started(*, ctrl: Any, message_id: str, chat_id: str) -> None:
+def on_message_started(*, ctrl: Any, message_id: str, chat_id: str, anchor_id: str | None = None) -> None:
     """[注入点 1] 函数开头 — message.started."""
-    ctrl.on_message_started(message_id=message_id, chat_id=chat_id)
+    ctrl.on_message_started(message_id=message_id, chat_id=chat_id, anchor_id=anchor_id)
 
 
 @_safe_hook(default_return=False)
@@ -135,10 +189,12 @@ def on_message_interrupted(
     message_id: str,
     new_message_id: str,
     chat_id: str,
+    anchor_id: str | None = None,
 ) -> None:
     """[注入点 9] interrupt 发生 — message.interrupted."""
     ctrl.on_interrupted(
         old_message_id=message_id,
         new_message_id=new_message_id,
         chat_id=chat_id,
+        anchor_id=anchor_id,
     )

--- a/hermes_lark_streaming/patcher.py
+++ b/hermes_lark_streaming/patcher.py
@@ -13,6 +13,7 @@ _logger = logging.getLogger("hermes_lark_streaming")
 PREFIX = "HERMES_LARK"
 
 _HOOK_NAMES = [
+    "NORMALIZE",
     "START",
     "COMPLETE",
     "TOOL",
@@ -25,15 +26,16 @@ _HOOK_NAMES = [
 ]
 MARKERS: list[tuple[str, str]] = [(f"# {PREFIX}_{n}_BEGIN", f"# {PREFIX}_{n}_END") for n in _HOOK_NAMES]
 
-MK_START, MK_START_END = MARKERS[0]
-MK_COMPLETE, MK_COMPLETE_END = MARKERS[1]
-MK_TOOL, MK_TOOL_END = MARKERS[2]
-MK_ANSWER, MK_ANSWER_END = MARKERS[3]
-MK_THINKING, MK_THINKING_END = MARKERS[4]
-MK_REASONING, MK_REASONING_END = MARKERS[5]
-MK_BACKGROUND_REVIEW, MK_BACKGROUND_REVIEW_END = MARKERS[6]
-MK_ABORT, MK_ABORT_END = MARKERS[7]
-MK_INTERRUPT, MK_INTERRUPT_END = MARKERS[8]
+MK_NORMALIZE, MK_NORMALIZE_END = MARKERS[0]
+MK_START, MK_START_END = MARKERS[1]
+MK_COMPLETE, MK_COMPLETE_END = MARKERS[2]
+MK_TOOL, MK_TOOL_END = MARKERS[3]
+MK_ANSWER, MK_ANSWER_END = MARKERS[4]
+MK_THINKING, MK_THINKING_END = MARKERS[5]
+MK_REASONING, MK_REASONING_END = MARKERS[6]
+MK_BACKGROUND_REVIEW, MK_BACKGROUND_REVIEW_END = MARKERS[7]
+MK_ABORT, MK_ABORT_END = MARKERS[8]
+MK_INTERRUPT, MK_INTERRUPT_END = MARKERS[9]
 
 _BACKUP_SUFFIX = ".hermes_lark.bak"
 
@@ -44,6 +46,26 @@ def _make_hook(indent: str, begin: str, end: str, body_lines: list[str]) -> str:
     return f"{indent}{begin}\n" + "".join(f"{indent}{line}\n" for line in body_lines) + f"{indent}{end}\n"
 
 
+def _feishu_normalize_hook(indent: str) -> str:
+    return _make_hook(
+        indent,
+        MK_NORMALIZE,
+        MK_NORMALIZE_END,
+        [
+            "try:",
+            "    from hermes_lark_streaming.patch import on_feishu_normalize",
+            "    on_feishu_normalize(",
+            "        message_id=event.message_id,",
+            "        source=source,",
+            "        event=event,",
+            "        reply_anchor_id=self._reply_anchor_for_event(event),",
+            "    )",
+            "except Exception:",
+            "    pass",
+        ],
+    )
+
+
 def _start_hook(indent: str) -> str:
     return _make_hook(
         indent,
@@ -52,8 +74,12 @@ def _start_hook(indent: str) -> str:
         [
             "try:",
             "    from hermes_lark_streaming.patch import on_message_started",
-            "    _lark_message_id = self._reply_anchor_for_event(event) or event.message_id",
-            "    on_message_started(message_id=_lark_message_id, chat_id=source.chat_id)",
+            "    _lark_anchor_id = self._reply_anchor_for_event(event)",
+            "    on_message_started(",
+            "        message_id=event.message_id,",
+            "        chat_id=source.chat_id,",
+            "        anchor_id=_lark_anchor_id,",
+            "    )",
             "except Exception:",
             "    pass",
         ],
@@ -68,9 +94,8 @@ def _complete_hook(indent: str) -> str:
         [
             "try:",
             "    from hermes_lark_streaming.patch import on_message_completed",
-            "    _lark_message_id = self._reply_anchor_for_event(event) or event.message_id",
             "    _lark_card_sent = on_message_completed(",
-            "        message_id=_lark_message_id,",
+            "        message_id=event.message_id,",
             "        answer=response,",
             "        duration=_response_time,",
             "        model=agent_result.get('model', ''),",
@@ -210,13 +235,18 @@ def _interrupt_hook(indent: str) -> str:
         MK_INTERRUPT_END,
         [
             "try:",
-            "    from hermes_lark_streaming.patch import on_message_interrupted",
-            "    if was_interrupted and next_message_id:",
+            "    from hermes_lark_streaming.patch import on_message_interrupted, on_message_aborted",
+            "    _lark_next_message_id = getattr(pending_event, 'message_id', None) or next_message_id",
+            "    _lark_next_anchor_id = next_message_id",
+            "    if was_interrupted and _lark_next_message_id:",
             "        on_message_interrupted(",
             "            message_id=event_message_id,",
-            "            new_message_id=next_message_id,",
+            "            new_message_id=_lark_next_message_id,",
             "            chat_id=source.chat_id,",
+            "            anchor_id=_lark_next_anchor_id,",
             "        )",
+            "    elif was_interrupted:",
+            "        on_message_aborted(message_id=event_message_id)",
             "except Exception:",
             "    pass",
         ],
@@ -295,6 +325,12 @@ class Patcher:
                 "Cannot find background_review_callback anchor in run.py — Hermes version may be incompatible"
             )
 
+        normalize_site = _find_handle_message_source_site(tree, content.splitlines(keepends=True))
+        if normalize_site is None:
+            raise PatcherError(
+                "Cannot find _handle_message source anchor in run.py — Hermes version may be incompatible"
+            )
+
     def apply(self) -> None:
         if self.is_fully_patched():
             return
@@ -333,6 +369,7 @@ class Patcher:
         lines = content.splitlines(keepends=True)
 
         hook_defs: list[tuple[str, str, tuple[int, str] | None]] = [
+            ("normalize", "normalize", _find_handle_message_source_site(tree, lines)),
             ("start", "start", _find_func_body(tree, lines, "_handle_message_with_agent")),
             ("complete", "complete", _find_handler_return(tree, lines)),
             ("abort", "abort", _find_handler_abort(tree, lines)),
@@ -353,6 +390,7 @@ class Patcher:
 
         sites.sort(key=lambda x: x[0], reverse=True)
         _HOOK_FNS = {
+            "normalize": _feishu_normalize_hook,
             "start": _start_hook,
             "complete": _complete_hook,
             "abort": _abort_hook,
@@ -401,6 +439,25 @@ def _find_func_body(tree: ast.Module, lines: list[str], name: str) -> tuple[int,
                 lineno = body[start].lineno - 1
                 indent = _safe_indent(lines, lineno)
                 return lineno, indent
+    return None
+
+
+def _find_handle_message_source_site(tree: ast.Module, lines: list[str]) -> tuple[int, str] | None:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "_handle_message":
+            for stmt in node.body:
+                if (
+                    isinstance(stmt, ast.Assign)
+                    and len(stmt.targets) == 1
+                    and isinstance(stmt.targets[0], ast.Name)
+                    and stmt.targets[0].id == "source"
+                    and isinstance(stmt.value, ast.Attribute)
+                    and stmt.value.attr == "source"
+                    and isinstance(stmt.value.value, ast.Name)
+                    and stmt.value.value.id == "event"
+                ):
+                    lineno = stmt.end_lineno or stmt.lineno
+                    return lineno, _safe_indent(lines, stmt.lineno - 1)
     return None
 
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -12,6 +12,7 @@ import pytest
 from hermes_lark_streaming.controller import CardSession, StreamCardController
 from hermes_lark_streaming.controller_linear_mixin import _estimate_segment_elements
 from hermes_lark_streaming.controller_mixin import (
+    ABORTED,
     COMPLETED,
     FAILED,
     STREAMING,
@@ -43,6 +44,43 @@ def test_on_message_started_ignores_missing_message_id(message_id: str | None) -
     ctrl.on_message_started(message_id=message_id, chat_id="chat")
 
     assert ctrl._sessions == {}
+
+
+def test_on_message_started_registers_anchor_alias_and_cleanup() -> None:
+    ctrl = StreamCardController()
+    _enable(ctrl)
+
+    with patch.object(ctrl, "_fire_and_forget", side_effect=lambda coro, loop: coro.close()):
+        ctrl.on_message_started(message_id="msg", chat_id="chat", anchor_id="quoted")
+
+    session = ctrl._sessions["msg"]
+    assert ctrl._sessions["quoted"] is session
+    assert session.anchor_id == "quoted"
+
+    ctrl._cleanup("msg")
+
+    assert "msg" not in ctrl._sessions
+    assert "quoted" not in ctrl._sessions
+
+
+def test_on_interrupted_uses_new_message_id_and_anchor_alias() -> None:
+    ctrl = StreamCardController()
+    _enable(ctrl)
+
+    with patch.object(ctrl, "_fire_and_forget", side_effect=lambda coro, loop: coro.close()):
+        ctrl.on_message_started(message_id="old", chat_id="chat")
+        ctrl.on_interrupted(
+            old_message_id="old",
+            new_message_id="new",
+            chat_id="chat",
+            anchor_id="quoted",
+        )
+
+    session = ctrl._sessions["new"]
+    assert ctrl._sessions["quoted"] is session
+    assert session.anchor_id == "quoted"
+    assert ctrl._interrupt_map["old"] == "new"
+    assert ctrl._sessions["old"].state == ABORTED
 
 
 def test_prune_stale_sessions_ignores_none_key_and_prunes_valid_key() -> None:
@@ -137,6 +175,18 @@ def _setup_ctrl(*, linear: bool = False) -> StreamCardController:
     ctrl._initialized = True
     ctrl._client = _mock_client()
     return ctrl
+
+
+@pytest.mark.asyncio
+async def test_create_card_replies_to_anchor_id() -> None:
+    ctrl = _setup_ctrl()
+    session = _make_session("msg")
+    session.anchor_id = "quoted"
+
+    await ctrl._do_create_card(session)
+
+    ctrl._client.reply_card_by_id.assert_called_once()
+    assert ctrl._client.reply_card_by_id.call_args.args[0] == "quoted"
 
 
 def _capture_split_calls(

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -119,9 +119,18 @@ class TestApplyRemove:
         patcher.apply()
         content = run_copy.read_text(encoding="utf-8")
 
-        assert "_lark_message_id = self._reply_anchor_for_event(event) or event.message_id" in content
-        assert "on_message_started(message_id=_lark_message_id" in content
-        assert "on_message_completed(\n                    message_id=_lark_message_id" in content
+        assert "# HERMES_LARK_NORMALIZE_BEGIN" in content
+        assert "source = event.source\n        # HERMES_LARK_NORMALIZE_BEGIN" in content
+        assert "on_feishu_normalize(" in content
+        assert "on_message_started(" in content
+        assert "_lark_anchor_id = self._reply_anchor_for_event(event)" in content
+        assert "message_id=event.message_id" in content
+        assert "anchor_id=_lark_anchor_id" in content
+        assert "_lark_next_message_id = getattr(pending_event, 'message_id', None) or next_message_id" in content
+        assert "new_message_id=_lark_next_message_id" in content
+        assert "anchor_id=_lark_next_anchor_id" in content
+        assert "on_message_completed(" in content
+        assert "message_id=event.message_id" in content
         assert "on_answer_delta(message_id=event_message_id" in content
         assert "on_thinking_delta(message_id=event_message_id" in content
         assert "on_reasoning_delta(message_id=event_message_id" in content


### PR DESCRIPTION
## Summary

- Add NORMALIZE hook (`on_feishu_normalize`) to clear false `thread_id` on Feishu quoted messages before Hermes processing
- Introduce `anchor_id` mechanism: sessions registered under both `message_id` and reply anchor, card delivery targets anchor while streaming callbacks use message_id
- Interrupt hook handles `pending_event=None` with abort fallback
- Extract normalize logic into `patch.py` consistent with other hooks

Closes #25 (supersedes)
Closes #26

## Root cause

PR #25 fixed the session ID mismatch but introduced a regression: cards replied to the quoted message instead of the user's new message. Additionally, the Feishu adapter sets `source.thread_id` on quoted messages even when the raw event has no `thread_id`, causing Hermes to treat it as a thread conversation.

## Test plan

- [x] ruff + mypy + 63 tests pass
- [x] Patcher install/uninstall/reinstall cycle verified
- [x] Live test: Feishu quoted message card replies to user's message
- [x] Live test: Non-quote messages unaffected