### PR TITLE
fix: await card completion before suppressing fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ gateway/run.py (Hermes)
        ├─ on_reasoning_delta    → controller.on_reasoning()
        ├─ on_background_review_message → controller.defer_background_review()
        ├─ on_message_interrupted → controller.on_interrupted()
-       ├─ on_message_completed  → controller.on_completed()
+       ├─ on_message_completed_wait → controller.on_completed_wait()
        └─ on_message_aborted    → controller.on_aborted()
 
 cron/scheduler.py (Hermes)
@@ -77,7 +77,8 @@ Card templates (cardkit.py) — builds Feishu card JSON
 ## Key Constraints
 
 - Hermes `>= 0.11.0` (2026.4.23) required. `patcher.py` targets specific function names in Hermes's `gateway/run.py` (`_handle_message_with_agent`, `progress_callback`, `_stream_delta_cb`, `_interim_assistant_cb`) and `cron/scheduler.py` (`_deliver_result`). If Hermes changes these, `verify` will catch it.
-- The interrupt hook is injected at the `"Restart typing indicator"` comment in `_run_agent`. It fires when `was_interrupted and next_message_id` are both truthy. The `_interrupt_map` redirects `on_completed(old_id)` to the new session, handling nested interrupts (A→B→C).
+- The interrupt hook is injected at the `"Restart typing indicator"` comment in `_run_agent`. It fires when `was_interrupted and next_message_id` are both truthy. The `_interrupt_map` redirects completion from `old_id` to the new session, handling nested interrupts (A→B→C).
+- The completion hook installed into `gateway/run.py` is async: `on_message_completed_wait` awaits queued CardKit creation/finalization before setting `already_sent`. The legacy sync `on_message_completed` entrypoint remains for compatibility with older installed patches.
 - The `_thinking_hook` has a `not already_streamed` guard (patcher.py:103) — thinking deltas are skipped once answer streaming has begun.
 - The NORMALIZE hook (`on_feishu_normalize`) is injected at `source = event.source` in `_handle_message`, before any other processing. It detects Feishu quoted messages with a false `thread_id` (set by the Feishu adapter but absent in raw event) and clears it, preventing `_reply_anchor_for_event` from returning the wrong ID.
 - The `anchor_id` mechanism: for Feishu quoted messages, `_reply_anchor_for_event(event)` returns `reply_to_message_id` instead of `event.message_id`. The START hook passes both — `message_id` for session identity and streaming callback lookup, `anchor_id` for card delivery (reply target). Sessions are registered under both keys.

--- a/README.en.md
+++ b/README.en.md
@@ -193,7 +193,7 @@ The plugin injects hook calls into `gateway/run.py` and `cron/scheduler.py` via 
 | `on_background_review_message` | At `background_review_callback` assignment | Defers self-evolution messages until card completion |
 | `on_message_aborted` | Before stale `return None` | Handles `/stop` abort |
 | `on_message_interrupted` | Before recursive `_run_agent` call | Handles message interrupts, terminates old card and creates new session |
-| `on_message_completed` | Before `return response` | Sends completion card |
+| `on_message_completed_wait` | Before `return response` | Waits for card creation/finalization before sending the completion card; yields to gateway text fallback on failure |
 | `on_cron_deliver` | After `delivered = False` in `_deliver_result` | Intercepts Feishu cron delivery, sends as card |
 
 **Message flow:**

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ $HERMES_PYTHON -m pip uninstall hermes-lark-streaming
 | `on_background_review_message` | `background_review_callback` 赋值处 | 延迟自我进化消息到卡片完成后再发送 |
 | `on_message_aborted` | stale `return None` 之前 | 处理 `/stop` 中断 |
 | `on_message_interrupted` | `_run_agent` 递归调用前 | 处理消息打断，终止旧卡片并创建新会话 |
-| `on_message_completed` | `return response` 之前 | 发送终态卡片 |
+| `on_message_completed_wait` | `return response` 之前 | 等待卡片创建/收尾完成后发送终态卡片，失败时让网关走文本兜底 |
 | `on_cron_deliver` | `_deliver_result` 中 `delivered = False` 之后 | 拦截飞书 Cron 推送，以卡片形式发送 |
 
 **消息处理流程：**

