### PR TITLE
feat: add queued follow-up hooks for streaming card lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,8 @@ gateway/run.py (Hermes)
        ├─ on_reasoning_delta    → controller.on_reasoning()
        ├─ on_background_review_message → controller.defer_background_review()
        ├─ on_message_interrupted → controller.on_interrupted()
+       ├─ on_queued_followup_boundary → patch.on_queued_followup_boundary() (finalize card before drain, set response_previewed/already_sent)
+       ├─ on_queued_followup_result   → patch.on_queued_followup_result() (carry deepest completion ID through recursive merge)
        ├─ on_message_completed_wait → controller.on_completed_wait()
        ├─ on_message_aborted    → controller.on_aborted()
        └─ on_background_deliver → controller.on_background_deliver()
@@ -95,5 +97,7 @@ Card templates (cardkit/)
 - Reasoning display depends on upstream providing `<thinking>`/`<thought>`/`<antthinking>` tags or `Reasoning:\n` prefix in text. Native API reasoning blocks (Anthropic extended thinking, DeepSeek reasoning_content) are available via `on_reasoning_delta` hook when `display.platforms.feishu.show_reasoning` is enabled.
 - CardKit v2.0 elements (collapsible_panel, streaming_mode) only work with `"schema": "2.0"` cards.
 - Streaming cards use a single CardKit card for the message lifecycle: elements are dynamically created in event arrival order. When CardKit creation fails, the plugin yields to the Hermes Gateway default reply.
+- The follow-up drain hooks manage card lifecycle for Hermes's queued follow-up messages (triggered when `busy_text_mode: queue` or `busy_input_mode: queue`). `on_queued_followup_boundary` is injected at `was_interrupted = result.get("interrupted")` in `_run_agent` — it finalizes the current card and sets `response_previewed`/`already_sent` on the result dict before the drain loop processes the queued message. `on_queued_followup_result` is injected at `return _preserve_queued_followup_history_offset(...)` and uses `setdefault` to carry the deepest `_hermes_lark_completion_id` back through the recursive merge chain.
+- The COMPLETE hook uses `_lark_completion_id = agent_result.get('_hermes_lark_completion_id') or event.message_id` — in follow-up scenarios the deepest message_id propagates up via `on_queued_followup_result`, ensuring the correct card session is finalized. Non-follow-up scenarios fall back to `event.message_id`.
 - The background deliver hook (`on_background_deliver`) is injected in `_run_background_task` after `adapter.extract_images(response)`. It uses `ReplyMessage` API with `event_message_id` as anchor, so cards land in the correct topic. On success, `text_content` is cleared to avoid duplicate text delivery, while images and media files continue through the original Hermes loops. On failure, the original Hermes delivery logic runs as fallback.
 - Commit messages: body should use bullet list format (unnumbered `- item`).

--- a/README.en.md
+++ b/README.en.md
@@ -199,6 +199,8 @@ The plugin injects hook calls into `gateway/run.py` and `cron/scheduler.py` via 
 | `on_background_review_message` | At `background_review_callback` assignment | Defers self-evolution messages until card completion |
 | `on_message_aborted` | Before stale `return None` | Handles `/stop` abort |
 | `on_message_interrupted` | Before recursive `_run_agent` call | Handles message interrupts, terminates old card and creates new session |
+| `on_queued_followup_boundary` | Before `was_interrupted = result.get("interrupted")` | Finalizes current card before Queue-mode follow-up drain |
+| `on_queued_followup_result` | Before `return _preserve_queued_followup_history_offset` | Carries deepest completion ID back through recursive merge chain |
 | `on_message_completed_wait` | Before `return response` | Waits for card creation/finalization before sending the completion card; yields to gateway text fallback on failure |
 | `on_cron_deliver` | After `delivered = False` in `_deliver_result` | Intercepts Feishu cron delivery, sends as card |
 | `on_background_deliver` | After `extract_images` in `_run_background_task` | Intercepts Feishu background task delivery, replies as card with topic-aware positioning |

--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ $HERMES_PYTHON -m pip uninstall hermes-lark-streaming
 | `on_background_review_message` | `background_review_callback` 赋值处 | 延迟自我进化消息到卡片完成后再发送 |
 | `on_message_aborted` | stale `return None` 之前 | 处理 `/stop` 中断 |
 | `on_message_interrupted` | `_run_agent` 递归调用前 | 处理消息打断，终止旧卡片并创建新会话 |
