### PR TITLE
fix: auto-discover Hermes module paths for pip-installed scenarios

### DIFF
--- a/hermes_lark_streaming/patcher.py
+++ b/hermes_lark_streaming/patcher.py
@@ -55,11 +55,14 @@ _HERMES_HOME = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
 def _resolve_module_path(module_name: str, hardcoded: Path) -> Path:
     """Discover the actual file path of a Hermes module.
 
-    Works for both git-clone (editable install) and pip-install scenarios.
-    Resolves dotted modules without importing their parent package, then
-    falls back to the hardcoded path so Patcher can report a clear error.
+    Uses the standard Hermes home layout when available, then falls back to
+    module discovery for pip-install scenarios without importing parent packages.
     """
     try:
+        hardcoded_candidate = hardcoded.resolve()
+        if hardcoded_candidate.is_file() and hardcoded_candidate.suffix == ".py":
+            return hardcoded_candidate
+
         package_name, separator, relative_name = module_name.partition(".")
         spec = importlib.util.find_spec(package_name)
         if separator and spec and spec.submodule_search_locations:

--- a/hermes_lark_streaming/patcher.py
+++ b/hermes_lark_streaming/patcher.py
@@ -61,9 +61,11 @@ def _resolve_module_path(module_name: str, hardcoded: Path) -> Path:
     try:
         spec = importlib.util.find_spec(module_name)
         if spec and spec.origin:
-            return Path(spec.origin)
-    except (ModuleNotFoundError, ValueError):
-        pass
+            candidate = Path(spec.origin).resolve()
+            if candidate.is_file() and candidate.suffix == ".py":
+                return candidate
+    except Exception:
+        _logger.debug("Failed to resolve Hermes module %s", module_name, exc_info=True)
     return hardcoded
 
 

--- a/hermes_lark_streaming/patcher.py
+++ b/hermes_lark_streaming/patcher.py
@@ -56,11 +56,19 @@ def _resolve_module_path(module_name: str, hardcoded: Path) -> Path:
     """Discover the actual file path of a Hermes module.
 
     Works for both git-clone (editable install) and pip-install scenarios.
-    Falls back to the hardcoded path so Patcher can report a clear error.
+    Resolves dotted modules without importing their parent package, then
+    falls back to the hardcoded path so Patcher can report a clear error.
     """
     try:
-        spec = importlib.util.find_spec(module_name)
-        if spec and spec.origin:
+        package_name, separator, relative_name = module_name.partition(".")
+        spec = importlib.util.find_spec(package_name)
+        if separator and spec and spec.submodule_search_locations:
+            relative_path = Path(*relative_name.split(".")).with_suffix(".py")
+            for location in spec.submodule_search_locations:
+                candidate = (Path(location) / relative_path).resolve()
+                if candidate.is_file():
+                    return candidate
+        elif spec and spec.origin:
             candidate = Path(spec.origin).resolve()
             if candidate.is_file() and candidate.suffix == ".py":
                 return candidate

--- a/hermes_lark_streaming/patcher.py
+++ b/hermes_lark_streaming/patcher.py
@@ -52,29 +52,33 @@ _BACKUP_SUFFIX = ".hermes_lark.bak"
 _HERMES_HOME = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
 
 
+def _valid_source(path: Path) -> Path | None:
+    try:
+        candidate = path.resolve()
+        if candidate.is_file() and candidate.suffix == ".py":
+            return candidate
+    except (OSError, RuntimeError):
+        pass
+    return None
+
+
 def _resolve_module_path(module_name: str, hardcoded: Path) -> Path:
     """Discover the actual file path of a Hermes module.
 
     Uses the standard Hermes home layout when available, then falls back to
     module discovery for pip-install scenarios without importing parent packages.
     """
-    try:
-        hardcoded_candidate = hardcoded.resolve()
-        if hardcoded_candidate.is_file() and hardcoded_candidate.suffix == ".py":
-            return hardcoded_candidate
+    if candidate := _valid_source(hardcoded):
+        return candidate
 
