### PR TITLE
feat: merge thinking/tool segments in completed card + show step count

### DIFF
--- a/hermes_lark_streaming/cardkit/builder.py
+++ b/hermes_lark_streaming/cardkit/builder.py
@@ -245,12 +245,18 @@ def _escape_md(value: str) -> str:
 
 
 def _build_reasoning_panel(
-    text: str, elapsed_ms: float = 0, *, expanded: bool = False, element_id: str | None = None,
+    text: str, elapsed_ms: float = 0, *, step_count: int = 0, expanded: bool = False, element_id: str | None = None,
     text_element_id: str | None = REASONING_TEXT_ELEMENT_ID,
 ) -> dict:
     if elapsed_ms > 0:
         d = _format_elapsed(elapsed_ms)
-        en_label, zh_label = _T["thought_for"][0].format(d), _T["thought_for"][1].format(d)
+        if step_count > 1:
+            tpl_en, tpl_zh = _T["thought_steps_for"]
+            step_s = "s" if step_count > 1 else ""
+            en_label = tpl_en.format(d, step_count, step_s)
+            zh_label = tpl_zh.format(d, step_count)
+        else:
+            en_label, zh_label = _T["thought_for"][0].format(d), _T["thought_for"][1].format(d)
     elif not text.strip():
         en_label, zh_label = _T["thinking_panel"]
     else:
