### PR TITLE
feat: add card style config — header, footer toggle, body/footer text_size

### DIFF
--- a/hermes_lark_streaming/cardkit/builder.py
+++ b/hermes_lark_streaming/cardkit/builder.py
@@ -54,14 +54,41 @@ def _collapsible_panel(
     }
 
 
-def _streaming_element(content: str = "", *, element_id: str = STREAMING_ELEMENT_ID) -> dict:
+def _streaming_element(
+    content: str = "",
+    *,
+    element_id: str = STREAMING_ELEMENT_ID,
+    text_size: str = "normal_v2",
+) -> dict:
     return {
         "tag": "markdown",
         "content": content,
         "text_align": "left",
-        "text_size": "normal_v2",
+        "text_size": text_size,
         "margin": "0px 0px 0px 0px",
         "element_id": element_id,
+    }
+
+
+_HEADER_STATES: dict[str, dict[str, str]] = {
+    "streaming": {"template": "blue", "i18n_key": "processing_prefix"},
+    "completed": {"template": "green", "i18n_key": "status_completed"},
+    "error": {"template": "red", "i18n_key": "status_error"},
+    "stopped": {"template": "red", "i18n_key": "status_stopped"},
+}
+
+
+def _build_header(status: str) -> dict[str, Any]:
+    """构建卡片级 header — 流式蓝 / 完成绿 / 停止红."""
+    cfg = _HEADER_STATES.get(status, _HEADER_STATES["completed"])
+    en_text, zh_text = _T[cfg["i18n_key"]]
+    return {
+        "title": {
+            "tag": "plain_text",
+            "content": en_text,
+            "i18n_content": _i18n(en_text, zh_text),
+        },
+        "template": cfg["template"],
     }
 
 
@@ -256,6 +283,7 @@ def _build_footer_elements(
     is_aborted: bool = False,
     fields: list[list[str]] | None = None,
     show_label: bool = False,
+    text_size: str = "notation",
 ) -> list[dict]:
     if fields is None:
         fields = [["status", "elapsed", "context", "model"]]
@@ -291,7 +319,7 @@ def _build_footer_elements(
             "tag": "markdown",
             "content": en_content,
             "i18n_content": _i18n(en_content, zh_content),
-            "text_size": "notation",
+            "text_size": text_size,
         },
     ]
 
@@ -380,6 +408,8 @@ def build_streaming_card_v2(
     show_tool_use: bool = True,
     show_reasoning: bool = False,
     show_streaming_element: bool = True,
+    header_enabled: bool = False,
+    text_size: str = "normal_v2",
 ) -> dict[str, Any]:
     """CardKit 2.0 流式占位卡片 — 含工具面板 + streaming + loading 元素."""
     elements: list[dict] = []
