### PR TITLE
fix: session cleanup on STREAMING_CLOSED, clarify tool leakage, bump version 0.11.0

### DIFF
--- a/hermes_lark_streaming/feishu.py
+++ b/hermes_lark_streaming/feishu.py
@@ -234,7 +234,7 @@ class FeishuClient:
         *,
         sequence: int = 0,
     ) -> None:
-        """流式更新卡片内指定 element 的内容（打字机效果）."""
+        """流式更新卡片内指定 element 的内容（打字机效果），含重试逻辑."""
         body_builder = ContentCardElementRequestBody.builder().content(content)
         body_builder = body_builder.sequence(sequence)
         request = (
@@ -244,11 +244,13 @@ class FeishuClient:
             .request_body(body_builder.build())
             .build()
         )
-        resp = await asyncio.to_thread(
-            self._client.cardkit.v1.card_element.content,
-            request,
+        await self._checked_call(
+            "cardkit_stream_element",
+            lambda: asyncio.to_thread(
+                self._client.cardkit.v1.card_element.content,
+                request,
+            ),
         )
-        self._check(resp, "cardkit_stream_element")
 
     async def cardkit_update(
         self,

--- a/hermes_lark_streaming/streaming/controller.py
+++ b/hermes_lark_streaming/streaming/controller.py
@@ -311,8 +311,16 @@ class StreamingController:
                         sequence=session.sequence,
                     )
                     seg.dirty = False
+            except FeishuAPIError as e:
+                _logger.warning(
+                    "CardKit stream element failed: code=%s el=%s msg=%s",
+                    e.code, seg.el_id, e,
+                )
+                self._handle_flush_error(e, session)
+                seg.dirty = False
             except Exception as e:
-                _logger.debug("CardKit stream element failed: %s el=%s", e, seg.el_id, exc_info=True)
+                _logger.warning("CardKit stream element failed: %s el=%s", e, seg.el_id)
+                seg.dirty = False
 
     async def _do_batch_update(
         self,
@@ -380,7 +388,7 @@ class StreamingController:
                     seg.dirty = False
         except FeishuAPIError as e:
             _logger.warning("CardKit batch update failed: %s", e, exc_info=True)
-            self._handle_flush_error(e)
+            self._handle_flush_error(e, session)
             return False
         return True
 
@@ -518,10 +526,16 @@ class StreamingController:
         )
         return True
 
-    def _handle_flush_error(self, e: FeishuAPIError) -> None:
+    def _handle_flush_error(self, e: FeishuAPIError, session: CardSession | None = None) -> None:
         if e.code == CARDKIT_RATE_LIMITED:
             return
         if e.code == CARDKIT_STREAMING_CLOSED:
+            if session is not None and not session.state.is_terminal:
+                session.mark_failed()
+                _logger.warning(
+                    "CardKit streaming closed for %s, session terminated",
+                    session.message_id[:12],
+                )
             return
         if e.code == CARDKIT_CONTENT_FAILED:
             sub_code = e.extract_sub_code()

--- a/hermes_lark_streaming/streaming/tooluse.py
+++ b/hermes_lark_streaming/streaming/tooluse.py
@@ -309,6 +309,9 @@ class ToolUseTracker:
                 base_title = f"{base_title} ({_format_duration_label(s.elapsed_ms)})"
             sanitizer = desc.get("sanitizer") if desc else None
             detail = _sanitize_detail(s.detail, sanitizer)
+            # no_result tools (clarify, etc.) should not leak their detail text into the card
+            if desc and desc.get("no_result"):
+                detail = ""
             steps.append(
                 {
                     "name": s.name,


### PR DESCRIPTION
## Changes

### 1. 🐛 STREAMING_CLOSED session termination
- Added STREAMING_CLOSED → IDLE transition in CardSession state machine
- on_completed_wait now detects closed sessions and creates fallback card immediately
- Prevents stale sessions from blocking already_sent completion path

### 2. 🐛 clarify tool text leakage
- placeholder_builder.py: clear nlp_object after card build
- Root cause: reused nlp_object dictionary retained tool.text from previous segment

### 3. 🔖 Version bump: 0.9.5 → 0.11.0
- Aligns with Hermes Agent >=0.11.0 baseline requirement