### PR TITLE
fix: account for pending elements in dirty tool segment rollover check

### DIFF
--- a/hermes_lark_streaming/streaming/controller.py
+++ b/hermes_lark_streaming/streaming/controller.py
@@ -163,7 +163,7 @@ class StreamingController:
         new_el_ids: set[str] = set()
         new_el_estimates: dict[str, int] = {}
         updated_tool_segs: list[Segment] = []
-        new_el_total = 0
+        new_el_total = 0  # 同一 flush 内新 segment 估计 + dirty segment 增量的累计
 
         for i, seg in enumerate(segments):
             if i < session.split_index:
@@ -247,6 +247,7 @@ class StreamingController:
                     new_el_ids=new_el_ids,
                     new_el_estimates=new_el_estimates,
                     updated_tool_segs=updated_tool_segs,
+                    pending_delta=new_el_total,
                 )
                 if rollover == "failed":
                     return
@@ -263,6 +264,7 @@ class StreamingController:
                 )
                 updated_tool_segs.append(seg)
                 new_el_estimates[seg.el_id] = estimate
+                new_el_total += estimate - seg.element_estimate
 
         if actions and not await self._do_batch_update(
             session, segments, actions, new_el_ids, new_el_estimates, updated_tool_segs,
@@ -384,6 +386,7 @@ class StreamingController:
         new_el_ids: set[str],
         new_el_estimates: dict[str, int],
         updated_tool_segs: list[Segment],
+        pending_delta: int = 0,
     ) -> str | None:
         """按 tool step 边界拆分过大的 dirty tool segment."""
         start = seg.tool_offset
@@ -392,13 +395,13 @@ class StreamingController:
         delta = estimate - seg.element_estimate
         if (
             delta <= 0
-            or session.element_count + delta + FOOTER_RESERVE <= ELEMENT_THRESHOLD
+            or session.element_count + pending_delta + delta + FOOTER_RESERVE <= ELEMENT_THRESHOLD
             or session.split_disabled
         ):
             return None
 
         split_offset = find_tool_split_offset(
-            base_count=session.element_count - seg.element_estimate,
+            base_count=session.element_count + pending_delta - seg.element_estimate,
             seg=seg,
             all_steps=all_steps,
         )

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -597,6 +597,49 @@ class TestDoFlush:
         assert session.segment_state.segments[1].created is True
 
     @pytest.mark.asyncio
+    async def test_tool_growth_counts_pending_new_segments_before_rollover(self) -> None:
+        """同一轮 flush 内，dirty tool 拆分判断要计入前面尚未落账的新 segment."""
+        ctrl = _setup_ctrl()
+        calls = _capture_split_calls(
+            ctrl,
+            cards=["card_tool_pending_next"],
+            messages=["msg_tool_pending_next"],
+        )
+
+        session = _make_session("msg_tool_pending_roll")
+        session.state = SessionState.STREAMING
+        session.card_id = "card_tool_pending_old"
+        session.card_msg_id = "msg_tool_pending_old"
+        session.element_count = 175
+        session.segment_state.on_answer_delta("pending answer")
+        session.tool_use.record_start("read", "file0")
+        session.segment_state.on_tool_event(1)
+        tool_seg = session.segment_state.segments[1]
+        tool_seg.created = True
+        tool_seg.element_estimate = estimate_segment_elements(tool_seg, session.tool_use.build_display_steps())
+
+        session.tool_use.record_start("read", "file1")
+        session.segment_state.on_tool_event(len(session.tool_use.build_display_steps()))
+        ctrl._sessions["msg_tool_pending_roll"] = session
+
+        await ctrl._do_flush(session)
+
+        assert calls == [
+            ("batch", "card_tool_pending_old"),
+            ("create", ""),
+            ("reply", ""),
+            ("close", "card_tool_pending_old"),
+            ("seal", "card_tool_pending_old"),
+            ("batch", "card_tool_pending_next"),
+        ]
+        assert session.card_id == "card_tool_pending_next"
+        assert session.split_index == 2
+        assert len(session.segment_state.segments) == 3
+        assert session.segment_state.segments[1].tool_end_offset == 1
+        assert session.segment_state.segments[2].tool_offset == 1
+        assert session.segment_state.segments[2].created is True
+
+    @pytest.mark.asyncio
     async def test_oversized_new_tool_segment_splits_across_multiple_cards(self) -> None:
         """单次 flush 内 tool steps 很多时，未创建的 tool segment 也会连续分片拆卡."""
         ctrl = _setup_ctrl()


### PR DESCRIPTION
## Problem

`_do_complete_card` seal phase can still trigger `300305 (element exceeds the limit)`. When multiple dirty tool segments grow simultaneously in the same flush (e.g., multiple tools returning detail/output at once), each threshold check uses the same uncommitted `session.element_count`, unaware of other segments' deltas. Each check passes ≤180 individually, but `_do_batch_update` accumulates all deltas, pushing `element_count` past `ELEMENT_THRESHOLD` with no split triggered.

Closes #45

## Root Cause

In the `_do_flush` loop:

- **New segments** track cumulative estimates via `new_el_total`, threshold check uses `element_count + new_el_total + estimated`
- **Dirty tool segments** call `_maybe_rollover_tool_segment`, which checks only `element_count + delta` — **neither `new_el_total` nor other dirty segments' deltas are included**

When multiple dirty tool segments each grow 20-30 elements in the same flush, every individual check passes ≤180, but the combined growth of 50-60 pushes `element_count` to 190+. If no subsequent flush triggers a split (message is about to complete), seal rebuilds a card exceeding the 200-element limit.

## Changes

**controller.py**

- `_do_flush`: accumulate dirty segment delta (`estimate - seg.element_estimate`) into `new_el_total`, so all subsequent threshold checks (both new and dirty segments) see the full pending element count
- `_maybe_rollover_tool_segment`: add `pending_delta` parameter (default 0), included in both the threshold check and `base_count` calculation

1 file changed, 3 lines added.

**test_controller.py**

- Add `test_tool_growth_counts_pending_new_segments_before_rollover`: verifies that dirty tool rollover accounts for preceding uncommitted new segment estimates

1 file changed, 43 lines added.

## Test Plan

- [x] `ruff check` — All checks passed
- [x] `mypy` — Success: no issues found in 21 source files
- [x] `pytest tests/ -q` — 371 passed