### PR TITLE
feat: support HERMES_HOME env var for custom install path

### DIFF
--- a/hermes_lark_streaming/config.py
+++ b/hermes_lark_streaming/config.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import yaml
 
-_HERMES_CONFIG_PATH = Path.home() / ".hermes" / "config.yaml"
+_HERMES_CONFIG_PATH = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))) / "config.yaml"
 
 
 class Config:

--- a/hermes_lark_streaming/patcher.py
+++ b/hermes_lark_streaming/patcher.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 import logging
+import os
 import shutil
 from pathlib import Path
 
@@ -39,8 +40,9 @@ MK_INTERRUPT, MK_INTERRUPT_END = MARKERS[9]
 
 _BACKUP_SUFFIX = ".hermes_lark.bak"
 
-_RUN_PATH = Path.home() / ".hermes" / "hermes-agent" / "gateway" / "run.py"
-_CRON_PATH = Path.home() / ".hermes" / "hermes-agent" / "cron" / "scheduler.py"
+_HERMES_HOME = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
+_RUN_PATH = _HERMES_HOME / "hermes-agent" / "gateway" / "run.py"
+_CRON_PATH = _HERMES_HOME / "hermes-agent" / "cron" / "scheduler.py"
 
 MK_CRON_DELIVER = f"# {PREFIX}_CRON_DELIVER_BEGIN"
 MK_CRON_DELIVER_END = f"# {PREFIX}_CRON_DELIVER_END"


### PR DESCRIPTION
- Read `HERMES_HOME` from environment variable, fallback to `~/.hermes`
- Aligns with Hermes's own `hermes_constants.get_hermes_home()`
- Closes #30