### PR TITLE
fix: harden CardKit fallback and transient retries

### DIFF
--- a/hermes_lark_streaming/controller.py
+++ b/hermes_lark_streaming/controller.py
@@ -145,7 +145,12 @@ class StreamCardController(StreamingController):
         """Return whether gateway should undo already_sent and deliver plain text."""
         if message_id not in self._text_fallback_needed:
             return False
+        session = self._sessions.get(message_id)
         self._text_fallback_needed.discard(message_id)
+        if session is not None:
+            self._text_fallback_needed.discard(session.message_id)
+            if session.anchor_id:
+                self._text_fallback_needed.discard(session.anchor_id)
         return True
 
     def on_thinking(self, *, message_id: str, text: str) -> bool:

--- a/hermes_lark_streaming/controller.py
+++ b/hermes_lark_streaming/controller.py
@@ -35,6 +35,7 @@ class StreamCardController(StreamingController):
         self._init_lock = asyncio.Lock()
         self._session_ttl = self._cfg.card_duration_sec
         self._loop: asyncio.AbstractEventLoop | None = None
+        self._text_fallback_needed: set[str] = set()
 
     @property
     def enabled(self) -> bool:
@@ -134,6 +135,18 @@ class StreamCardController(StreamingController):
         _logger.info("session created: msg=%s chat=%s anchor=%s", message_id[:12], chat_id[:12], (anchor_id or "")[:12])
 
         session.create_task = self._fire_and_forget(self._do_create_card(session), loop)
+
+    def _mark_text_fallback_needed(self, session: CardSession) -> None:
+        self._text_fallback_needed.add(session.message_id)
+        if session.anchor_id:
+            self._text_fallback_needed.add(session.anchor_id)
+
+    def consume_text_fallback(self, message_id: str) -> bool:
+        """Return whether gateway should undo already_sent and deliver plain text."""
+        if message_id not in self._text_fallback_needed:
+            return False
+        self._text_fallback_needed.discard(message_id)
+        return True
 
     def on_thinking(self, *, message_id: str, text: str) -> bool:
         """思考内容增量."""
@@ -292,6 +305,7 @@ class StreamCardController(StreamingController):
         # 卡片创建失败 → 交回 gateway 正常回复
         if session.state == SessionState.FAILED:
             _logger.info("on_completed: msg=%s state=FAILED, yielding to gateway", message_id[:12])
+            self._mark_text_fallback_needed(session)
             self._cleanup(message_id)
             return False
 
@@ -334,16 +348,19 @@ class StreamCardController(StreamingController):
 
         if not await self._wait_for_card_creation(session):
             _logger.info("on_completed_wait: msg=%s card creation not ready, yielding to gateway", message_id[:12])
+            self._mark_text_fallback_needed(session)
             self._cleanup(message_id)
             return False
 
         if session.state == SessionState.FAILED:
             _logger.info("on_completed_wait: msg=%s state=FAILED, yielding to gateway", message_id[:12])
+            self._mark_text_fallback_needed(session)
             self._cleanup(message_id)
             return False
 
         if not session.has_card:
             _logger.info("on_completed_wait: msg=%s has no card, yielding to gateway", message_id[:12])
+            self._mark_text_fallback_needed(session)
             self._cleanup(message_id)
             return False
 

--- a/hermes_lark_streaming/controller.py
+++ b/hermes_lark_streaming/controller.py
@@ -36,6 +36,7 @@ class StreamCardController(StreamingController):
         self._session_ttl = self._cfg.card_duration_sec
         self._loop: asyncio.AbstractEventLoop | None = None
         self._text_fallback_needed: set[str] = set()
+        self._text_fallback_aliases: dict[str, set[str]] = {}
 
     @property
     def enabled(self) -> bool:
@@ -137,20 +138,21 @@ class StreamCardController(StreamingController):
         session.create_task = self._fire_and_forget(self._do_create_card(session), loop)
 
     def _mark_text_fallback_needed(self, session: CardSession) -> None:
-        self._text_fallback_needed.add(session.message_id)
+        keys = {session.message_id}
         if session.anchor_id:
-            self._text_fallback_needed.add(session.anchor_id)
+            keys.add(session.anchor_id)
+        self._text_fallback_needed.update(keys)
+        for key in keys:
+            self._text_fallback_aliases[key] = set(keys)
 
     def consume_text_fallback(self, message_id: str) -> bool:
         """Return whether gateway should undo already_sent and deliver plain text."""
         if message_id not in self._text_fallback_needed:
             return False
-        session = self._sessions.get(message_id)
-        self._text_fallback_needed.discard(message_id)
-        if session is not None:
-            self._text_fallback_needed.discard(session.message_id)
-            if session.anchor_id:
-                self._text_fallback_needed.discard(session.anchor_id)
+        keys = self._text_fallback_aliases.pop(message_id, {message_id})
+        for key in keys:
+            self._text_fallback_needed.discard(key)
+            self._text_fallback_aliases.pop(key, None)
         return True
 
     def on_thinking(self, *, message_id: str, text: str) -> bool:

--- a/hermes_lark_streaming/feishu.py
+++ b/hermes_lark_streaming/feishu.py
@@ -7,6 +7,7 @@ import io
 import json
 import logging
 import re
+import uuid
 from dataclasses import dataclass
 from typing import Any
 from urllib.error import URLError
@@ -147,6 +148,7 @@ class FeishuClient:
         reply_to_message_id: str | None = None,
     ) -> str:
         """发送独立卡片到聊天（非回复），返回 message_id."""
+        request_uuid = uuid.uuid4().hex
         if reply_to_message_id:
             request = (
                 ReplyMessageRequest.builder()
@@ -155,6 +157,7 @@ class FeishuClient:
                     ReplyMessageRequestBody.builder()
                     .msg_type("interactive")
                     .content(self._dumps(card))
+                    .uuid(request_uuid)
                     .build()
                 )
                 .build()
@@ -172,6 +175,7 @@ class FeishuClient:
                     .receive_id(chat_id)
                     .msg_type("interactive")
                     .content(self._dumps(card))
+                    .uuid(request_uuid)
                     .build()
                 )
                 .build()
@@ -186,6 +190,7 @@ class FeishuClient:
 
     async def reply_card_by_id(self, message_id: str, card_id: str) -> str:
         """通过 card_id 回复 CardKit 卡片消息，返回 message_id."""
+        request_uuid = uuid.uuid4().hex
         request = (
             ReplyMessageRequest.builder()
             .message_id(message_id)
@@ -193,6 +198,7 @@ class FeishuClient:
                 ReplyMessageRequestBody.builder()
                 .msg_type("interactive")
                 .content(self._dumps({"type": "card", "data": {"card_id": card_id}}))
+                .uuid(request_uuid)
                 .build()
             )
             .build()

--- a/hermes_lark_streaming/feishu.py
+++ b/hermes_lark_streaming/feishu.py
@@ -37,6 +37,9 @@ from lark_oapi.api.im.v1 import (
 
 _logger = logging.getLogger("hermes_lark_streaming")
 
+CARDKIT_GATEWAY_TIMEOUT = 2200
+_TRANSIENT_RETRY_DELAYS_SEC = (0.15, 0.5)
+
 
 def _sanitize_message(msg: str) -> str:
     """从错误消息中移除 token 和 secret."""
@@ -111,6 +114,31 @@ class FeishuClient:
     def _dumps(obj: Any) -> str:
         return json.dumps(obj, ensure_ascii=False)
 
+    async def _checked_call(self, operation: str, call: Any) -> Any:
+        """Run a Feishu SDK call and retry transient gateway timeouts."""
+        attempts = len(_TRANSIENT_RETRY_DELAYS_SEC) + 1
+        last_error: FeishuAPIError | None = None
+        for attempt in range(attempts):
+            resp = await call()
+            try:
+                self._check(resp, operation)
+                return resp
+            except FeishuAPIError as exc:
+                last_error = exc
+                if exc.code != CARDKIT_GATEWAY_TIMEOUT or attempt >= attempts - 1:
+                    raise
+                delay = _TRANSIENT_RETRY_DELAYS_SEC[attempt]
+                _logger.warning(
+                    "%s transient gateway timeout, retrying attempt=%d/%d delay=%.2fs",
+                    operation,
+                    attempt + 2,
+                    attempts,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+        assert last_error is not None
+        raise last_error
+
     async def send_card_to_chat(
         self,
         chat_id: str,
@@ -131,7 +159,10 @@ class FeishuClient:
                 )
                 .build()
             )
-            resp = await self._client.im.v1.message.areply(request)
+            resp = await self._checked_call(
+                "send_card_to_chat",
+                lambda: self._client.im.v1.message.areply(request),
+            )
         else:
             request = (
                 CreateMessageRequest.builder()
@@ -145,8 +176,10 @@ class FeishuClient:
                 )
                 .build()
             )