--- a/hermes_lark_streaming/controller.py
+++ b/hermes_lark_streaming/controller.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
     from .image import ImageResolver
 
 _logger = logging.getLogger("hermes_lark_streaming")
+_CARD_CREATION_WAIT_SEC = 10.0
 
 
 class CardSession:
@@ -52,6 +53,7 @@ class CardSession:
         "card_id",
         "card_msg_id",
         "chat_id",
+        "create_task",
         "created_at",
         "deferred_background_review_closed",
         "deferred_background_review_lock",
@@ -88,6 +90,7 @@ class CardSession:
         self.message_id = message_id
         self.anchor_id: str | None = None
         self.chat_id = chat_id
+        self.create_task: asyncio.Future[Any] | ConcurrentFuture | None = None
         self.state = IDLE
         self.card_msg_id: str | None = None
         self.card_id: str | None = None
@@ -186,15 +189,23 @@ class StreamCardController(ControllerMixin, LinearControllerMixin):
             return None
         return session
 
-    def _fire_and_forget(self, coro: Coroutine[Any, Any, Any], loop: asyncio.AbstractEventLoop) -> None:
+    def _fire_and_forget(
+        self,
+        coro: Coroutine[Any, Any, Any],
+        loop: asyncio.AbstractEventLoop,
+    ) -> asyncio.Future[Any] | ConcurrentFuture | None:
         try:
-            loop.create_task(coro)
+            task = loop.create_task(coro)
+            task.add_done_callback(self._on_bg_task_done)
+            return task
         except RuntimeError:
             try:
                 fut = asyncio.run_coroutine_threadsafe(coro, loop)
                 fut.add_done_callback(self._on_bg_task_done)
+                return fut
             except Exception:
                 _logger.debug("fire_and_forget failed", exc_info=True)
+                return None
 
     def on_message_started(
         self,
@@ -226,9 +237,9 @@ class StreamCardController(ControllerMixin, LinearControllerMixin):
         _logger.info("session created: msg=%s chat=%s anchor=%s", message_id[:12], chat_id[:12], (anchor_id or "")[:12])
 
         if self._cfg.linear:
-            self._fire_and_forget(self._do_create_linear_card(session), loop)
+            session.create_task = self._fire_and_forget(self._do_create_linear_card(session), loop)
         else:
-            self._fire_and_forget(self._do_create_card(session), loop)
+            session.create_task = self._fire_and_forget(self._do_create_card(session), loop)
 
     def on_thinking(self, *, message_id: str, text: str) -> None:
         """思考内容增量."""
@@ -399,9 +410,9 @@ class StreamCardController(ControllerMixin, LinearControllerMixin):
                     (reply_anchor_id or new_message_id)[:12],
                 )
                 if self._cfg.linear:
-                    self._fire_and_forget(self._do_create_linear_card(session), loop)
+                    session.create_task = self._fire_and_forget(self._do_create_linear_card(session), loop)
                 else:
-                    self._fire_and_forget(self._do_create_card(session), loop)
+                    session.create_task = self._fire_and_forget(self._do_create_card(session), loop)
 
         self._interrupt_map[old_message_id] = new_message_id
         for key, val in list(self._interrupt_map.items()):
@@ -449,20 +460,69 @@ class StreamCardController(ControllerMixin, LinearControllerMixin):
             session.use_cardkit,
         )
 
-        if answer:
-            session.text.on_deliver(answer)
-
-        session.footer = {
-            "duration": duration,
-            "model": model,
-            **({"input_tokens": tokens.get("input_tokens")} if tokens else {}),
-            **({"output_tokens": tokens.get("output_tokens")} if tokens else {}),
-            **({"context_used": context.get("used_tokens")} if context else {}),
-            **({"context_max": context.get("max_tokens")} if context else {}),
-        }
+        self._apply_completion_payload(
+            session=session,
+            answer=answer,
+            duration=duration,
+            model=model,
+            tokens=tokens,
+            context=context,
+        )
 
         self._complete_session(session)
         return True