@@ -536,6 +542,9 @@ def build_complete_card(
     merged_reason = _merge_reasoning_segments(segments) if should_merge_reason else None
     merged_tool_indices = _merge_tool_segments(segments, len(all_tool_steps)) if should_merge_tool else None
 
+    # 被合并的 reasoning 段数 → 标题里 "N 步"
+    reasoning_step_count = sum(1 for s in segments if s.type == SegmentType.REASONING) if should_merge_reason else 0
+
     # 跟踪是否已经输出了合并后的 panel（避免循环里重复）
     reason_emitted = False
     tool_emitted = False
@@ -546,6 +555,7 @@ def build_complete_card(
                 if not reason_emitted:
                     elements.append(_build_reasoning_panel(
                         merged_reason.text, merged_reason.elapsed_ms,
+                        step_count=reasoning_step_count,
                         expanded=panel_expanded,
                         element_id=None, text_element_id=None,
                     ))

--- a/hermes_lark_streaming/cardkit/builder.py
+++ b/hermes_lark_streaming/cardkit/builder.py
@@ -451,6 +451,53 @@ def build_streaming_card_v2(
     return card
 
 
+def _merge_reasoning_segments(segments: list[Segment]) -> Segment | None:
+    """聚合所有 REASONING 段为一个虚拟 segment.
+
+    合并所有非空 REASONING 段的 text，用 --- 分隔；elapsed_ms 取最大。
+    第一个非空段的 el_id / text_el_id 保留，供 controller 重用。
+    """
+    parts: list[str] = []
+    total_ms: float = 0.0
+    first: Segment | None = None
+    for s in segments:
+        if s.type != SegmentType.REASONING or not s.text:
+            continue
+        if first is None:
+            first = s
+        else:
+            parts.append("\n\n---\n\n")
+        parts.append(s.text)
+        total_ms = max(total_ms, s.elapsed_ms)
+    if first is None:
+        return None
+    merged = Segment(SegmentType.REASONING, first.el_id)
+    merged.text_el_id = first.text_el_id
+    merged.text = "".join(parts)
+    merged.elapsed_ms = total_ms
+    return merged
+
+
+def _merge_tool_segments(
+    segments: list[Segment], total_steps: int
+) -> list[int] | None:
+    """聚合所有 TOOL 段的 step 索引集合（去重、按顺序）.
+
+    tool_end_offset 在 hermes 语义中是切片结尾（不含），不能简单 union
+    [start, end) 区间。改为展开每个段的 step 索引后去重排序。
+    """
+    indices: set[int] = set()
+    for s in segments:
+        if s.type != SegmentType.TOOL:
+            continue
+        s_start = s.tool_offset
+        s_end = s.tool_end_offset if s.tool_end_offset else total_steps
+        indices.update(range(s_start, s_end))
+    if not indices:
+        return None
+    return sorted(indices)
+
+
 def build_complete_card(
     *,
     segments: list[Segment],
@@ -465,19 +512,60 @@ def build_complete_card(
     panel_expanded: bool = False,
     header_enabled: bool = False,
     body_text_size: str = "normal_v2",
+    merge_segments: bool = True,
+    merge_threshold: int = 1,
 ) -> dict[str, Any]:
-    """完成态流式卡片 — 按 segments 顺序渲染."""
+    """完成态流式卡片 — 按 segments 顺序渲染.
+
+    合并选项:
+        merge_segments=True 且 同类型段数 > merge_threshold 时:
+            所有 REASONING 段合并为 1 个 panel，所有 TOOL 段合并为 1 个 panel。
+            ANSWER 保持原样（一般只有 1 段）。
+        否则: 每个 segment 渲染一个 panel（原行为）。
+    """
     elements: list[dict] = []
     has_answer = False
 
+    # 预计算是否需要合并
+    reason_count = sum(1 for s in segments if s.type == SegmentType.REASONING and s.text)
+    tool_count = sum(1 for s in segments if s.type == SegmentType.TOOL)
+    should_merge_reason = merge_segments and reason_count > merge_threshold
+    should_merge_tool = merge_segments and tool_count > merge_threshold
+
+    # 预计算聚合后的 reasoning segment 和 tool step 索引
+    merged_reason = _merge_reasoning_segments(segments) if should_merge_reason else None
+    merged_tool_indices = _merge_tool_segments(segments, len(all_tool_steps)) if should_merge_tool else None
+
+    # 跟踪是否已经输出了合并后的 panel（避免循环里重复）
+    reason_emitted = False
+    tool_emitted = False
+
     for seg in segments:
         if seg.type == SegmentType.REASONING:
+            if should_merge_reason and merged_reason is not None:
+                if not reason_emitted:
+                    elements.append(_build_reasoning_panel(
+                        merged_reason.text, merged_reason.elapsed_ms,
+                        expanded=panel_expanded,
+                        element_id=None, text_element_id=None,
+                    ))
+                    reason_emitted = True
+                continue
             if seg.text:
                 elements.append(_build_reasoning_panel(
                     seg.text, seg.elapsed_ms, expanded=panel_expanded,
                     element_id=None, text_element_id=None,
                 ))
         elif seg.type == SegmentType.TOOL:
+            if should_merge_tool and merged_tool_indices is not None:
+                if not tool_emitted:
+                    steps = [all_tool_steps[i] for i in merged_tool_indices if i < len(all_tool_steps)]
+                    if steps:
+                        elements.append(_build_tool_panel(
+                            steps, expanded=panel_expanded, element_id=None,
+                        ))
+                    tool_emitted = True
+                continue
             start = seg.tool_offset
             end = seg.tool_end_offset if seg.tool_end_offset else len(all_tool_steps)
             steps = all_tool_steps[start:end]

--- a/hermes_lark_streaming/cardkit/builder.py
+++ b/hermes_lark_streaming/cardkit/builder.py
@@ -460,7 +460,7 @@ def build_streaming_card_v2(
 def _merge_reasoning_segments(segments: list[Segment]) -> Segment | None:
     """聚合所有 REASONING 段为一个虚拟 segment.
 
-    合并所有非空 REASONING 段的 text，用 --- 分隔；elapsed_ms 取最大。
+    合并所有非空 REASONING 段的 text，用 --- 分隔；elapsed_ms 取总和。
     第一个非空段的 el_id / text_el_id 保留，供 controller 重用。
     """
     parts: list[str] = []
@@ -474,7 +474,7 @@ def _merge_reasoning_segments(segments: list[Segment]) -> Segment | None:
         else:
             parts.append("\n\n---\n\n")
         parts.append(s.text)
-        total_ms = max(total_ms, s.elapsed_ms)
+        total_ms += s.elapsed_ms
     if first is None:
         return None
     merged = Segment(SegmentType.REASONING, first.el_id)

--- a/hermes_lark_streaming/cardkit/i18n.py
+++ b/hermes_lark_streaming/cardkit/i18n.py
@@ -26,7 +26,6 @@ _T: dict[str, tuple[str, str]] = {
     "thought": ("Thought", "思考"),
     "thinking_panel": ("Thinking", "思考中"),
     "thought_for": ("Thought for {}", "思考了 {}"),
-    "thought_steps_for": ("Thought for {} · {} step{}", "思考了 {} · {} 步"),
     "done": ("Done.", "完成。"),
 }
 

--- a/hermes_lark_streaming/cardkit/i18n.py
+++ b/hermes_lark_streaming/cardkit/i18n.py
@@ -26,6 +26,7 @@ _T: dict[str, tuple[str, str]] = {
     "thought": ("Thought", "思考"),
     "thinking_panel": ("Thinking", "思考中"),
     "thought_for": ("Thought for {}", "思考了 {}"),
+    "thought_steps_for": ("Thought for {} · {} step{}", "思考了 {} · {} 步"),
     "done": ("Done.", "完成。"),
 }
 

--- a/hermes_lark_streaming/config.py
+++ b/hermes_lark_streaming/config.py
@@ -122,6 +122,31 @@ class Config:
         footer = sec.get("footer", {})
         return bool(footer.get("show_label", False))
 
+    @property
+    def merge_segments(self) -> bool:
+        """完成态卡片是否把同一任务的多个 thinking/tool 段合并为单个 panel.
+
+        True: 所有 REASONING 段合并成 1 个 reasoning panel，所有 TOOL 段合并成 1 个 tool panel。
+        False: 保持原行为，每个 segment 一个 panel。
+        """
+        sec = self._streaming_sec()
+        return bool(sec.get("merge_segments", True))
+
+    @property
+    def merge_threshold(self) -> int:
+        """启用合并的最小段数阈值.
+
+        当 REASONING（或 TOOL）段数 > merge_threshold 时启用合并；
+        ≤ 阈值时保持原行为（每个段独立 panel），避免对短任务强制聚合。
+        默认 1（只要多段就合并）。
+        """
+        sec = self._streaming_sec()
+        raw = sec.get("merge_threshold", 1)
+        try:
+            return max(0, int(raw))
+        except (TypeError, ValueError):
+            return 1
+
     @staticmethod
     def _default_footer_fields() -> list[list[str]]:
         return [["status", "elapsed", "context", "model"]]

--- a/hermes_lark_streaming/streaming/controller.py
+++ b/hermes_lark_streaming/streaming/controller.py
@@ -477,6 +477,8 @@ class StreamingController:
             panel_expanded=self._cfg.panel_expanded,
             header_enabled=False,
             body_text_size=self._cfg.body_text_size,
+            merge_segments=self._cfg.merge_segments,
+            merge_threshold=self._cfg.merge_threshold,
         )
 
         try:
@@ -580,6 +582,8 @@ class StreamingController:
             panel_expanded=self._cfg.panel_expanded,
             header_enabled=self._cfg.header_enabled,
             body_text_size=self._cfg.body_text_size,
+            merge_segments=self._cfg.merge_segments,
+            merge_threshold=self._cfg.merge_threshold,
         )
 
         streaming_closed = False

--- a/tests/test_cardkit.py
+++ b/tests/test_cardkit.py
@@ -467,6 +467,7 @@ class TestBuildSegmentCompleteCard:
                 _seg("answer", "a2"),
             ],
             all_tool_steps=[_STEP_SUCCESS, _STEP_RUNNING],
+            merge_segments=False,
         )
         contents = [str(e) for e in card["body"]["elements"]]
         r1 = next(i for i, c in enumerate(contents) if "r1" in c)
@@ -640,3 +641,135 @@ class TestCompleteCardFooter:
         )
         tags = [e.get("tag") for e in card["body"]["elements"]]
         assert "hr" not in tags
