### PR TITLE
fix: retry transient CardKit server errors

### DIFF
--- a/hermes_lark_streaming/feishu.py
+++ b/hermes_lark_streaming/feishu.py
@@ -39,7 +39,16 @@ from lark_oapi.api.im.v1 import (
 _logger = logging.getLogger("hermes_lark_streaming")
 
 CARDKIT_GATEWAY_TIMEOUT = 2200
-_TRANSIENT_RETRY_DELAYS_SEC = (0.15, 0.5)
+CARDKIT_INTERNAL_ERROR = 1663
+CARDKIT_SERVER_INTERNAL_ERROR = 300000
+CARDKIT_TRANSIENT_ERROR_CODES = frozenset(
+    {
+        CARDKIT_GATEWAY_TIMEOUT,
+        CARDKIT_INTERNAL_ERROR,
+        CARDKIT_SERVER_INTERNAL_ERROR,
+    }
+)
+_TRANSIENT_RETRY_DELAYS_SEC = (0.15, 0.5, 1.0)
 
 
 def _sanitize_message(msg: str) -> str:
@@ -116,7 +125,7 @@ class FeishuClient:
         return json.dumps(obj, ensure_ascii=False)
 
     async def _checked_call(self, operation: str, call: Any) -> Any:
-        """Run a Feishu SDK call and retry transient gateway timeouts."""
+        """Run a Feishu SDK call and retry transient CardKit/Lark server errors."""
         attempts = len(_TRANSIENT_RETRY_DELAYS_SEC) + 1
         last_error: FeishuAPIError | None = None
         for attempt in range(attempts):
@@ -126,12 +135,13 @@ class FeishuClient:
                 return resp
             except FeishuAPIError as exc:
                 last_error = exc
-                if exc.code != CARDKIT_GATEWAY_TIMEOUT or attempt >= attempts - 1:
+                if exc.code not in CARDKIT_TRANSIENT_ERROR_CODES or attempt >= attempts - 1:
                     raise
                 delay = _TRANSIENT_RETRY_DELAYS_SEC[attempt]
                 _logger.warning(
-                    "%s transient gateway timeout, retrying attempt=%d/%d delay=%.2fs",
+                    "%s transient Feishu API error code=%s, retrying attempt=%d/%d delay=%.2fs",
                     operation,
+                    exc.code,
                     attempt + 2,
                     attempts,
                     delay,
@@ -244,9 +254,9 @@ class FeishuClient:
             .request_body(body_builder.build())
             .build()
         )
-        resp = await asyncio.to_thread(
-            self._client.cardkit.v1.card_element.content,
-            request,
+        resp = await self._checked_call(
+            "cardkit_stream_element",
+            lambda: asyncio.to_thread(self._client.cardkit.v1.card_element.content, request),
         )
         self._check(resp, "cardkit_stream_element")
 
@@ -262,7 +272,10 @@ class FeishuClient:
         )
         body_builder = body_builder.sequence(sequence)
         request = UpdateCardRequest.builder().card_id(card_id).request_body(body_builder.build()).build()
-        resp = await self._client.cardkit.v1.card.aupdate(request)
+        resp = await self._checked_call(
+            "cardkit_update",
+            lambda: self._client.cardkit.v1.card.aupdate(request),
+        )
         self._check(resp, "cardkit_update")
 
     async def cardkit_batch_update(
@@ -275,7 +288,10 @@ class FeishuClient:
         """局部更新 CardKit 卡片（增删改组件）."""
         body_builder = BatchUpdateCardRequestBody.builder().sequence(sequence).actions(self._dumps(actions))
         request = BatchUpdateCardRequest.builder().card_id(card_id).request_body(body_builder.build()).build()
-        resp = await self._client.cardkit.v1.card.abatch_update(request)
+        resp = await self._checked_call(
+            "cardkit_batch_update",
+            lambda: self._client.cardkit.v1.card.abatch_update(request),
+        )
         self._check(resp, "cardkit_batch_update")
 
     async def cardkit_close_streaming(self, card_id: str, sequence: int = 0) -> None:
@@ -283,7 +299,10 @@ class FeishuClient:
         body_builder = SettingsCardRequestBody.builder().settings(self._dumps({"streaming_mode": False}))
         body_builder = body_builder.sequence(sequence)
         request = SettingsCardRequest.builder().card_id(card_id).request_body(body_builder.build()).build()
-        resp = await self._client.cardkit.v1.card.asettings(request)
+        resp = await self._checked_call(
+            "cardkit_close_streaming",
+            lambda: self._client.cardkit.v1.card.asettings(request),
+        )
         self._check(resp, "cardkit_close_streaming")
 
     async def upload_image(self, image_url: str) -> str | None:

--- a/hermes_lark_streaming/feishu.py
+++ b/hermes_lark_streaming/feishu.py
@@ -254,11 +254,10 @@ class FeishuClient:
             .request_body(body_builder.build())
             .build()
         )
-        resp = await self._checked_call(
+        await self._checked_call(
             "cardkit_stream_element",
             lambda: asyncio.to_thread(self._client.cardkit.v1.card_element.content, request),
         )
-        self._check(resp, "cardkit_stream_element")
 
     async def cardkit_update(
         self,
@@ -272,11 +271,10 @@ class FeishuClient:
         )
         body_builder = body_builder.sequence(sequence)
         request = UpdateCardRequest.builder().card_id(card_id).request_body(body_builder.build()).build()
-        resp = await self._checked_call(
+        await self._checked_call(
             "cardkit_update",
             lambda: self._client.cardkit.v1.card.aupdate(request),
         )
-        self._check(resp, "cardkit_update")
 
     async def cardkit_batch_update(
         self,
@@ -288,22 +286,20 @@ class FeishuClient:
         """局部更新 CardKit 卡片（增删改组件）."""
         body_builder = BatchUpdateCardRequestBody.builder().sequence(sequence).actions(self._dumps(actions))
         request = BatchUpdateCardRequest.builder().card_id(card_id).request_body(body_builder.build()).build()
-        resp = await self._checked_call(
+        await self._checked_call(
             "cardkit_batch_update",
             lambda: self._client.cardkit.v1.card.abatch_update(request),
         )
-        self._check(resp, "cardkit_batch_update")
 
     async def cardkit_close_streaming(self, card_id: str, sequence: int = 0) -> None:
         """关闭 CardKit 卡片的流式模式."""
         body_builder = SettingsCardRequestBody.builder().settings(self._dumps({"streaming_mode": False}))
         body_builder = body_builder.sequence(sequence)
         request = SettingsCardRequest.builder().card_id(card_id).request_body(body_builder.build()).build()
-        resp = await self._checked_call(
+        await self._checked_call(
             "cardkit_close_streaming",
             lambda: self._client.cardkit.v1.card.asettings(request),
         )
-        self._check(resp, "cardkit_close_streaming")
 
     async def upload_image(self, image_url: str) -> str | None:
         """下载远程图片并上传到飞书，返回 img_key."""

--- a/tests/test_feishu.py
+++ b/tests/test_feishu.py
@@ -26,7 +26,13 @@ def _client_with(**methods: AsyncMock) -> FeishuClient:
     client._client = SimpleNamespace(  # type: ignore[attr-defined]
         cardkit=SimpleNamespace(
             v1=SimpleNamespace(
-                card=SimpleNamespace(acreate=methods.get("card_create", AsyncMock())),
+                card=SimpleNamespace(
+                    acreate=methods.get("card_create", AsyncMock()),
+                    aupdate=methods.get("card_update", AsyncMock()),
+                    abatch_update=methods.get("batch_update", AsyncMock()),
+                    asettings=methods.get("settings", AsyncMock()),
+                ),
+                card_element=SimpleNamespace(content=methods.get("card_element_content", AsyncMock())),
             ),
         ),
         im=SimpleNamespace(
@@ -53,6 +59,39 @@ async def test_cardkit_create_retries_gateway_timeout_once() -> None:
 
     assert await client.cardkit_create({"schema": "2.0"}) == "card-ok"
     assert create.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_cardkit_create_retries_server_internal_error() -> None:
+    create = AsyncMock(
+        side_effect=[
+            _Resp(ok=False, code=300000, msg="Server Internal Error"),
+            _Resp(ok=True, data=SimpleNamespace(card_id="card-ok")),
+        ]
+    )
+    client = _client_with(card_create=create)
+
+    assert await client.cardkit_create({"schema": "2.0"}) == "card-ok"
+    assert create.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_cardkit_batch_update_retries_internal_error() -> None:
+    batch_update = AsyncMock(
+        side_effect=[
+            _Resp(ok=False, code=1663, msg="internal error"),
+            _Resp(ok=True),
+        ]
+    )
+    client = _client_with(batch_update=batch_update)
+
+    await client.cardkit_batch_update("card", [{"action": "add"}], sequence=7)
+
+    assert batch_update.await_count == 2
+    first_request = batch_update.await_args_list[0].args[0]
+    second_request = batch_update.await_args_list[1].args[0]
+    assert second_request.card_id == first_request.card_id
+    assert second_request.request_body.sequence == first_request.request_body.sequence
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- retry transient Feishu/Lark CardKit API failures for codes `2200`, `1663`, and `300000`
- route CardKit stream element, update, batch update, and close calls through the bounded retry helper
- add regression coverage for `cardkit_create` retrying `300000` and `cardkit_batch_update` retrying `1663`

## Why

We observed intermittent Feishu CardKit server-side failures such as:

- `2200` gateway timeout / service unavailable
- `300000` server internal error
- `1663` internal error

These are usually transient API-side failures. Retrying them briefly avoids unnecessary fallback to ordinary text or failed CardKit delivery while still preserving normal failure behavior for validation, credential, sequence, permission, and message-not-found errors.

## Verification

```bash
/home/thunderfight127/.hermes/hermes-agent/venv/bin/python3 -m py_compile hermes_lark_streaming/feishu.py tests/test_feishu.py
/home/thunderfight127/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/test_feishu.py -q
```

Result:

```text
7 passed, 2 warnings in 7.08s
```

Warnings are dependency deprecation warnings from `lark_oapi` / `websockets`, not test failures.