+
+    async def on_completed_wait(
+        self,
+        *,
+        message_id: str,
+        answer: str = "",
+        duration: float = 0.0,
+        model: str = "",
+        tokens: dict | None = None,
+        context: dict | None = None,
+    ) -> bool:
+        """消息处理完成，并等待卡片真正收尾后返回是否已发送."""
+        if not self.enabled:
+            return False
+        session = self._completion_session(message_id)
+        if session is None:
+            return False
+        message_id = session.message_id
+
+        if not await self._wait_for_card_creation(session):
+            _logger.info("on_completed_wait: msg=%s card creation not ready, yielding to gateway", message_id[:12])
+            self._cleanup(message_id)
+            return False
+
+        if session.state == FAILED:
+            _logger.info("on_completed_wait: msg=%s state=FAILED, yielding to gateway", message_id[:12])
+            self._cleanup(message_id)
+            return False
+
+        if not session.card_msg_id and not session.card_id:
+            _logger.info("on_completed_wait: msg=%s has no card, yielding to gateway", message_id[:12])
+            self._cleanup(message_id)
+            return False
+
+        _logger.info(
+            "on_completed_wait: msg=%s has_card=%s state=%s use_cardkit=%s",
+            message_id[:12],
+            bool(session.card_msg_id),
+            session.state,
+            session.use_cardkit,
+        )
+
+        self._apply_completion_payload(
+            session=session,
+            answer=answer,
+            duration=duration,
+            model=model,
+            tokens=tokens,
+            context=context,
+        )
+
+        return await self._complete_session_wait(session)
 
     def on_cron_deliver(
         self,
@@ -557,6 +617,73 @@ class StreamCardController(ControllerMixin, LinearControllerMixin):
         if session.image_resolver:
             session.image_resolver.cancel_pending()
 
+    def _completion_session(self, message_id: str) -> CardSession | None:
+        session = self._get_active_session(message_id)
+        if session is None:
+            redirected_id = self._interrupt_map.pop(message_id, None)
+            if redirected_id is not None:
+                _logger.info(
+                    "on_completed: redirect msg=%s -> msg=%s",
+                    message_id[:12],
+                    redirected_id[:12],
+                )
+                session = self._get_active_session(redirected_id)
+        return session
+
+    async def _wait_for_card_creation(self, session: CardSession) -> bool:
+        task = session.create_task
+        if task is None:
+            return True
+        try:
+            if isinstance(task, asyncio.Future):
+                await asyncio.wait_for(task, timeout=_CARD_CREATION_WAIT_SEC)
+            else:
+                await asyncio.wait_for(asyncio.wrap_future(task), timeout=_CARD_CREATION_WAIT_SEC)
+            return True
+        except TimeoutError:
+            _logger.warning(
+                "card creation timed out: msg=%s timeout=%.1fs",
+                session.message_id[:12],
+                _CARD_CREATION_WAIT_SEC,
+            )
+            task.cancel()
+            session.state = FAILED
+            return False
+        except asyncio.CancelledError:
+            session.state = FAILED
+            return False
+        except Exception:
+            _logger.debug("card creation task failed", exc_info=True)
+            return False
+
+    def _apply_completion_payload(
+        self,
+        *,
+        session: CardSession,
+        answer: str,
+        duration: float,
+        model: str,
+        tokens: dict | None,
+        context: dict | None,
+    ) -> None:
+        if answer:
+            if session.linear and session.linear_state and not any(
+                seg.type == "answer" for seg in session.linear_state.segments
+            ):
+                final_answer = strip_reasoning_tags(answer)
+                if final_answer:
+                    session.linear_state.on_answer_delta(final_answer)
+            session.text.on_deliver(answer)
+
+        session.footer = {
+            "duration": duration,
+            "model": model,
+            **({"input_tokens": tokens.get("input_tokens")} if tokens else {}),
+            **({"output_tokens": tokens.get("output_tokens")} if tokens else {}),
+            **({"context_used": context.get("used_tokens")} if context else {}),
+            **({"context_max": context.get("max_tokens")} if context else {}),
+        }
+
     def _complete_session(self, session: CardSession) -> None:
         """根据 session 线性/非线性选择完成路径."""
         session.flush.mark_completed()
@@ -564,6 +691,13 @@ class StreamCardController(ControllerMixin, LinearControllerMixin):
             self._fire_and_forget(self._do_linear_complete(session), session._loop)
         else:
             self._fire_and_forget(self._do_complete(session), session._loop)
+
+    async def _complete_session_wait(self, session: CardSession) -> bool:
+        """根据 session 线性/非线性完成，并等待最终 API 结果."""
+        session.flush.mark_completed()
+        if session.linear and session.linear_state:
+            return await self._do_linear_complete(session)
+        return await self._do_complete(session)
 
     def _prune_stale_sessions(self) -> None:
         now = time.time()
@@ -573,9 +707,11 @@ class StreamCardController(ControllerMixin, LinearControllerMixin):
             self._cleanup(mid)
 
     @staticmethod
-    def _on_bg_task_done(fut: ConcurrentFuture) -> None:
+    def _on_bg_task_done(fut: asyncio.Future[Any] | ConcurrentFuture) -> None:
         try:
             fut.result()
+        except asyncio.CancelledError:
+            return
         except Exception:
             _logger.warning("background task failed", exc_info=True)
 

--- a/hermes_lark_streaming/patch.py
+++ b/hermes_lark_streaming/patch.py
@@ -123,6 +123,35 @@ def on_message_completed(
     )
 
 
+async def on_message_completed_wait(
+    *,
+    message_id: str,
+    answer: str = "",
+    duration: float = 0.0,
+    model: str = "",
+    tokens: dict[str, Any] | None = None,
+    context: dict[str, Any] | None = None,
+) -> bool:
+    """[注入点 2] return 前 — message.completed，等待卡片完成收尾."""
+    try:
+        ctrl = get_controller()
+        if not ctrl.enabled:
+            return False
+        return bool(
+            await ctrl.on_completed_wait(
+                message_id=message_id,
+                answer=answer,
+                duration=duration,
+                model=model,
+                tokens=tokens,
+                context=context,
+            )
+        )
+    except Exception as exc:
+        _logger.warning("on_message_completed_wait error: %s", exc, exc_info=True)
+        return False
+
+
 @_safe_hook(default_return=False)
 def on_tool_updated(
     *,

--- a/hermes_lark_streaming/patcher.py
+++ b/hermes_lark_streaming/patcher.py
@@ -99,8 +99,8 @@ def _complete_hook(indent: str) -> str:
         MK_COMPLETE_END,
         [
             "try:",
-            "    from hermes_lark_streaming.patch import on_message_completed",
-            "    _lark_card_sent = on_message_completed(",
+            "    from hermes_lark_streaming.patch import on_message_completed_wait",
+            "    _lark_card_sent = await on_message_completed_wait(",
             "        message_id=event.message_id,",
             "        answer=response,",
             "        duration=_response_time,",

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -177,6 +177,76 @@ def _setup_ctrl(*, linear: bool = False) -> StreamCardController:
     return ctrl
 
 
+class TestAwaitedCompletion:
+    @pytest.mark.asyncio
+    async def test_waits_for_queued_card_creation_before_success(self) -> None:
+        ctrl = _setup_ctrl()
+        session = CardSession("msg_wait", "chat", asyncio.get_running_loop())
+        ctrl._sessions["msg_wait"] = session
+        ready = asyncio.Event()
+
+        async def finish_create() -> None:
+            await ready.wait()
+            session.card_id = "card_wait"
+            session.card_msg_id = "card_msg_wait"
+            session.state = STREAMING
+
+        session.create_task = asyncio.create_task(finish_create())
+
+        with patch.object(ctrl, "_complete_session_wait", new_callable=AsyncMock, return_value=True) as complete:
+            waiter = asyncio.create_task(ctrl.on_completed_wait(message_id="msg_wait", answer="ok"))
+            await asyncio.sleep(0.01)
+            assert not waiter.done()
+
+            ready.set()
+
+            assert await waiter is True
+            complete.assert_awaited_once_with(session)
+
+    @pytest.mark.asyncio
+    async def test_card_creation_timeout_yields_to_gateway(self) -> None:
+        ctrl = _setup_ctrl()
+        session = CardSession("msg_timeout", "chat", asyncio.get_running_loop())
+        ctrl._sessions["msg_timeout"] = session
+        session.create_task = asyncio.create_task(asyncio.sleep(60))
+
+        with patch("hermes_lark_streaming.controller._CARD_CREATION_WAIT_SEC", 0.01):
+            assert await ctrl.on_completed_wait(message_id="msg_timeout", answer="ok") is False
+
+        assert session.state == FAILED
+        assert "msg_timeout" not in ctrl._sessions
+
+    @pytest.mark.asyncio
+    async def test_finalization_failure_yields_to_gateway(self) -> None:
+        ctrl = _setup_ctrl()
+        session = CardSession("msg_fail", "chat", asyncio.get_running_loop())
+        session.state = STREAMING
+        session.card_id = "card_fail"
+        session.card_msg_id = "card_msg_fail"
+        ctrl._sessions["msg_fail"] = session
+
+        with patch.object(ctrl, "_complete_session_wait", new_callable=AsyncMock, return_value=False):
+            assert await ctrl.on_completed_wait(message_id="msg_fail", answer="ok") is False
+
+    @pytest.mark.asyncio
+    async def test_linear_short_reply_adds_final_answer_segment(self) -> None:
+        ctrl = _setup_ctrl(linear=True)
+        session = CardSession("msg_linear", "chat", asyncio.get_running_loop())
+        session.state = STREAMING
+        session.linear = True
+        session.linear_state = LinearState()
+        session.card_id = "card_linear"
+        session.card_msg_id = "card_msg_linear"
+        ctrl._sessions["msg_linear"] = session
+
+        with patch.object(ctrl, "_complete_session_wait", new_callable=AsyncMock, return_value=True):
+            assert await ctrl.on_completed_wait(message_id="msg_linear", answer="short") is True
+
+        assert len(session.linear_state.segments) == 1
+        assert session.linear_state.segments[0].type == "answer"
+        assert session.linear_state.segments[0].text == "short"
+
+
 @pytest.mark.asyncio
 async def test_create_card_replies_to_anchor_id() -> None:
     ctrl = _setup_ctrl()
@@ -261,7 +331,10 @@ class TestLinearDispatch:
         session.state = STREAMING
         session.card_id = "card_123"
         ctrl._sessions["msg_c"] = session
-        with patch.object(ctrl, "_do_linear_complete", new_callable=AsyncMock):
+        with (
+            patch.object(ctrl, "_do_linear_complete", new_callable=AsyncMock),
+            patch.object(ctrl, "_fire_and_forget", side_effect=lambda coro, loop: coro.close()),
+        ):
             ctrl.on_completed(message_id="msg_c")
         assert session.flush._completed
 

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -169,7 +169,8 @@ class TestApplyRemove:
         assert "_lark_next_message_id = getattr(pending_event, 'message_id', None) or next_message_id" in content
         assert "new_message_id=_lark_next_message_id" in content
         assert "anchor_id=_lark_next_anchor_id" in content
-        assert "on_message_completed(" in content
+        assert "on_message_completed_wait(" in content
+        assert "_lark_card_sent = await on_message_completed_wait(" in content
         assert "message_id=event.message_id" in content
         assert "on_answer_delta(message_id=event_message_id" in content
         assert "on_thinking_delta(message_id=event_message_id" in content


### PR DESCRIPTION
- Await queued CardKit creation before marking completion as sent
- Yield to gateway text fallback when card creation or finalization fails
- Preserve legacy sync completion hook for existing installs
- Closes #32