-        package_name, separator, relative_name = module_name.partition(".")
+    try:
+        package_name, _, relative_name = module_name.partition(".")
         spec = importlib.util.find_spec(package_name)
-        if separator and spec and spec.submodule_search_locations:
+        if spec and spec.submodule_search_locations:
             relative_path = Path(*relative_name.split(".")).with_suffix(".py")
             for location in spec.submodule_search_locations:
-                candidate = (Path(location) / relative_path).resolve()
-                if candidate.is_file():
+                if candidate := _valid_source(Path(location) / relative_path):
                     return candidate
-        elif spec and spec.origin:
-            candidate = Path(spec.origin).resolve()
-            if candidate.is_file() and candidate.suffix == ".py":
-                return candidate
     except Exception:
         _logger.debug("Failed to resolve Hermes module %s", module_name, exc_info=True)
     return hardcoded

--- a/hermes_lark_streaming/patcher.py
+++ b/hermes_lark_streaming/patcher.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 import contextlib
+import importlib.util
 import logging
 import os
 import shutil
@@ -49,8 +50,29 @@ MK_BG_DELIVER, MK_BG_DELIVER_END = MARKERS[12]
 _BACKUP_SUFFIX = ".hermes_lark.bak"
 
 _HERMES_HOME = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
-_RUN_PATH = _HERMES_HOME / "hermes-agent" / "gateway" / "run.py"
-_CRON_PATH = _HERMES_HOME / "hermes-agent" / "cron" / "scheduler.py"
+
+
+def _resolve_module_path(module_name: str, hardcoded: Path) -> Path:
+    """Discover the actual file path of a Hermes module.
+
+    Works for both git-clone (editable install) and pip-install scenarios.
+    Falls back to the hardcoded path so Patcher can report a clear error.
+    """
+    try:
+        spec = importlib.util.find_spec(module_name)
+        if spec and spec.origin:
+            return Path(spec.origin)
+    except (ModuleNotFoundError, ValueError):
+        pass
+    return hardcoded
+
+
+_RUN_PATH = _resolve_module_path(
+    "gateway.run", _HERMES_HOME / "hermes-agent" / "gateway" / "run.py"
+)
+_CRON_PATH = _resolve_module_path(
+    "cron.scheduler", _HERMES_HOME / "hermes-agent" / "cron" / "scheduler.py"
+)
 
 MK_CRON_DELIVER = f"# {PREFIX}_CRON_DELIVER_BEGIN"
 MK_CRON_DELIVER_END = f"# {PREFIX}_CRON_DELIVER_END"


### PR DESCRIPTION
## Problem

The AST patcher hardcodes `_RUN_PATH` and `_CRON_PATH` relative to `_HERMES_HOME`:

```python
_RUN_PATH = _HERMES_HOME / "hermes-agent" / "gateway" / "run.py"
_CRON_PATH = _HERMES_HOME / "hermes-agent" / "cron" / "scheduler.py"
```

This only works when Hermes uses the standard git-clone layout. When Hermes is installed via pip, the actual files may be in the venv's `site-packages/`, so the patcher targets non-existent paths.

## Solution

Resolve each target using this order:

- **Standard layout first**: use the existing file under `HERMES_HOME/hermes-agent`
- **pip install fallback**: locate the top-level package with `find_spec`, then resolve the child source file from `submodule_search_locations`
- **Safe failure**: retain the original hardcoded path so `Patcher` can report a clear error

The fallback does not import `gateway` or `cron`, avoiding parent-package initialization and runtime side effects during CLI startup.

## Changes

- Add `_resolve_module_path()` with standard-path-first resolution
- Fall back to side-effect-free package discovery for pip installations
- Accept only existing Python source files and resolve symlinks before patching
- Keep `Patcher` and `CronPatcher` constructor behavior unchanged

## Testing

- 407 tests passed
- ruff + mypy clean
- `verify` works against the local Hermes installation
- Verified the standard path bypasses `find_spec`
- Verified the pip fallback does not import parent packages or modify `sys.path`

Closes #55
