### PR TITLE
fix: seal only current card segments on multi-split rollover

### DIFF
--- a/hermes_lark_streaming/streaming/controller.py
+++ b/hermes_lark_streaming/streaming/controller.py
@@ -474,13 +474,14 @@ class StreamingController:
         assert segment_state is not None
         segments = segment_state.segments
         all_steps = session.tool_use.build_display_steps()
+        seal_start_idx = session.split_index
 
         if actions and not await self._do_batch_update(
             session, segments, actions, new_el_ids, new_el_estimates, updated_tool_segs,
         ):
             return False
 
-        seal_segments = [s for s in segments[:split_idx] if s.created]
+        seal_segments = [s for s in segments[seal_start_idx:split_idx] if s.created]
         if session.image_resolver:
             await _resolve_answer_images(
                 seal_segments,

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -554,6 +554,35 @@ class TestDoFlush:
         assert [s.created for s in session.segment_state.segments] == [True, True, True]
 
     @pytest.mark.asyncio
+    async def test_second_split_seals_only_current_card_segments(self) -> None:
+        """多次拆卡时，seal 不应重复包含更早卡片上的 segments."""
+        ctrl = _setup_ctrl()
+        sealed_cards: list[dict] = []
+        ctrl._client.cardkit_create = AsyncMock(return_value="card_page_3")
+        ctrl._client.reply_card_by_id = AsyncMock(return_value="msg_page_3")
+        ctrl._client.cardkit_update = AsyncMock(
+            side_effect=lambda _card_id, card, **_kwargs: sealed_cards.append(card)
+        )
+
+        session = _make_session("msg_second_split")
+        session.state = SessionState.STREAMING
+        session.card_id = "card_page_2"
+        session.card_msg_id = "msg_page_2"
+        session.split_index = 2
+        for index in range(5):
+            seg = Segment("answer", f"answer_{index}")
+            seg.text = f"page content {index}"
+            seg.created = True
+            seg.dirty = False
+            session.segment_state.segments.append(seg)
+
+        assert await ctrl._do_split_card(session, 5, [], set(), {}, []) is True
+
+        contents = [element["content"] for element in sealed_cards[0]["body"]["elements"]]
+        assert contents == ["page content 2", "page content 3", "page content 4"]
+        assert session.split_index == 5
+
+    @pytest.mark.asyncio
     async def test_tool_growth_rolls_over_at_step_boundary(self) -> None:
         """同一个 tool segment 增长超阈值时，在 step 边界拆到新卡继续更新."""
         ctrl = _setup_ctrl()


### PR DESCRIPTION
## Problem

`_do_split_card` seals the old card before rolling over to a new one, building the sealed card from:

```python
seal_segments = [s for s in segments[:split_idx] if s.created]
```

`segments` accumulates across the entire message lifetime, but `split_idx` is only the current split boundary. On a second-or-later split, slicing from `0` re-includes segments that already belong to earlier cards, so the new card's seal re-renders previous cards' content — duplication grows with each rollover.

## Solution

Bound the seal range by `session.split_index`, which always marks the first segment of the currently active card:

```python
seal_start_idx = session.split_index
seal_segments = [s for s in segments[seal_start_idx:split_idx] if s.created]
```

`session.split_index` is an existing invariant — already shared by `active_segments()`, the flush skip guard (`controller.py:172`), and stream_element iteration (`controller.py:278`). The fix reuses it rather than introducing a new mechanism, so the seal range now matches the codebase's existing notion of "current card".

## Changes

- Start the seal range at `session.split_index` instead of `0`
- Read `seal_start_idx` up front (before the batch update), since `split_index` is only written at the end of the method (`controller.py:538`)

## Testing

- 416 tests passed
- ruff + mypy clean
- Added `test_second_split_seals_only_current_card_segments`: simulates a second split (`split_index=2`) and asserts the seal contains only the current card's segments (indices 2/3/4). Under the old code this test fails (5 contents), confirming it captures the regression
- Verified no impact on existing behavior: the only `split_index` write site is `controller.py:538`, so the first split runs with `split_index == 0` and stays byte-for-byte equivalent to the old `segments[:split_idx]`