+
+
+class TestCompleteCardMergeSegments:
+    """测试 build_complete_card 的 segment 合并行为."""
+
+    def _panel_titles(self, card: dict) -> list[str]:
+        """提取所有 collapsible_panel 的标题文本."""
+        titles: list[str] = []
+        for e in card["body"]["elements"]:
+            if e.get("tag") != "collapsible_panel":
+                continue
+            title = e.get("header", {}).get("title", {}).get("content", "")
+            titles.append(title)
+        return titles
+
+    def test_merge_disabled_keeps_separate_panels(self) -> None:
+        """merge_segments=False 时保持原行为 — 每个段一个 panel."""
+        segs = [
+            _seg("reasoning", "think 1", elapsed_ms=1000),
+            _seg("reasoning", "think 2", elapsed_ms=2000),
+            _seg("answer", "result"),
+        ]
+        card = build_complete_card(
+            segments=segs, all_tool_steps=[], merge_segments=False,
+        )
+        titles = self._panel_titles(card)
+        # 应该有 2 个 thinking panel
+        assert sum(1 for t in titles if "Thought" in t or "思考了" in t) == 2
+
+    def test_merge_enabled_combines_reasoning(self) -> None:
+        """merge_segments=True + 段数 > 阈值时合并."""
+        segs = [
+            _seg("reasoning", "first thought", elapsed_ms=1000),
+            _seg("reasoning", "second thought", elapsed_ms=2000),
+            _seg("answer", "final answer"),
+        ]
+        card = build_complete_card(
+            segments=segs, all_tool_steps=[], merge_segments=True, merge_threshold=1,
+        )
+        titles = self._panel_titles(card)
+        # 2 段 thinking 应该合并成 1 个 panel
+        think_titles = [t for t in titles if "Thought" in t or "思考了" in t]
+        assert len(think_titles) == 1
+        # panel 元素应该包含两段内容（用 --- 分隔）
+        # 找出 reasoning panel（用 text 元素包含 "first thought" 的 panel）
+        for e in card["body"]["elements"]:
+            if e.get("tag") != "collapsible_panel":
+                continue
+            for sub in e.get("elements", []):
+                if sub.get("tag") == "markdown" and "first thought" in sub.get("content", ""):
+                    content = sub["content"]
+                    assert "second thought" in content
+                    assert "---" in content
+                    return
+        raise AssertionError("未找到合并后的 reasoning panel")
+
+    def test_merge_tool_segments(self) -> None:
+        """多个 TOOL 段合并成 1 个 panel，steps 范围是 union."""
+        steps = [
+            {"name": "a", "title": "A", "status": "success"},
+            {"name": "b", "title": "B", "status": "success"},
+            {"name": "c", "title": "C", "status": "success"},
+        ]
+        segs = [
+            _seg("tool", tool_offset=0, tool_end_offset=1),
+            _seg("tool", tool_offset=2, tool_end_offset=3),
+        ]
+        card = build_complete_card(
+            segments=segs, all_tool_steps=steps,
+            merge_segments=True, merge_threshold=1,
+        )
+        # 应该只有 1 个 tool panel
+        tool_titles = [t for t in self._panel_titles(card) if "Tool" in t or "工具执行" in t or "工具使用" in t]
+        assert len(tool_titles) == 1
+        # 2 步合并（A 和 C）
+        for e in card["body"]["elements"]:
+            if e.get("tag") != "collapsible_panel":
+                continue
+            title = e.get("header", {}).get("title", {}).get("content", "")
+            if "Tool" not in title and "工具执行" not in title and "工具使用" not in title:
+                continue
+            # 应该有 2 步（A, C），不是 3
+            sub_titles = [
+                s.get("text", {}).get("content", "")
+                for s in e.get("elements", [])
+                if s.get("tag") == "div"
+            ]
+            assert len(sub_titles) == 2
+            return
+        raise AssertionError("未找到 tool panel")
+
+    def test_merge_threshold_suppresses_short_runs(self) -> None:
+        """merge_threshold=5 时，2 段不合并（≤ 阈值）."""
+        segs = [
+            _seg("reasoning", "only one", elapsed_ms=1000),
+            _seg("reasoning", "second", elapsed_ms=2000),
+        ]
+        card = build_complete_card(
+            segments=segs, all_tool_steps=[],
+            merge_segments=True, merge_threshold=5,
+        )
+        titles = self._panel_titles(card)
+        # 2 段 ≤ 5，不合并 — 应该有 2 个独立 panel
+        think_titles = [t for t in titles if "Thought" in t or "思考了" in t]
+        assert len(think_titles) == 2
+
+    def test_mixed_reasoning_and_tool_all_merged(self) -> None:
+        """混合场景：3 段 thinking + 2 个 tool 段 + answer → 2 个 panel + answer."""
+        segs = [
+            _seg("reasoning", "t1", elapsed_ms=500),
+            _seg("tool", tool_offset=0, tool_end_offset=1),
+            _seg("reasoning", "t2", elapsed_ms=800),
+            _seg("tool", tool_offset=1, tool_end_offset=2),
+            _seg("reasoning", "t3", elapsed_ms=300),
+            _seg("answer", "final"),
+        ]
+        steps = [
+            {"name": "x", "title": "X", "status": "success"},
+            {"name": "y", "title": "Y", "status": "success"},
+        ]
+        card = build_complete_card(
+            segments=segs, all_tool_steps=steps,
+            merge_segments=True, merge_threshold=1,
+        )
+        titles = self._panel_titles(card)
+        # 1 个 reasoning + 1 个 tool = 2 个 panel
+        think_count = sum(1 for t in titles if "Thought" in t or "思考了" in t)
+        tool_count = sum(1 for t in titles if "Tool" in t or "工具执行" in t or "工具使用" in t)
+        assert think_count == 1
+        assert tool_count == 1
+        # answer 元素存在
+        assert any("final" in str(e) for e in card["body"]["elements"])