-            resp = await self._client.im.v1.message.acreate(request)
-        self._check(resp, "send_card_to_chat")
+            resp = await self._checked_call(
+                "send_card_to_chat",
+                lambda: self._client.im.v1.message.acreate(request),
+            )
         if resp.data and resp.data.message_id:
             return str(resp.data.message_id)
         raise FeishuAPIError("send_card_to_chat: response missing message_id")
@@ -164,8 +197,10 @@ class FeishuClient:
             )
             .build()
         )
-        resp = await self._client.im.v1.message.areply(request)
-        self._check(resp, "reply_card_by_id")
+        resp = await self._checked_call(
+            "reply_card_by_id",
+            lambda: self._client.im.v1.message.areply(request),
+        )
         if resp.data and resp.data.message_id:
             return str(resp.data.message_id)
         raise FeishuAPIError("reply_card_by_id: response missing message_id")
@@ -177,8 +212,10 @@ class FeishuClient:
             .request_body(CreateCardRequestBody.builder().type("card_json").data(self._dumps(card)).build())
             .build()
         )
-        resp = await self._client.cardkit.v1.card.acreate(request)
-        self._check(resp, "cardkit_create")
+        resp = await self._checked_call(
+            "cardkit_create",
+            lambda: self._client.cardkit.v1.card.acreate(request),
+        )
         if resp.data and resp.data.card_id:
             return str(resp.data.card_id)
         raise FeishuAPIError("cardkit_create: response missing card_id")

