### PR TITLE
feat: add background task card delivery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,8 @@ gateway/run.py (Hermes)
        ├─ on_background_review_message → controller.defer_background_review()
        ├─ on_message_interrupted → controller.on_interrupted()
        ├─ on_message_completed_wait → controller.on_completed_wait()
-       └─ on_message_aborted    → controller.on_aborted()
+       ├─ on_message_aborted    → controller.on_aborted()
+       └─ on_background_deliver → controller.on_background_deliver()
 
 cron/scheduler.py (Hermes)
   └─ CronPatcher (patcher.py) injects on_cron_deliver into _deliver_result
@@ -75,7 +76,9 @@ FeishuClient (feishu.py) — lark-oapi SDK wrapper
 Card templates (cardkit/)
   ├─ builder.py — builds Feishu card JSON
   │   ├─ build_streaming_card_v2 — initial streaming CardKit v2 card
-  │   └─ build_complete_card — final card, renders segments in order
+  │   ├─ build_complete_card — final card, renders segments in order
+  │   ├─ build_cron_card — static card for cron delivery
+  │   └─ build_background_card — static card for background task delivery
   ├─ markdown.py — CardKit markdown normalization and table/image helpers
   └─ i18n.py — localized CardKit labels
 ```
@@ -91,4 +94,5 @@ Card templates (cardkit/)
 - Reasoning display depends on upstream providing `<thinking>`/`<thought>`/`<antthinking>` tags or `Reasoning:\n` prefix in text. Native API reasoning blocks (Anthropic extended thinking, DeepSeek reasoning_content) are available via `on_reasoning_delta` hook when `display.platforms.feishu.show_reasoning` is enabled.
 - CardKit v2.0 elements (collapsible_panel, streaming_mode) only work with `"schema": "2.0"` cards.
 - Streaming cards use a single CardKit card for the message lifecycle: elements are dynamically created in event arrival order. When CardKit creation fails, the plugin yields to the Hermes Gateway default reply.
+- The background deliver hook (`on_background_deliver`) is injected in `_run_background_task` after `adapter.extract_images(response)`. It uses `ReplyMessage` API with `event_message_id` as anchor, so cards land in the correct topic. On success, `text_content` is cleared to avoid duplicate text delivery, while images and media files continue through the original Hermes loops. On failure, the original Hermes delivery logic runs as fallback.
 - Commit messages: body should use bullet list format (unnumbered `- item`).

--- a/README.en.md
+++ b/README.en.md
@@ -25,6 +25,7 @@ Inspired by [openclaw-lark](https://github.com/larksuite/openclaw-lark) and [her
 - **Image resolution** — Detects markdown image references, downloads and re-uploads as Feishu img_key
 - **Abort handling** — Gracefully handles `/stop` command and message interrupts with aborted state card and automatic new session
 - **Cron card delivery** — Delivers scheduled job results as Feishu cards, preserving Markdown rendering
+- **Background task card delivery** — Delivers `/background` task results as cards, with topic-aware reply
 - **i18n** — Built-in Chinese/English bilingual card text (status, tool panel, thinking labels, etc.) that auto-switches based on Feishu client language
 
 ---
@@ -196,6 +197,7 @@ The plugin injects hook calls into `gateway/run.py` and `cron/scheduler.py` via 
 | `on_message_interrupted` | Before recursive `_run_agent` call | Handles message interrupts, terminates old card and creates new session |
 | `on_message_completed_wait` | Before `return response` | Waits for card creation/finalization before sending the completion card; yields to gateway text fallback on failure |
 | `on_cron_deliver` | After `delivered = False` in `_deliver_result` | Intercepts Feishu cron delivery, sends as card |
+| `on_background_deliver` | After `extract_images` in `_run_background_task` | Intercepts Feishu background task delivery, replies as card with topic-aware positioning |
 
 **Message flow:**
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 - **图片解析** — 自动识别 markdown 图片引用，下载上传后替换为飞书 img_key
 - **中断处理** — 处理 `/stop` 命令和消息打断，展示中断状态卡片并自动开启新会话
 - **Cron 卡片推送** — 定时任务结果以飞书卡片形式推送，保留 Markdown 渲染
+- **后台任务卡片推送** — `/background` 任务完成后以卡片形式推送，支持话题内回复
 - **多语言** — 卡片文本（状态、工具面板、思考标签等）内置中英双语，根据飞书客户端语言自动切换
 
 ---
@@ -196,6 +197,7 @@ $HERMES_PYTHON -m pip uninstall hermes-lark-streaming
 | `on_message_interrupted` | `_run_agent` 递归调用前 | 处理消息打断，终止旧卡片并创建新会话 |
 | `on_message_completed_wait` | `return response` 之前 | 等待卡片创建/收尾完成后发送终态卡片，失败时让网关走文本兜底 |
 | `on_cron_deliver` | `_deliver_result` 中 `delivered = False` 之后 | 拦截飞书 Cron 推送，以卡片形式发送 |
+| `on_background_deliver` | `_run_background_task` 中 `extract_images` 之后 | 拦截飞书后台任务推送，以卡片形式回复到原始消息（话题内正确定位） |
 
 **消息处理流程：**
 

--- a/hermes_lark_streaming/cardkit/builder.py
+++ b/hermes_lark_streaming/cardkit/builder.py
@@ -502,3 +502,23 @@ def build_cron_card(content: str) -> dict[str, Any]:
         if chunk.strip():
             card["body"]["elements"].append({"tag": "markdown", "content": chunk})
     return card
+
+
+def build_background_card(preview: str, content: str) -> dict[str, Any]:
+    """Background 任务完成推送卡片 — schema 2.0，header + markdown."""
+    card: dict[str, Any] = {
+        "schema": "2.0",
+        "config": {"wide_screen_mode": True, "locales": _LOCALES},
+        "header": {
+            "title": {"tag": "plain_text", "content": f"✅ Background: \"{preview}\""},
+        },
+        "body": {"elements": []},
+    }
+    body = content if content.strip() else "(No response generated)"
+    summary = body[:120].replace("\n", " ").replace("```", "").strip()
+    if summary:
+        card["config"]["summary"] = {"content": summary}
+    for chunk in _split_long_text(optimize_markdown_style(body)):
+        if chunk.strip():
+            card["body"]["elements"].append({"tag": "markdown", "content": chunk})
+    return card

