### PR TITLE
feat: collapse panels in completion card by default

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -118,6 +118,16 @@ streaming:
 
 Default (when not configured): `fields: [[status, elapsed, context, model]]`, `show_label: false`.
 
+### Panel Collapse
+
+In the completion card, reasoning and tool panels are collapsed by default. Set `panel_expanded: true` to keep them expanded:
+
+```yaml
+streaming:
+  enabled: true
+  panel_expanded: true
+```
+
 ### Linear Mode (Default)
 
 The plugin dynamically renders thinking, tool call, and answer elements in event arrival order. Reasoning and tool calls are no longer collapsed to the top — multi-round content is displayed in actual order.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ streaming:
 
 未配置时的默认值：`fields: [[status, elapsed, context, model]]`，`show_label: false`。
 
+### 面板折叠
+
+完成态卡片中，推理面板和工具面板默认折叠。配置 `panel_expanded: true` 可保持展开：
+
+```yaml
+streaming:
+  enabled: true
+  panel_expanded: true
+```
+
 ### 线性模式（默认）
 
 插件按事件到达顺序在卡片内动态渲染思考、工具调用、回答元素，推理和工具调用不再收纳置顶，多轮对话内容按实际顺序展示。

--- a/hermes_lark_streaming/cardkit.py
+++ b/hermes_lark_streaming/cardkit.py
@@ -485,15 +485,16 @@ def build_complete_card(
     is_aborted: bool = False,
     footer_fields: list[list[str]] | None = None,
     footer_show_label: bool = True,
+    panel_expanded: bool = False,
 ) -> dict[str, Any]:
     """完成态卡片 — 含 header、reasoning 面板、footer."""
     elements: list[dict] = []
 
     if reasoning_text:
-        elements.append(_build_reasoning_panel(reasoning_text, reasoning_elapsed_ms))
+        elements.append(_build_reasoning_panel(reasoning_text, reasoning_elapsed_ms, expanded=panel_expanded))
 
     if tool_steps:
-        elements.append(_build_tool_panel(tool_steps, tool_elapsed_ms, expanded=False))
+        elements.append(_build_tool_panel(tool_steps, tool_elapsed_ms, expanded=panel_expanded))
 
     content = _downgrade_tables(optimize_markdown_style(text or _T["done"][0]))
     for chunk in _split_long_text(content):
@@ -540,6 +541,7 @@ def build_linear_complete_card(
     is_aborted: bool = False,
     footer_fields: list[list[str]] | None = None,
     footer_show_label: bool = True,
+    panel_expanded: bool = False,
 ) -> dict[str, Any]:
     """线性模式完成态卡片 — 按 segments 顺序渲染."""
     elements: list[dict] = []
@@ -549,7 +551,7 @@ def build_linear_complete_card(
         if seg.type == "reasoning":
             if seg.text:
                 elements.append(_build_reasoning_panel(
-                    seg.text, seg.elapsed_ms, expanded=True,
+                    seg.text, seg.elapsed_ms, expanded=panel_expanded,
                     element_id=None, text_element_id=None,
                 ))
         elif seg.type == "tool":
@@ -557,7 +559,7 @@ def build_linear_complete_card(
             end = seg.tool_end_offset if seg.tool_end_offset else len(all_tool_steps)
             steps = all_tool_steps[start:end]
             if steps:
-                elements.append(_build_tool_panel(steps, expanded=True, element_id=None))
+                elements.append(_build_tool_panel(steps, expanded=panel_expanded, element_id=None))
         elif seg.type == "answer" and seg.text:
             has_answer = True
             content = _downgrade_tables(optimize_markdown_style(seg.text))

--- a/hermes_lark_streaming/config.py
+++ b/hermes_lark_streaming/config.py
@@ -30,6 +30,12 @@ class Config:
         return bool(sec.get("linear", True))
 
     @property
+    def panel_expanded(self) -> bool:
+        """完成态卡片中面板（工具、推理）是否保持展开."""
+        sec = self._streaming_sec()
+        return bool(sec.get("panel_expanded", False))
+
+    @property
     def show_reasoning(self) -> bool:
         """是否展示推理过程（display.platforms.feishu.show_reasoning → display.show_reasoning）.
 

--- a/hermes_lark_streaming/controller_linear_mixin.py
+++ b/hermes_lark_streaming/controller_linear_mixin.py
@@ -568,6 +568,7 @@ class LinearControllerMixin:
             all_tool_steps=all_steps,
             footer_fields=[],
             footer_show_label=False,
+            panel_expanded=self._cfg.panel_expanded,
         )
 
         try:
@@ -666,6 +667,7 @@ class LinearControllerMixin:
             is_aborted=is_aborted,
             footer_fields=self._cfg.footer_fields,
             footer_show_label=self._cfg.footer_show_label,
+            panel_expanded=self._cfg.panel_expanded,
         )
 
         streaming_closed = False

--- a/hermes_lark_streaming/controller_mixin.py
+++ b/hermes_lark_streaming/controller_mixin.py
@@ -316,6 +316,7 @@ class ControllerMixin:
             is_aborted=is_aborted,
             footer_fields=self._cfg.footer_fields,
             footer_show_label=self._cfg.footer_show_label,
+            panel_expanded=self._cfg.panel_expanded,
         )
 
         for attempt in range(3):


### PR DESCRIPTION
- Add `panel_expanded` config option (default: `false`) to control reasoning/tool panel state in completion cards
- Affects both linear and non-linear modes
- Closes #28