--- a/hermes_lark_streaming/patch.py
+++ b/hermes_lark_streaming/patch.py
@@ -140,6 +140,12 @@ async def on_message_completed_wait(
 
 
 @_safe_hook(default_return=False)
+def on_message_needs_text_fallback(*, ctrl: Any, message_id: str) -> bool:
+    """Return True once when CardKit failed and gateway must send plain text."""
+    return bool(ctrl.consume_text_fallback(message_id))
+
+
+@_safe_hook(default_return=False)
 def on_tool_updated(
     *,
     ctrl: Any,

--- a/hermes_lark_streaming/patcher.py
+++ b/hermes_lark_streaming/patcher.py
@@ -101,7 +101,7 @@ def _complete_hook(indent: str) -> str:
         MK_COMPLETE_END,
         [
             "try:",
-            "    from hermes_lark_streaming.patch import on_message_completed_wait",
+            "    from hermes_lark_streaming.patch import on_message_completed_wait, on_message_needs_text_fallback",
             "    _lark_card_sent = await on_message_completed_wait(",
             "        message_id=event.message_id,",
             "        answer=response,",
@@ -118,6 +118,8 @@ def _complete_hook(indent: str) -> str:
             "    )",
             "    if _lark_card_sent:",
             "        agent_result['already_sent'] = True",
+            "    elif on_message_needs_text_fallback(message_id=event.message_id):",
+            "        agent_result.pop('already_sent', None)",
             "except Exception:",
             "    pass",
         ],

--- a/hermes_lark_streaming/streaming/controller.py
+++ b/hermes_lark_streaming/streaming/controller.py
@@ -139,6 +139,8 @@ class StreamingController:
             )
         except FeishuAPIError:
             _logger.info("CardKit create failed, yielding to gateway", exc_info=True)
+            if hasattr(self, "_mark_text_fallback_needed"):
+                self._mark_text_fallback_needed(session)
             session.mark_failed()
         except Exception:
             _logger.exception("_do_create_card failed")

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -58,6 +58,20 @@ def test_on_message_started_registers_anchor_alias_and_cleanup() -> None:
     assert "quoted" not in ctrl._sessions
 
 
+def test_consume_text_fallback_clears_anchor_alias() -> None:
+    ctrl = StreamCardController()
+    session = _make_session("msg")
+    session.anchor_id = "quoted"
+    ctrl._sessions["msg"] = session
+    ctrl._sessions["quoted"] = session
+    ctrl._text_fallback_needed.update({"msg", "quoted"})
+
+    assert ctrl.consume_text_fallback("quoted") is True
+
+    assert "msg" not in ctrl._text_fallback_needed
+    assert "quoted" not in ctrl._text_fallback_needed
+
+
 def test_on_interrupted_uses_new_message_id_and_anchor_alias() -> None:
     ctrl = StreamCardController()
     _enable(ctrl)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -394,6 +394,8 @@ class TestDoCreateCard:
         assert session.segment_state is not None
         assert session.state == SessionState.FAILED
         assert await ctrl.on_completed_wait(message_id="msg_fallback", answer="plain") is False
+        assert ctrl.consume_text_fallback("msg_fallback") is True
+        assert ctrl.consume_text_fallback("msg_fallback") is False
         assert "msg_fallback" not in ctrl._sessions
 
     @pytest.mark.asyncio

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -64,12 +64,14 @@ def test_consume_text_fallback_clears_anchor_alias() -> None:
     session.anchor_id = "quoted"
     ctrl._sessions["msg"] = session
     ctrl._sessions["quoted"] = session
-    ctrl._text_fallback_needed.update({"msg", "quoted"})
+    ctrl._mark_text_fallback_needed(session)
+    ctrl._cleanup("msg")
 
-    assert ctrl.consume_text_fallback("quoted") is True
+    assert ctrl.consume_text_fallback("msg") is True
 
     assert "msg" not in ctrl._text_fallback_needed
     assert "quoted" not in ctrl._text_fallback_needed
+    assert ctrl._text_fallback_aliases == {}
 
 
 def test_on_interrupted_uses_new_message_id_and_anchor_alias() -> None:

--- a/tests/test_feishu.py
+++ b/tests/test_feishu.py
@@ -31,7 +31,10 @@ def _client_with(**methods: AsyncMock) -> FeishuClient:
         ),
         im=SimpleNamespace(
             v1=SimpleNamespace(
-                message=SimpleNamespace(areply=methods.get("reply", AsyncMock())),
+                message=SimpleNamespace(
+                    acreate=methods.get("create_message", AsyncMock()),
+                    areply=methods.get("reply", AsyncMock()),
+                ),
             ),
         ),
     )
@@ -64,6 +67,46 @@ async def test_reply_card_by_id_retries_gateway_timeout_once() -> None:
 
     assert await client.reply_card_by_id("anchor", "card") == "msg-ok"
     assert reply.await_count == 2
+    first_request = reply.await_args_list[0].args[0]
+    second_request = reply.await_args_list[1].args[0]
+    assert first_request.request_body.uuid
+    assert second_request.request_body.uuid == first_request.request_body.uuid
+
+
+@pytest.mark.asyncio
+async def test_send_card_to_chat_reuses_uuid_across_retries() -> None:
+    create = AsyncMock(
+        side_effect=[
+            _Resp(ok=False, code=2200, msg="Gateway timeout. Please try again later."),
+            _Resp(ok=True, data=SimpleNamespace(message_id="msg-ok")),
+        ]
+    )
+    client = _client_with(create_message=create)
+
+    assert await client.send_card_to_chat("chat", {"schema": "2.0"}) == "msg-ok"
+    assert create.await_count == 2
+    first_request = create.await_args_list[0].args[0]
+    second_request = create.await_args_list[1].args[0]
+    assert first_request.request_body.uuid
+    assert second_request.request_body.uuid == first_request.request_body.uuid
+
+
+@pytest.mark.asyncio
+async def test_send_card_reply_reuses_uuid_across_retries() -> None:
+    reply = AsyncMock(
+        side_effect=[
+            _Resp(ok=False, code=2200, msg="Gateway timeout. Please try again later."),
+            _Resp(ok=True, data=SimpleNamespace(message_id="msg-ok")),
+        ]
+    )
+    client = _client_with(reply=reply)
+
+    assert await client.send_card_to_chat("chat", {"schema": "2.0"}, reply_to_message_id="anchor") == "msg-ok"
+    assert reply.await_count == 2
+    first_request = reply.await_args_list[0].args[0]
+    second_request = reply.await_args_list[1].args[0]
+    assert first_request.request_body.uuid
+    assert second_request.request_body.uuid == first_request.request_body.uuid
 
 
 @pytest.mark.asyncio

