### PR TITLE
fix: reset segment created state after card split

### DIFF
--- a/hermes_lark_streaming/streaming/controller.py
+++ b/hermes_lark_streaming/streaming/controller.py
@@ -495,6 +495,8 @@ class StreamingController:
         session.sequence = 1
         session.split_disabled = False
         session.split_index = split_idx
+        for seg in segments[split_idx:]:
+            seg.created = False
         _logger.info(
             "CardKit split: msg=%s sealed=%d new_card=%s",
             session.message_id[:12],


### PR DESCRIPTION
## Problem

`cardkit_batch_update` fails with `300313: not find elementID` after a tool segment rollover triggers a card split. The affected element IDs (e.g. `tools_6`) exist in the old card but not in the newly created card, yet the segment objects still carry `created = True` from the old card — causing the flush loop to issue UPDATE actions instead of ADD actions.

Fixes #43

## Root Cause

`_do_split_card()` creates a fresh empty card and sets `session.split_index = split_idx`. Segments at and after `split_idx` retain `created = True` from the old card. In subsequent flushes, the loop treats them as existing elements (UPDATE path via `build_tool_update_action`), but the new card has none of them — Feishu returns 300313.

Only the rollover split path (`_maybe_rollover_tool_segment` → `_do_split_card(index+1)`) leaves `created = True` segments after the split boundary. The two ADD-path split sites already have `created = False` segments after the boundary, so the fix is a no-op there.

## Changes

**controller.py** `_do_split_card` — reset `created` to `False` for all segments in the new card domain after switching cards:

```python
session.split_index = split_idx
for seg in segments[split_idx:]:
    seg.created = False
```

1 file, 2 lines added.

## Test Plan

- [x] `ruff check` — All checks passed
- [x] `mypy` — Success: no issues found in 21 source files
- [x] `pytest tests/ -q` — 370 passed