--- a/hermes_lark_streaming/controller.py
+++ b/hermes_lark_streaming/controller.py
@@ -386,6 +386,30 @@ class StreamCardController(StreamingController):
             _logger.warning("cron card delivery failed", exc_info=True)
             return False
 
+    async def on_background_deliver(
+        self,
+        *,
+        chat_id: str,
+        preview: str,
+        content: str,
+        reply_to_message_id: str | None = None,
+    ) -> bool:
+        """Background 任务完成推送 — 包装为静态卡片发送，成功返回 True."""
+        if not self.enabled or not content or not chat_id:
+            return False
+        try:
+            await self._do_background_deliver(
+                chat_id,
+                preview,
+                content,
+                reply_to_message_id=reply_to_message_id,
+            )
+            _logger.info("background card delivered: chat=%s len=%d", chat_id[:12], len(content))
+            return True
+        except Exception:
+            _logger.warning("background card delivery failed", exc_info=True)
+            return False
+
     def defer_background_review(
         self,
         *,

--- a/hermes_lark_streaming/feishu.py
+++ b/hermes_lark_streaming/feishu.py
@@ -111,21 +111,41 @@ class FeishuClient:
     def _dumps(obj: Any) -> str:
         return json.dumps(obj, ensure_ascii=False)
 
-    async def send_card_to_chat(self, chat_id: str, card: dict[str, Any]) -> str:
+    async def send_card_to_chat(
+        self,
+        chat_id: str,
+        card: dict[str, Any],
+        *,
+        reply_to_message_id: str | None = None,
+    ) -> str:
         """发送独立卡片到聊天（非回复），返回 message_id."""
-        request = (
-            CreateMessageRequest.builder()
-            .receive_id_type("chat_id")
-            .request_body(
-                CreateMessageRequestBody.builder()
-                .receive_id(chat_id)
-                .msg_type("interactive")
-                .content(self._dumps(card))
+        if reply_to_message_id:
+            request = (
+                ReplyMessageRequest.builder()
+                .message_id(reply_to_message_id)
+                .request_body(
+                    ReplyMessageRequestBody.builder()
+                    .msg_type("interactive")
+                    .content(self._dumps(card))
+                    .build()
+                )
                 .build()
             )
-            .build()
-        )
-        resp = await self._client.im.v1.message.acreate(request)
+            resp = await self._client.im.v1.message.areply(request)
+        else:
+            request = (
+                CreateMessageRequest.builder()
+                .receive_id_type("chat_id")
+                .request_body(
+                    CreateMessageRequestBody.builder()
+                    .receive_id(chat_id)
+                    .msg_type("interactive")
+                    .content(self._dumps(card))
+                    .build()
+                )
+                .build()
+            )
+            resp = await self._client.im.v1.message.acreate(request)
         self._check(resp, "send_card_to_chat")
         if resp.data and resp.data.message_id:
             return str(resp.data.message_id)

--- a/hermes_lark_streaming/patch.py
+++ b/hermes_lark_streaming/patch.py
@@ -231,3 +231,26 @@ def on_cron_deliver(
     except Exception as exc:
         _logger.warning("on_cron_deliver error: %s", exc, exc_info=True)
         return False
+
+
+async def on_background_deliver(
+    *,
+    chat_id: str,
+    preview: str,
+    content: str,
+    reply_to_message_id: str | None = None,
+) -> bool:
+    """[注入点 11] background 任务完成推送 — 包装为飞书卡片发送."""
+    try:
+        ctrl = get_controller()
+        if not ctrl.enabled:
+            return False
+        return await ctrl.on_background_deliver(
+            chat_id=chat_id,
+            preview=preview,
+            content=content,
+            reply_to_message_id=reply_to_message_id,
+        )
+    except Exception as exc:
+        _logger.warning("on_background_deliver error: %s", exc, exc_info=True)
+        return False

--- a/hermes_lark_streaming/patcher.py
+++ b/hermes_lark_streaming/patcher.py
@@ -24,6 +24,7 @@ _HOOK_NAMES = [
     "BACKGROUND_REVIEW",
     "ABORT",
     "INTERRUPT",
+    "BG_DELIVER",
 ]
 MARKERS: list[tuple[str, str]] = [(f"# {PREFIX}_{n}_BEGIN", f"# {PREFIX}_{n}_END") for n in _HOOK_NAMES]
 
@@ -37,6 +38,7 @@ MK_REASONING, MK_REASONING_END = MARKERS[6]
 MK_BACKGROUND_REVIEW, MK_BACKGROUND_REVIEW_END = MARKERS[7]
 MK_ABORT, MK_ABORT_END = MARKERS[8]
 MK_INTERRUPT, MK_INTERRUPT_END = MARKERS[9]
+MK_BG_DELIVER, MK_BG_DELIVER_END = MARKERS[10]
 
 _BACKUP_SUFFIX = ".hermes_lark.bak"
 
@@ -277,6 +279,31 @@ def _cron_deliver_hook(indent: str) -> str:
     )
 
 
+def _bg_deliver_hook(indent: str) -> str:
+    return _make_hook(
+        indent,
+        MK_BG_DELIVER,
+        MK_BG_DELIVER_END,
+        [
+            "try:",
+            "    if source.platform.value.lower() in ('feishu', 'lark') and response:",
+            "        from hermes_lark_streaming.patch import on_background_deliver",
+            "        _bg_preview = prompt[:60] + ('...' if len(prompt) > 60 else '')",
+            "        if await on_background_deliver(",
+            "            chat_id=source.chat_id,",
+            "            preview=_bg_preview,",
+            "            content=text_content,",
+            "            reply_to_message_id=event_message_id,",
+            "        ):",
+            "            text_content = ''",
+            "            if not images and not media_files:",
+            "                return",
+            "except Exception:",
+            "    pass",
+        ],
+    )
+
+
 def _remove_block(content: str, begin: str, end: str) -> str:
     lines = content.splitlines(keepends=True)
     begin_idx = end_idx = None
@@ -364,6 +391,11 @@ class Patcher:
                 "Cannot find background_review_callback anchor in run.py — Hermes version may be incompatible"
             )
 
+        if "images, text_content = adapter.extract_images(response)" not in content:
+            raise PatcherError(
+                "Cannot find background deliver anchor in run.py — Hermes version may be incompatible"
+            )
+
         normalize_site = _find_handle_message_source_site(tree, content.splitlines(keepends=True))
         if normalize_site is None:
             raise PatcherError(
@@ -418,6 +450,7 @@ class Patcher:
             ("thinking", "thinking", _find_func_body(tree, lines, "_interim_assistant_cb")),
             ("reasoning", "reasoning", _find_reasoning_site(tree, lines)),
             ("background_review", "background_review", _find_background_review_site(tree, lines)),
+            ("bg_deliver", "bg_deliver", _find_bg_deliver_site(tree, lines)),
         ]
 
         sites: list[tuple[int, str, str]] = []
@@ -439,6 +472,7 @@ class Patcher:
             "thinking": _thinking_hook,
             "reasoning": _reasoning_hook,
             "background_review": _background_review_hook,
+            "bg_deliver": _bg_deliver_hook,
         }
         for idx, indent, fn_name in sites:
             hook = _HOOK_FNS[fn_name](indent)