--- a/tests/test_feishu.py
+++ b/tests/test_feishu.py
@@ -1,0 +1,77 @@
+"""Feishu client transient-error behavior."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from hermes_lark_streaming.feishu import FeishuAPIError, FeishuClient
+
+
+class _Resp:
+    def __init__(self, *, ok: bool, code: int = 0, msg: str = "", data: object | None = None) -> None:
+        self._ok = ok
+        self.code = code
+        self.msg = msg
+        self.data = data
+
+    def success(self) -> bool:
+        return self._ok
+
+
+def _client_with(**methods: AsyncMock) -> FeishuClient:
+    client = FeishuClient.__new__(FeishuClient)
+    client._client = SimpleNamespace(  # type: ignore[attr-defined]
+        cardkit=SimpleNamespace(
+            v1=SimpleNamespace(
+                card=SimpleNamespace(acreate=methods.get("card_create", AsyncMock())),
+            ),
+        ),
+        im=SimpleNamespace(
+            v1=SimpleNamespace(
+                message=SimpleNamespace(areply=methods.get("reply", AsyncMock())),
+            ),
+        ),
+    )
+    return client
+
+
+@pytest.mark.asyncio
+async def test_cardkit_create_retries_gateway_timeout_once() -> None:
+    create = AsyncMock(
+        side_effect=[
+            _Resp(ok=False, code=2200, msg="Gateway timeout. Please try again later."),
+            _Resp(ok=True, data=SimpleNamespace(card_id="card-ok")),
+        ]
+    )
+    client = _client_with(card_create=create)
+
+    assert await client.cardkit_create({"schema": "2.0"}) == "card-ok"
+    assert create.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_reply_card_by_id_retries_gateway_timeout_once() -> None:
+    reply = AsyncMock(
+        side_effect=[
+            _Resp(ok=False, code=2200, msg="Gateway timeout. Please try again later."),
+            _Resp(ok=True, data=SimpleNamespace(message_id="msg-ok")),
+        ]
+    )
+    client = _client_with(reply=reply)
+
+    assert await client.reply_card_by_id("anchor", "card") == "msg-ok"
+    assert reply.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_cardkit_create_does_not_retry_non_transient_error() -> None:
+    create = AsyncMock(side_effect=[_Resp(ok=False, code=230099, msg="content failed")])
+    client = _client_with(card_create=create)
+
+    with pytest.raises(FeishuAPIError):
+        await client.cardkit_create({"schema": "2.0"})
+
+    assert create.await_count == 1

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -170,7 +170,9 @@ class TestApplyRemove:
         assert "new_message_id=_lark_next_message_id" in content
         assert "anchor_id=_lark_next_anchor_id" in content
         assert "on_message_completed_wait(" in content
+        assert "on_message_needs_text_fallback" in content
         assert "_lark_card_sent = await on_message_completed_wait(" in content
+        assert "agent_result.pop('already_sent', None)" in content
         assert "message_id=event.message_id" in content
         assert "on_answer_delta(message_id=event_message_id" in content
         assert "on_thinking_delta(message_id=event_message_id" in content


### PR DESCRIPTION
## Summary
- Add checked Feishu/Lark API calls that retry transient gateway timeout errors.
- Preserve Hermes fallback behavior when CardKit card creation fails before a card id exists.
- Extend controller, patcher, and Feishu tests for fallback and retry paths.

## Test Plan
- `~/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/test_controller.py tests/test_flush.py tests/test_patcher.py tests/test_feishu.py -q`

## Notes
- This keeps upstream `reply_to_message_id` support and adds retry/fallback hardening needed for production Feishu CardKit delivery.