--- a/tests/test_cardkit.py
+++ b/tests/test_cardkit.py
@@ -773,3 +773,67 @@ class TestCompleteCardMergeSegments:
         assert tool_count == 1
         # answer 元素存在
         assert any("final" in str(e) for e in card["body"]["elements"])
+
+
+class TestReasoningPanelStepCount:
+    """验证 reasoning panel 标题在合并时显示步数."""
+
+    def _reasoning_title(self, card: dict) -> tuple[str, str]:
+        """提取 reasoning panel 的 en/zh 标题."""
+        for e in card["body"]["elements"]:
+            if e.get("tag") != "collapsible_panel":
+                continue
+            title = e.get("header", {}).get("title", {})
+            content = title.get("content", "")
+            if "Thought" in content or "思考" in content:
+                i18n = title.get("i18n_content", {})
+                return content, i18n.get("zh_cn", "")
+        return "", ""
+
+    def test_merged_reasoning_shows_step_count(self) -> None:
+        """3 段 thinking 合并时标题应显示 '3 steps' / '3 步'."""
+        segs = [
+            _seg("reasoning", "t1", elapsed_ms=1000),
+            _seg("reasoning", "t2", elapsed_ms=2000),
+            _seg("reasoning", "t3", elapsed_ms=3000),
+            _seg("answer", "done"),
+        ]
+        card = build_complete_card(
+            segments=segs, all_tool_steps=[],
+            merge_segments=True, merge_threshold=1,
+        )
+        en, zh = self._reasoning_title(card)
+        assert "3 steps" in en, f"expected '3 steps' in: {en}"
+        assert "3 步" in zh, f"expected '3 步' in: {zh}"
+        # elapsed 取最大（hermes 现有语义）
+        assert "3.0s" in en, f"expected max elapsed 3.0s in: {en}"
+        assert "3.0s" in zh, f"expected 3.0s in: {zh}"
+
+    def test_single_reasoning_hides_step_count(self) -> None:
+        """1 段 reasoning 时不显示步数（保持原行为）."""
+        card = build_complete_card(
+            segments=[_seg("reasoning", "solo", elapsed_ms=2500), _seg("answer", "ok")],
+            all_tool_steps=[], merge_segments=True, merge_threshold=1,
+        )
+        en, zh = self._reasoning_title(card)
+        assert "step" not in en.lower(), f"single reasoning should not show step: {en}"
+        assert "步" not in zh, f"single reasoning should not show 步: {zh}"
+        assert "2.5s" in en and "2.5s" in zh
+
+    def test_tool_panel_uses_singular_for_one_step(self) -> None:
+        """回归测试：单步 tool 标题 '1 step' / '1 步'（不被影响）."""
+        card = build_complete_card(
+            segments=[
+                _seg("tool", tool_offset=0, tool_end_offset=1),
+                _seg("answer", "ok"),
+            ],
+            all_tool_steps=[{"name": "x", "title": "X", "status": "success"}],
+            merge_segments=True, merge_threshold=1,
+        )
+        for e in card["body"]["elements"]:
+            if e.get("tag") != "collapsible_panel":
+                continue
+            title = e.get("header", {}).get("title", {})
+            content = title.get("content", "")
+            if "Tool" in content:
+                assert "1 step" in content, f"single tool step: {content}"