@@ -539,6 +573,13 @@ def _find_reasoning_site(tree: ast.Module, lines: list[str]) -> tuple[int, str] 
 def _find_background_review_site(tree: ast.Module, lines: list[str]) -> tuple[int, str] | None:
     for i, line in enumerate(lines):
         if line.strip() == "agent.background_review_callback = _bg_review_send":
+            return i + 1, _safe_indent(lines, i)
+    return None
+
+
+def _find_bg_deliver_site(tree: ast.Module, lines: list[str]) -> tuple[int, str] | None:
+    for i, line in enumerate(lines):
+        if line.strip() == "images, text_content = adapter.extract_images(response)":
             return i + 1, _safe_indent(lines, i)
     return None
 

--- a/hermes_lark_streaming/streaming/controller.py
+++ b/hermes_lark_streaming/streaming/controller.py
@@ -7,7 +7,7 @@ import logging
 from collections.abc import Callable, Coroutine
 from typing import TYPE_CHECKING, Any
 
-from ..cardkit.builder import build_complete_card, build_cron_card, build_streaming_card_v2
+from ..cardkit.builder import build_background_card, build_complete_card, build_cron_card, build_streaming_card_v2
 from ..cardkit.markdown import (
     _downgrade_tables,
     optimize_markdown_style,
@@ -616,3 +616,20 @@ class StreamingController:
         assert self._client is not None
         card = build_cron_card(content)
         await self._client.send_card_to_chat(chat_id, card)
+
+    async def _do_background_deliver(
+        self,
+        chat_id: str,
+        preview: str,
+        content: str,
+        *,
+        reply_to_message_id: str | None = None,
+    ) -> None:
+        await self._ensure_init()
+        assert self._client is not None
+        card = build_background_card(preview, content)
+        await self._client.send_card_to_chat(
+            chat_id,
+            card,
+            reply_to_message_id=reply_to_message_id,
+        )

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1098,7 +1098,6 @@ class TestBackgroundDeliver:
         card = args[1]
         body = card["body"]["elements"][0]["content"]
         assert "Here\n\nDone" in body
-        assert "https://example.com/a.png" not in body
 
     @pytest.mark.asyncio
     async def test_returns_false_on_empty_cleaned_text(self) -> None:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1068,3 +1068,55 @@ class TestCronDeliver:
             assert result is False
         finally:
             loop.call_soon_threadsafe(loop.stop)
+
+
+class TestBackgroundDeliver:
+    @pytest.mark.asyncio
+    async def test_sends_cleaned_text_card(self) -> None:
+        ctrl = StreamCardController()
+        ctrl._cfg = MagicMock()
+        ctrl._cfg.enabled = True
+
+        mock_client = AsyncMock()
+        mock_client.send_card_to_chat.return_value = "msg_123"
+        ctrl._client = mock_client
+        ctrl._initialized = True
+
+        result = await ctrl.on_background_deliver(
+            chat_id="c1",
+            preview="prompt",
+            content="Here\n\nDone",
+            reply_to_message_id="om_1",
+        )
+
+        assert result is True
+        mock_client.upload_image.assert_not_called()
+        mock_client.send_card_to_chat.assert_awaited_once()
+        args, kwargs = mock_client.send_card_to_chat.call_args
+        assert args[0] == "c1"
+        assert kwargs["reply_to_message_id"] == "om_1"
+        card = args[1]
+        body = card["body"]["elements"][0]["content"]
+        assert "Here\n\nDone" in body
+        assert "https://example.com/a.png" not in body
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_empty_cleaned_text(self) -> None:
+        ctrl = StreamCardController()
+        ctrl._cfg = MagicMock()
+        ctrl._cfg.enabled = True
+
+        mock_client = AsyncMock()
+        mock_client.send_card_to_chat.return_value = "msg_123"
+        ctrl._client = mock_client
+        ctrl._initialized = True
+
+        result = await ctrl.on_background_deliver(
+            chat_id="c1",
+            preview="prompt",
+            content="",
+        )
+
+        assert result is False
+        mock_client.upload_image.assert_not_called()
+        mock_client.send_card_to_chat.assert_not_called()

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -175,6 +175,11 @@ class TestApplyRemove:
         assert "on_answer_delta(message_id=event_message_id" in content
         assert "on_thinking_delta(message_id=event_message_id" in content
         assert "on_reasoning_delta(message_id=event_message_id" in content
+        assert "on_background_deliver(" in content
+        assert "_bg_preview = prompt[:60] + ('...' if len(prompt) > 60 else '')" in content
+        assert "content=text_content" in content
+        assert "reply_to_message_id=event_message_id" in content
+        assert "if not images and not media_files:" in content
 
     def test_apply_idempotent(self, run_copy: Path) -> None:
         patcher = _patcher(run_copy)


### PR DESCRIPTION
- Inject `BG_DELIVER` hook into `_run_background_task` after `extract_images`
- Build static CardKit v2 card with preview header and markdown body
- Use `ReplyMessage` API with `event_message_id` to land card in correct topic
- Clear `text_content` after card sent, keep image/media loops as fallback
- Add `reply_to_message_id` support to `FeishuClient.send_card_to_chat`
- Add `build_background_card` builder and full async delivery chain
- Add tests for background card delivery and patcher hook injection

Closes #36