+| `on_queued_followup_boundary` | `was_interrupted = result.get("interrupted")` 之前 | Queue 模式 follow-up 前终结当前卡片 |
+| `on_queued_followup_result` | `return _preserve_queued_followup_history_offset` 之前 | 传递最深 completion ID 回递归合并链 |
 | `on_message_completed_wait` | `return response` 之前 | 等待卡片创建/收尾完成后发送终态卡片，失败时让网关走文本兜底 |
 | `on_cron_deliver` | `_deliver_result` 中 `delivered = False` 之后 | 拦截飞书 Cron 推送，以卡片形式发送 |
 | `on_background_deliver` | `_run_background_task` 中 `extract_images` 之后 | 拦截飞书后台任务推送，以卡片形式回复到原始消息（话题内正确定位） |

--- a/hermes_lark_streaming/patch.py
+++ b/hermes_lark_streaming/patch.py
@@ -149,6 +149,43 @@ def on_message_needs_text_fallback(*, ctrl: Any, message_id: str) -> bool:
 
 
 @_safe_hook(default_return=False)
+async def on_queued_followup_boundary(*, ctrl: Any, message_id: str, result: dict[str, Any]) -> bool:
+    """Complete the current card before Hermes drains a queued follow-up turn."""
+    if not isinstance(result, dict) or result.get("interrupted"):
+        return False
+
+    sent = bool(
+        await ctrl.on_completed_wait(
+            message_id=message_id,
+            answer=result.get("final_response") or "",
+            duration=0.0,
+            model=result.get("model", ""),
+            tokens={
+                "input_tokens": result.get("input_tokens", 0),
+                "output_tokens": result.get("output_tokens", 0),
+            },
+            context={
+                "used_tokens": result.get("last_prompt_tokens", 0),
+                "max_tokens": result.get("context_length", 0),
+            },
+        )
+    )
+    if sent:
+        result["response_previewed"] = True
+        result["already_sent"] = True
+    else:
+        ctrl.consume_text_fallback(message_id)
+    return sent
+
+
+@_safe_hook()
+def on_queued_followup_result(*, ctrl: Any, message_id: str, followup_result: dict[str, Any]) -> None:
+    """Carry the deepest queued follow-up id back to the outer completion hook."""
+    if isinstance(followup_result, dict) and message_id:
+        followup_result.setdefault("_hermes_lark_completion_id", message_id)
+
+
+@_safe_hook(default_return=False)
 def on_tool_updated(
     *,
     ctrl: Any,

--- a/hermes_lark_streaming/patcher.py
+++ b/hermes_lark_streaming/patcher.py
@@ -19,6 +19,8 @@ _HOOK_NAMES = [
     "NORMALIZE",
     "START",
     "COMPLETE",
+    "FOLLOWUP_COMPLETE",
+    "FOLLOWUP_RESULT",
     "TOOL",
     "ANSWER",
     "THINKING",
@@ -33,14 +35,16 @@ MARKERS: list[tuple[str, str]] = [(f"# {PREFIX}_{n}_BEGIN", f"# {PREFIX}_{n}_END
 MK_NORMALIZE, MK_NORMALIZE_END = MARKERS[0]
 MK_START, MK_START_END = MARKERS[1]
 MK_COMPLETE, MK_COMPLETE_END = MARKERS[2]
-MK_TOOL, MK_TOOL_END = MARKERS[3]
-MK_ANSWER, MK_ANSWER_END = MARKERS[4]
-MK_THINKING, MK_THINKING_END = MARKERS[5]
-MK_REASONING, MK_REASONING_END = MARKERS[6]
-MK_BACKGROUND_REVIEW, MK_BACKGROUND_REVIEW_END = MARKERS[7]
-MK_ABORT, MK_ABORT_END = MARKERS[8]
-MK_INTERRUPT, MK_INTERRUPT_END = MARKERS[9]
-MK_BG_DELIVER, MK_BG_DELIVER_END = MARKERS[10]
+MK_FOLLOWUP_COMPLETE, MK_FOLLOWUP_COMPLETE_END = MARKERS[3]
+MK_FOLLOWUP_RESULT, MK_FOLLOWUP_RESULT_END = MARKERS[4]
+MK_TOOL, MK_TOOL_END = MARKERS[5]
+MK_ANSWER, MK_ANSWER_END = MARKERS[6]
+MK_THINKING, MK_THINKING_END = MARKERS[7]
+MK_REASONING, MK_REASONING_END = MARKERS[8]
+MK_BACKGROUND_REVIEW, MK_BACKGROUND_REVIEW_END = MARKERS[9]
+MK_ABORT, MK_ABORT_END = MARKERS[10]
+MK_INTERRUPT, MK_INTERRUPT_END = MARKERS[11]
+MK_BG_DELIVER, MK_BG_DELIVER_END = MARKERS[12]
 
 _BACKUP_SUFFIX = ".hermes_lark.bak"
 
@@ -104,8 +108,9 @@ def _complete_hook(indent: str) -> str:
         [
             "try:",
             "    from hermes_lark_streaming.patch import on_message_completed_wait, on_message_needs_text_fallback",
+            "    _lark_completion_id = agent_result.get('_hermes_lark_completion_id') or event.message_id",
             "    _lark_card_sent = await on_message_completed_wait(",
-            "        message_id=event.message_id,",
+            "        message_id=_lark_completion_id,",
             "        answer=response,",
             "        duration=_response_time,",
             "        model=agent_result.get('model', ''),",
@@ -120,8 +125,43 @@ def _complete_hook(indent: str) -> str:
             "    )",
             "    if _lark_card_sent:",
             "        agent_result['already_sent'] = True",
-            "    elif on_message_needs_text_fallback(message_id=event.message_id):",
+            "    elif on_message_needs_text_fallback(message_id=_lark_completion_id):",
             "        agent_result.pop('already_sent', None)",
+            "except Exception:",
+            "    pass",
+        ],
+    )
+
+
+def _followup_complete_hook(indent: str) -> str:
+    return _make_hook(
+        indent,
+        MK_FOLLOWUP_COMPLETE,
+        MK_FOLLOWUP_COMPLETE_END,
+        [
+            "try:",
+            "    from hermes_lark_streaming.patch import on_queued_followup_boundary",
+            "    await on_queued_followup_boundary(message_id=event_message_id, result=result)",
+            "except Exception:",
+            "    pass",
+        ],
+    )
+
+
+def _followup_result_hook(indent: str) -> str:
+    return _make_hook(
+        indent,
+        MK_FOLLOWUP_RESULT,
+        MK_FOLLOWUP_RESULT_END,
+        [
+            "try:",
+            "    from hermes_lark_streaming.patch import on_queued_followup_result",
+            "    _lark_followup_completion_id = next_message_id or getattr(pending_event, 'message_id', None)",
+            "    if _lark_followup_completion_id:",
+            "        on_queued_followup_result(",
+            "            message_id=_lark_followup_completion_id,",
+            "            followup_result=followup_result,",
+            "        )",
             "except Exception:",
             "    pass",
         ],
@@ -247,7 +287,9 @@ def _interrupt_hook(indent: str) -> str:
         MK_INTERRUPT_END,
         [
             "try:",
-            "    from hermes_lark_streaming.patch import on_message_interrupted, on_message_aborted",
+            "    from hermes_lark_streaming.patch import (",
+            "        on_message_aborted, on_message_interrupted, on_message_started,",
+            "    )",
             "    _lark_next_message_id = getattr(pending_event, 'message_id', None) or next_message_id",
             "    _lark_next_anchor_id = next_message_id",
             "    if was_interrupted and _lark_next_message_id:",
@@ -259,6 +301,12 @@ def _interrupt_hook(indent: str) -> str:
             "        )",
             "    elif was_interrupted:",
             "        on_message_aborted(message_id=event_message_id)",
+            "    elif pending_event is not None and _lark_next_message_id:",
+            "        on_message_started(",
+            "            message_id=_lark_next_message_id,",
+            "            chat_id=getattr(next_source, 'chat_id', source.chat_id),",
+            "            anchor_id=_lark_next_anchor_id,",
+            "        )",
             "except Exception:",
             "    pass",
         ],
@@ -412,6 +460,12 @@ class Patcher:
         if "Restart typing indicator so the user sees activity" not in content:
             raise PatcherError("Cannot find interrupt anchor in run.py — Hermes version may be incompatible")
 
+        if 'was_interrupted = result.get("interrupted")' not in content:
+            raise PatcherError("Cannot find queued follow-up boundary in run.py — Hermes version may be incompatible")
+
+        if "return _preserve_queued_followup_history_offset(result, followup_result)" not in content:
+            raise PatcherError("Cannot find queued follow-up return in run.py — Hermes version may be incompatible")
+
         if "agent.reasoning_config = reasoning_config" not in content:
             raise PatcherError("Cannot find reasoning_config anchor in run.py — Hermes version may be incompatible")
 
@@ -472,6 +526,8 @@ class Patcher:
             ("normalize", "normalize", _find_handle_message_source_site(tree, lines)),
             ("start", "start", _find_func_body(tree, lines, "_handle_message_with_agent")),
             ("complete", "complete", _find_handler_return(tree, lines)),
+            ("followup_complete", "followup_complete", _find_followup_complete_site(tree, lines)),
+            ("followup_result", "followup_result", _find_followup_result_site(tree, lines)),
             ("abort", "abort", _find_handler_abort(tree, lines)),
             ("interrupt", "interrupt", _find_interrupt_site(tree, lines)),
             ("tool", "tool", _find_func_body(tree, lines, "progress_callback")),
@@ -494,6 +550,8 @@ class Patcher:
             "normalize": _feishu_normalize_hook,
             "start": _start_hook,
             "complete": _complete_hook,
+            "followup_complete": _followup_complete_hook,
+            "followup_result": _followup_result_hook,
             "abort": _abort_hook,
             "interrupt": _interrupt_hook,
             "tool": _tool_hook,
@@ -589,6 +647,20 @@ def _find_interrupt_site(tree: ast.Module, lines: list[str]) -> tuple[int, str] 
         if "Restart typing indicator so the user sees activity" in line:
             indent = _safe_indent(lines, i)
             return i, indent
+    return None
+
+
+def _find_followup_complete_site(tree: ast.Module, lines: list[str]) -> tuple[int, str] | None:
+    for i, line in enumerate(lines):
+        if line.strip() == 'was_interrupted = result.get("interrupted")':
+            return i, _safe_indent(lines, i)
+    return None
+
+
+def _find_followup_result_site(tree: ast.Module, lines: list[str]) -> tuple[int, str] | None:
+    for i, line in enumerate(lines):
+        if line.strip() == "return _preserve_queued_followup_history_offset(result, followup_result)":
+            return i, _safe_indent(lines, i)
     return None
 
 

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -11,7 +11,7 @@ import shutil
 import textwrap
 import urllib.request
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -149,6 +149,8 @@ class TestVerify:
             def _interim_assistant_cb(text):
                 pass
             # Restart typing indicator so the user sees activity
+            was_interrupted = result.get("interrupted")
+            return _preserve_queued_followup_history_offset(result, followup_result)
         """)
         )
         with pytest.raises(PatcherError, match="reasoning_config"):
@@ -185,11 +187,17 @@ class TestApplyRemove:
         assert "_lark_next_message_id = getattr(pending_event, 'message_id', None) or next_message_id" in content
         assert "new_message_id=_lark_next_message_id" in content
         assert "anchor_id=_lark_next_anchor_id" in content
+        assert "# HERMES_LARK_FOLLOWUP_COMPLETE_BEGIN" in content
+        assert "message_id=event_message_id" in content
+        assert "on_queued_followup_boundary(message_id=event_message_id, result=result)" in content
+        assert "# HERMES_LARK_FOLLOWUP_RESULT_BEGIN" in content
+        assert "on_queued_followup_result(" in content
         assert "on_message_completed_wait(" in content
         assert "on_message_needs_text_fallback" in content
         assert "_lark_card_sent = await on_message_completed_wait(" in content
         assert "agent_result.pop('already_sent', None)" in content
-        assert "message_id=event.message_id" in content
+        assert "_lark_completion_id = agent_result.get('_hermes_lark_completion_id') or event.message_id" in content
+        assert "message_id=_lark_completion_id" in content
         assert "on_answer_delta(message_id=event_message_id" in content
         assert "on_thinking_delta(message_id=event_message_id" in content
         assert "on_reasoning_delta(message_id=event_message_id" in content
@@ -414,3 +422,50 @@ class TestOnCronDeliverHook:
             result = on_cron_deliver(chat_id="c1", content="hello", loop=loop)
             assert result is True
             ctrl.on_cron_deliver.assert_called_once_with(chat_id="c1", content="hello", loop=loop)
+
+
+class TestQueuedFollowupHooks:
+    @pytest.mark.asyncio
+    async def test_boundary_marks_result_when_card_sent(self) -> None:
+        from hermes_lark_streaming.patch import on_queued_followup_boundary
+
+        with patch("hermes_lark_streaming.patch.get_controller") as mock_get:
+            ctrl = MagicMock()
+            ctrl.enabled = True
+            ctrl.on_completed_wait = AsyncMock(return_value=True)
+            mock_get.return_value = ctrl
+            result = {"final_response": "ok", "model": "m"}
+
+            assert await on_queued_followup_boundary(message_id="msg", result=result) is True
+
+            assert result["response_previewed"] is True
+            assert result["already_sent"] is True
+
+    @pytest.mark.asyncio
+    async def test_boundary_consumes_fallback_when_card_not_sent(self) -> None:
+        from hermes_lark_streaming.patch import on_queued_followup_boundary
+
+        with patch("hermes_lark_streaming.patch.get_controller") as mock_get:
+            ctrl = MagicMock()
+            ctrl.enabled = True
+            ctrl.on_completed_wait = AsyncMock(return_value=False)
+            mock_get.return_value = ctrl
+            result = {"final_response": "plain"}
+
+            assert await on_queued_followup_boundary(message_id="msg", result=result) is False
+
+            ctrl.consume_text_fallback.assert_called_once_with("msg")
+            assert "response_previewed" not in result
+
+    def test_result_hook_preserves_deepest_completion_id(self) -> None:
+        from hermes_lark_streaming.patch import on_queued_followup_result
+
+        with patch("hermes_lark_streaming.patch.get_controller") as mock_get:
+            ctrl = MagicMock()
+            ctrl.enabled = True
+            mock_get.return_value = ctrl
+            result = {"_hermes_lark_completion_id": "deep"}
+
+            on_queued_followup_result(message_id="outer", followup_result=result)
+
+            assert result["_hermes_lark_completion_id"] == "deep"


### PR DESCRIPTION
## Summary

When Hermes drains queued follow-up messages (Queue mode busy_input), the streaming card lifecycle was not managed: previous card was not finalized, new card session was not registered, and the deepest completion ID could not reach the outer completion hook.

## Changes

- **FOLLOWUP_COMPLETE hook** — injected at `was_interrupted = result.get("interrupted")` in `_run_agent` drain loop. Finalizes the current card and sets `response_previewed`/`already_sent` on the result dict to prevent duplicate Hermes text delivery.
- **FOLLOWUP_RESULT hook** — injected at `return _preserve_queued_followup_history_offset(...)` in the recursive return path. Propagates `_hermes_lark_completion_id` (via `setdefault`) from the deepest follow-up level to the outer COMPLETE hook.
- **Modified COMPLETE hook** — uses `_hermes_lark_completion_id` from `agent_result` with fallback to `event.message_id` for non-followup cases.
- **Modified INTERRUPT hook** — new `elif` branch for Queue-mode follow-ups (non-interrupt, has `pending_event`) to call `on_message_started` and register the follow-up card session before recursive `_run_agent`.
- **Idempotent install** — `apply()` no longer early-returns on `is_fully_patched()`, allowing patch upgrades when new markers are added.
- **Removed dead code** — `is_fully_patched()` method no longer has any callers.

## Test plan

- [x] 405 tests pass (ruff + mypy + pytest)
- [x] New unit tests for `on_queued_followup_boundary` and `on_queued_followup_result` (no local Hermes dependency, CI-safe)
- [x] Patcher apply/remove/idempotent tests pass with new markers
- [x] Verified variable scope correctness against Hermes `run.py` source