--- a/tests/test_cardkit.py
+++ b/tests/test_cardkit.py
@@ -805,9 +805,9 @@ class TestReasoningPanelStepCount:
         en, zh = self._reasoning_title(card)
         assert "3 steps" in en, f"expected '3 steps' in: {en}"
         assert "3 步" in zh, f"expected '3 步' in: {zh}"
-        # elapsed 取最大（hermes 现有语义）
-        assert "3.0s" in en, f"expected max elapsed 3.0s in: {en}"
-        assert "3.0s" in zh, f"expected 3.0s in: {zh}"
+        # elapsed 是所有段耗时总和（总思考时间）
+        assert "6.0s" in en, f"expected total elapsed 6.0s in: {en}"
+        assert "6.0s" in zh, f"expected 6.0s in: {zh}"
 
     def test_single_reasoning_hides_step_count(self) -> None:
         """1 段 reasoning 时不显示步数（保持原行为）."""


### PR DESCRIPTION
## Problem

Long agent runs (multi-round tool calls) produce a completed card with **N reasoning panels + M tool panels** in addition to the final answer. For tasks with 5+ rounds, the card becomes unpleasantly long even though most users only care about the final answer and the total work done.

Two related UX issues are addressed in three commits:

1. **Card bloat from per-segment panels** — all REASONING/TOOL segments render as their own panels, producing N+M collapsibles.
2. **Missing step count on the reasoning panel** — the merged tool panel already shows `Tool use · 3 steps`, but the merged reasoning panel shows only elapsed time, with no comparable "step count" signal.
3. **Bug in commit 1: max vs sum of elapsed time** — the initial implementation summed only the *longest* segment's elapsed time (`max`), which is not the user's reading of "total think time". Fixed in commit 3 to use `sum`.