@@ -396,10 +426,10 @@ def build_streaming_card_v2(
             elements.append(build_streaming_tool_use_pending_panel())
 
     if show_streaming_element:
-        elements.append(_streaming_element())
+        elements.append(_streaming_element(text_size=text_size))
     elements.append(_loading_element())
 
-    return {
+    card = {
         "schema": "2.0",
         "config": {
             "streaming_mode": True,
@@ -416,6 +446,9 @@ def build_streaming_card_v2(
         },
         "body": {"elements": elements},
     }
+    if header_enabled:
+        card["header"] = _build_header("streaming")
+    return card
 
 
 def build_complete_card(
@@ -427,7 +460,11 @@ def build_complete_card(
     is_aborted: bool = False,
     footer_fields: list[list[str]] | None = None,
     footer_show_label: bool = True,
+    footer_enabled: bool = True,
+    footer_text_size: str = "notation",
     panel_expanded: bool = False,
+    header_enabled: bool = False,
+    body_text_size: str = "normal_v2",
 ) -> dict[str, Any]:
     """完成态流式卡片 — 按 segments 顺序渲染."""
     elements: list[dict] = []
@@ -450,20 +487,22 @@ def build_complete_card(
             has_answer = True
             content = _downgrade_tables(optimize_markdown_style(seg.text))
             for chunk in _split_long_text(content):
-                elements.append({"tag": "markdown", "content": chunk})
+                elements.append({"tag": "markdown", "content": chunk, "text_size": body_text_size})
 
     if not has_answer:
-        elements.append({"tag": "markdown", "content": _T["done"][0]})
+        elements.append({"tag": "markdown", "content": _T["done"][0], "text_size": body_text_size})
 
-    elements.extend(
-        _build_footer_elements(
-            footer_data,
-            is_error,
-            is_aborted,
-            fields=footer_fields,
-            show_label=footer_show_label,
+    if footer_enabled:
+        elements.extend(
+            _build_footer_elements(
+                footer_data,
+                is_error,
+                is_aborted,
+                fields=footer_fields,
+                show_label=footer_show_label,
+                text_size=footer_text_size,
+            )
         )
-    )
 
     summary_text = ""
     for seg in reversed(segments):
@@ -483,6 +522,9 @@ def build_complete_card(
     if summary:
         card["config"]["summary"] = {"content": summary}
     card["body"] = {"elements": elements}
+    if header_enabled:
+        header_status = "error" if is_error else "stopped" if is_aborted else "completed"
+        card["header"] = _build_header(header_status)
     return card
 
 

--- a/hermes_lark_streaming/config.py
+++ b/hermes_lark_streaming/config.py
@@ -63,6 +63,42 @@ class Config:
         return int(self._streaming_sec().get("card_ttl_sec", 600))
 
     @property
+    def header_enabled(self) -> bool:
+        """流式卡片和完成态卡片是否显示 header."""
+        sec = self._streaming_sec()
+        header = sec.get("header", {})
+        if not isinstance(header, dict):
+            return False
+        return bool(header.get("enabled", False))
+
+    @property
+    def footer_enabled(self) -> bool:
+        """完成态卡片是否显示 footer."""
+        sec = self._streaming_sec()
+        footer = sec.get("footer", {})
+        if not isinstance(footer, dict):
+            return True
+        return bool(footer.get("enabled", True))
+
+    @property
+    def body_text_size(self) -> str:
+        """Body answer markdown 的文字大小."""
+        sec = self._streaming_sec()
+        body = sec.get("body", {})
+        if not isinstance(body, dict):
+            return "normal_v2"
+        return str(body.get("text_size", "normal_v2")) or "normal_v2"
+
+    @property
+    def footer_text_size(self) -> str:
+        """Footer markdown 的文字大小."""
+        sec = self._streaming_sec()
+        footer = sec.get("footer", {})
+        if not isinstance(footer, dict):
+            return "notation"
+        return str(footer.get("text_size", "notation")) or "notation"
+
+    @property
     def footer_fields(self) -> list[list[str]]:
         """Footer 字段布局（二维数组）."""
         sec = self._streaming_sec()

--- a/hermes_lark_streaming/streaming/controller.py
+++ b/hermes_lark_streaming/streaming/controller.py
@@ -111,6 +111,8 @@ class StreamingController:
                 show_tool_use=False,
                 show_reasoning=False,
                 show_streaming_element=False,
+                header_enabled=self._cfg.header_enabled,
+                text_size=self._cfg.body_text_size,
             )
             card_id = await self._client.cardkit_create(card)
             card_msg_id = await self._client.reply_card_by_id(
@@ -471,7 +473,10 @@ class StreamingController:
             all_tool_steps=all_steps,
             footer_fields=[],
             footer_show_label=False,
+            footer_enabled=False,
             panel_expanded=self._cfg.panel_expanded,
+            header_enabled=False,
+            body_text_size=self._cfg.body_text_size,
         )
 
         try:
@@ -479,6 +484,8 @@ class StreamingController:
                 show_tool_use=False,
                 show_reasoning=False,
                 show_streaming_element=False,
+                header_enabled=self._cfg.header_enabled,
+                text_size=self._cfg.body_text_size,
             )
             new_card_id = await self._client.cardkit_create(card)
             new_msg_id = await self._client.reply_card_by_id(session.anchor_id or session.message_id, new_card_id)
@@ -568,7 +575,11 @@ class StreamingController:
             is_aborted=is_aborted,
             footer_fields=self._cfg.footer_fields,
             footer_show_label=self._cfg.footer_show_label,
+            footer_enabled=self._cfg.footer_enabled,
+            footer_text_size=self._cfg.footer_text_size,
             panel_expanded=self._cfg.panel_expanded,
+            header_enabled=self._cfg.header_enabled,
+            body_text_size=self._cfg.body_text_size,
         )
 
         streaming_closed = False

--- a/tests/test_cardkit.py
+++ b/tests/test_cardkit.py
@@ -7,6 +7,7 @@ from hermes_lark_streaming.cardkit.builder import (
     REASONING_TEXT_ELEMENT_ID,
     TOOL_PANEL_ELEMENT_ID,
     _build_footer_elements,
+    _build_header,
     _build_reasoning_panel,
     _build_tool_panel,
     _compact,
@@ -528,3 +529,114 @@ class TestBuildCronCard:
         content = "| A | B |\n|---|---|\n| 1 | 2 |"
         card = build_cron_card(content)
         assert "| A | B |" in card["body"]["elements"][0]["content"]
+
+
+# --- Header ---
+
+
+class TestBuildHeader:
+    def test_streaming_blue(self) -> None:
+        header = _build_header("streaming")
+        assert header is not None
+        assert header["template"] == "blue"
+        assert "Processing" in header["title"]["content"]
+
+    def test_completed_green(self) -> None:
+        header = _build_header("completed")
+        assert header is not None
+        assert header["template"] == "green"
+        assert "Completed" in header["title"]["content"]
+
+    def test_error_red(self) -> None:
+        header = _build_header("error")
+        assert header is not None
+        assert header["template"] == "red"
+        assert "Error" in header["title"]["content"]
+
+    def test_stopped_red(self) -> None:
+        header = _build_header("stopped")
+        assert header is not None
+        assert header["template"] == "red"
+        assert "Stopped" in header["title"]["content"]
+
+    def test_title_has_i18n(self) -> None:
+        header = _build_header("streaming")
+        assert "i18n_content" in header["title"]
+        assert "zh_cn" in header["title"]["i18n_content"]
+        assert "en_us" in header["title"]["i18n_content"]
+
+    def test_unknown_status_falls_back_to_completed(self) -> None:
+        header = _build_header("unknown")
+        assert header is not None
+        assert header["template"] == "green"
+        assert "Completed" in header["title"]["content"]
+
+
+class TestStreamingCardHeader:
+    def test_header_absent_by_default(self) -> None:
+        card = build_streaming_card_v2()
+        assert "header" not in card
+
+    def test_header_present_when_enabled(self) -> None:
+        card = build_streaming_card_v2(header_enabled=True)
+        assert "header" in card
+        assert card["header"]["template"] == "blue"
+
+
+class TestCompleteCardHeader:
+    def test_completed_has_green_header(self) -> None:
+        card = build_complete_card(
+            segments=[_seg("answer", "hi")],
+            all_tool_steps=[],
+            header_enabled=True,
+        )
+        assert "header" in card
+        assert card["header"]["template"] == "green"
+
+    def test_aborted_has_red_header(self) -> None:
+        card = build_complete_card(
+            segments=[_seg("answer", "hi")],
+            all_tool_steps=[],
+            is_aborted=True,
+            header_enabled=True,
+        )
+        assert "header" in card
+        assert card["header"]["template"] == "red"
+
+    def test_error_has_red_header(self) -> None:
+        card = build_complete_card(
+            segments=[_seg("answer", "hi")],
+            all_tool_steps=[],
+            is_error=True,
+            header_enabled=True,
+        )
+        assert "header" in card
+        assert card["header"]["template"] == "red"
+        assert "Error" in card["header"]["title"]["content"]
+
+    def test_header_disabled(self) -> None:
+        card = build_complete_card(
+            segments=[_seg("answer", "hi")],
+            all_tool_steps=[],
+            header_enabled=False,
+        )
+        assert "header" not in card
+
+
+class TestCompleteCardFooter:
+    def test_footer_present_by_default(self) -> None:
+        card = build_complete_card(
+            segments=[_seg("answer", "hi")],
+            all_tool_steps=[],
+        )
+        tags = [e.get("tag") for e in card["body"]["elements"]]
+        assert "hr" in tags
+
+    def test_footer_disabled(self) -> None:
+        card = build_complete_card(
+            segments=[_seg("answer", "hi")],
+            all_tool_steps=[],
+            footer_enabled=False,
+        )
+        tags = [e.get("tag") for e in card["body"]["elements"]]
+        assert "hr" not in tags

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -76,6 +76,58 @@ class TestFooterFields:
         assert cfg.footer_fields == [["status", "elapsed", "context", "model"]]
 
 
+class TestHeaderEnabled:
+    def test_enabled_true(self) -> None:
+        cfg = _make_config({"streaming": {"header": {"enabled": True}}})
+        assert cfg.header_enabled is True
+
+    def test_enabled_false(self) -> None:
+        cfg = _make_config({"streaming": {"header": {"enabled": False}}})
+        assert cfg.header_enabled is False
+
+    def test_missing_enabled_key_defaults_false(self) -> None:
+        cfg = _make_config({"streaming": {"header": {}}})
+        assert cfg.header_enabled is False
+
+    def test_missing_header_section_defaults_false(self) -> None:
+        cfg = _make_config({"streaming": {}})
+        assert cfg.header_enabled is False
+
+    def test_no_streaming_section_defaults_false(self) -> None:
+        cfg = _make_config({})
+        assert cfg.header_enabled is False
+
+    def test_header_not_dict_defaults_false(self) -> None:
+        cfg = _make_config({"streaming": {"header": "invalid"}})
+        assert cfg.header_enabled is False
+
+
+class TestFooterEnabled:
+    def test_enabled_true(self) -> None:
+        cfg = _make_config({"streaming": {"footer": {"enabled": True}}})
+        assert cfg.footer_enabled is True
+
+    def test_enabled_false(self) -> None:
+        cfg = _make_config({"streaming": {"footer": {"enabled": False}}})
+        assert cfg.footer_enabled is False
+
+    def test_missing_enabled_key_defaults_true(self) -> None:
+        cfg = _make_config({"streaming": {"footer": {}}})
+        assert cfg.footer_enabled is True
+
+    def test_no_footer_section_defaults_true(self) -> None:
+        cfg = _make_config({"streaming": {}})
+        assert cfg.footer_enabled is True
+
+    def test_no_streaming_section_defaults_true(self) -> None:
+        cfg = _make_config({})
+        assert cfg.footer_enabled is True
+
+    def test_footer_not_dict_defaults_true(self) -> None:
+        cfg = _make_config({"streaming": {"footer": "invalid"}})
+        assert cfg.footer_enabled is True
+
+
 class TestFooterShowLabel:
     def test_true(self) -> None:
         cfg = _make_config({"streaming": {"footer": {"show_label": True}}})


### PR DESCRIPTION
## Problem

Streaming cards do not support style customization. Users cannot control card header visibility, footer display, or text sizes.

Closes #18

## Changes

**config.py**
- `header_enabled`: reads `streaming.header.enabled`, defaults to `false` (opt-in)
- `footer_enabled`: reads `streaming.footer.enabled`, defaults to `true` (backward-compatible)
- `body_text_size`: reads `streaming.body.text_size`, defaults to `"normal_v2"`
- `footer_text_size`: reads `streaming.footer.text_size`, defaults to `"notation"`
- All properties safely handle non-dict values

**builder.py**
- `_build_header(status)`: card-level header with 4 states (streaming=blue, completed=green, error=red, stopped=red), reuses existing i18n keys
- `build_streaming_card_v2`: add `header_enabled`, `text_size` parameters
- `build_complete_card`: add `header_enabled`, `body_text_size`, `footer_enabled`, `footer_text_size` parameters
- `_build_footer_elements`: add `text_size` parameter replacing hardcoded `"notation"`
- Active streaming card and final complete card get header; seal cards do not

**controller.py**
- Pass new params at 4 call sites: `_do_create_card`, `_do_split_card` (seal + new card), `_do_complete_card_inner`

## Configuration

```yaml
streaming:
  header:
    enabled: true    # default false
  body:
    text_size: normal_v2 # default normal_v2
  footer:
    enabled: true    # default true
    text_size: notation  # default notation
```

## Note

- Feishu CardKit v2.0 markdown element does not support `text_color` — colors only via `<font>` inline tags, not included in config
- Valid `text_size` values: `heading-0` through `heading-4`, `heading`, `normal`, `notation`, `normal_v2`, etc.

## Test Plan

- [x] `ruff check` — All checks passed
- [x] `mypy` — Success: no issues found in 21 source files
- [x] `pytest tests/ -q` — 398 passed