### PR TITLE
fix: suppress redundant result block for Clarify tool

### DIFF
--- a/hermes_lark_streaming/tooluse.py
+++ b/hermes_lark_streaming/tooluse.py
@@ -148,6 +148,7 @@ _TOOL_DESCRIPTORS: list[dict[str, Any]] = [
     {"aliases": ["agent", "task", "spawn"], "icon": "robot_outlined", "title": "Run sub-agent"},
     {"aliases": ["check", "determine", "verify"], "icon": "list-check_outlined", "title": "Check"},
     {"aliases": ["summarize", "analyze", "prepare"], "icon": "report_outlined", "title": "Analyze"},
+    {"aliases": ["clarify"], "icon": "chat_outlined", "title": "Clarify", "no_result": True},
 ]
 
 


### PR DESCRIPTION
- Add clarify descriptor to `_TOOL_DESCRIPTORS` with `no_result: True`
- Prevents tool panel from rendering question text as raw code block
- Uses `chat_outlined` icon for visual consistency

Fixes #33