## Changes

**Commit 1: `bf51f40` — merge segments in completed card**

Add `streaming.merge_segments` and `streaming.merge_threshold` config:
- All REASONING segments collapse into 1 panel (text joined with `---`)
- All TOOL segments collapse into 1 panel (union of step indices, dedup)
- `merge_threshold` guards short runs (segments ≤ threshold keep original)
- Tool step offsets are de-duplicated via index-set union (slice union would incorrectly include intermediate steps)

**Commit 2: `b83a58b` — show step count in merged reasoning panel**

The merged reasoning panel title now mirrors the tool panel format:
- en: `Thought for 5.0s · 5 steps`
- zh: `思考了 5.0s · 5 步`
- Single-segment reasoning keeps the original `Thought for 3.0s` format (no "1 step")

**Commit 3: `92525fe` — sum, not max, of reasoning elapsed_ms**

The merged reasoning panel now shows the **sum** of all merged segments' elapsed time, matching user intuition for "total think time". E.g. 3 segments at 1.5s + 2.5s + 3.5s → `7.5s`, not `3.5s`.

**Commit 4: `656eb72d` — fix: include i18n.py with thought_steps_for key**

The earlier commits built on the upstream base_tree and inherited the unmodified i18n.py. Add the new i18n key on top so the merged reasoning panel title can resolve `thought_steps_for` at runtime.

**New i18n key**: `thought_steps_for`

## Configuration

```yaml
streaming:
  merge_segments: true     # default true; set false to disable globally
  merge_threshold: 1       # default 1; raise to keep short tasks unmerged
```

## Implementation Notes

- `tool_end_offset` is a slice-end index (exclusive) in hermes semantics, so merging by `[start, end)` interval would drag in intermediate steps. The fix is to expand each TOOL segment's step indices into a set, union across segments, and re-slice.
- `_merge_reasoning_segments` synthesizes a virtual Segment with combined text and `sum(elapsed_ms)`. Reasoning step count is computed at the call site (cleaner than extending `__slots__`).
- All new behavior is opt-out: `merge_segments: false` restores the previous per-segment rendering bit-for-bit.

## Test Plan

- [x] `ruff check` — All checks passed
- [x] `mypy` — Success: no issues found in 21 source files
- [x] `pytest tests/ -q` — **408 passed** (5 new tests for merging, 3 new for step count in reasoning title)

---

## 问题

多轮工具调用的长任务在完成态卡片里会产生 **N 个 reasoning panel + M 个 tool panel**，再加上最终答复，卡片会变得非常长。5 轮以上的任务尤其明显，而大多数用户其实只关心最终结果和总工作量。

这个 PR 在 4 个 commit 里解决了 3 个相关问题：

1. **逐段渲染导致卡片臃肿** — REASONING/TOOL 每段都独立成 panel，N+M 个折叠块
2. **合并后的 reasoning 缺步数显示** — tool panel 已经显示 `Tool use · 3 steps`，但 reasoning panel 只显示耗时，没有对应的"步数"信号
3. **commit 1 的 bug：耗时取 max 而非 sum** — 最初的实现用 `max`（取最长段），但用户直觉是"总思考时间"，commit 3 改用 `sum`

## 改动

**Commit 1: `bf51f40` — 合并完成态卡片中的 segments**

新增配置 `streaming.merge_segments` 和 `streaming.merge_threshold`：
- 所有 REASONING 段合并为 1 个 panel（文本用 `---` 连接）
- 所有 TOOL 段合并为 1 个 panel（step 索引集合 union、去重）
- `merge_threshold` 守门短任务（段数 ≤ 阈值时不合并，保持原样）
- TOOL 段 step 去重用 set union（直接用 `[start, end)` 区间 union 会错误地把中间的 step 带进来）

**Commit 2: `b83a58b` — 合并后的 reasoning panel 显示步数**

标题现在跟 tool panel 格式一致：
- 英文：`Thought for 5.0s · 5 steps`
- 中文：`思考了 5.0s · 5 步`
- 单段 reasoning 保持原格式 `Thought for 3.0s`（不显示 "1 step"）

**Commit 3: `92525fe` — reasoning elapsed_ms 用 sum 而非 max**

合并后的 reasoning panel 现在显示**所有合并段的总耗时**，符合用户对"总思考时间"的直觉。例：3 段 1.5s + 2.5s + 3.5s → `7.5s`，而非 `3.5s`。

**Commit 4: `656eb72d` — fix: 补推 i18n.py 的 thought_steps_for key**

前几个 commit 基于 upstream base_tree 继承到了未改动的 i18n.py，运行时拿不到 `thought_steps_for` 这个 key。本 commit 把新版 i18n.py 补上去。

**新增 i18n key**: `thought_steps_for`

## 配置

```yaml
streaming:
  merge_segments: true     # 默认 true；全局关闭改 false
  merge_threshold: 1       # 默认 1；想保留短任务不合并可以调高
```

## 实现细节

- `tool_end_offset` 在 hermes 语义里是切片结尾（不含），所以简单用 `[start, end)` 区间合并会错误地夹进中间 step。正确做法是把每段的 step 索引展开成 set，跨段 union 后重新切片。
- `_merge_reasoning_segments` 合成一个虚拟 Segment：text 拼接、elapsed_ms 取 `sum`、step_count 在调用点计算（比扩展 `__slots__` 干净）。
- 新行为完全 opt-out：`merge_segments: false` 即可逐字恢复原来的逐段渲染。

## 测试

- [x] `ruff check` — All checks passed
- [x] `mypy` — Success: no issues found in 21 source files
- [x] `pytest tests/ -q` — **408 passed**（5 个新 merge 测试 + 3 个新 reasoning 步数显示测试）