### PR TITLE
fix: wire base_url into SDK domain for self-hosted/Larksuite

### DIFF
--- a/hermes_lark_streaming/config.py
+++ b/hermes_lark_streaming/config.py
@@ -10,6 +10,8 @@ import yaml
 
 _HERMES_CONFIG_PATH = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))) / "config.yaml"
 
+DEFAULT_DOMAIN = "https://open.feishu.cn"  # SDK 根域名，Larksuite 用 https://open.larksuite.com
+
 
 class Config:
     """插件配置，惰性读取 Hermes 主配置."""
@@ -55,7 +57,7 @@ class Config:
 
     @property
     def feishu_base_url(self) -> str:
-        return str(self._platform_cfg().get("base_url", "https://open.feishu.cn/open-apis"))
+        return str(self._platform_cfg().get("base_url", DEFAULT_DOMAIN))
 
     @property
     def card_duration_sec(self) -> int:
@@ -149,7 +151,7 @@ class Config:
                 "app_secret": self.env_app_secret,
                 "base_url": os.environ.get(
                     "FEISHU_BASE_URL",
-                    os.environ.get("LARK_BASE_URL", "https://open.feishu.cn/open-apis"),
+                    os.environ.get("LARK_BASE_URL", DEFAULT_DOMAIN),
                 ),
             }
         raw = self._load()

--- a/hermes_lark_streaming/feishu.py
+++ b/hermes_lark_streaming/feishu.py
@@ -36,7 +36,11 @@ from lark_oapi.api.im.v1 import (
     ReplyMessageRequestBody,
 )
 
+from .config import DEFAULT_DOMAIN
+
 _logger = logging.getLogger("hermes_lark_streaming")
+
+_OPEN_APIS_SUFFIX = "/open-apis"
 
 CARDKIT_GATEWAY_TIMEOUT = 2200
 CARDKIT_INTERNAL_ERROR = 1663
@@ -88,7 +92,7 @@ MSG_NOT_FOUND = 1000023  # 消息不存在/已删除
 class FeishuClientConfig:
     app_id: str
     app_secret: str
-    base_url: str = "https://open.feishu.cn/open-apis"
+    base_url: str = DEFAULT_DOMAIN
 
     def __post_init__(self) -> None:
         if not isinstance(self.app_id, str) or not self.app_id.strip():
@@ -105,7 +109,13 @@ class FeishuClient:
 
     def __init__(self, config: FeishuClientConfig) -> None:
         self.config = config
-        builder = lark.Client.builder().app_id(config.app_id).app_secret(config.app_secret)
+        domain = config.base_url.strip().rstrip("/").removesuffix(_OPEN_APIS_SUFFIX) or DEFAULT_DOMAIN
+        builder = (
+            lark.Client.builder()
+            .app_id(config.app_id)
+            .app_secret(config.app_secret)
+            .domain(domain)
+        )
         self._client = builder.build()
 
     @staticmethod

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -153,7 +153,7 @@ class TestFeishuBaseURL:
     def test_default_url(self) -> None:
         cfg = _make_config({"feishu": {"app_id": "id", "app_secret": "s"}})
         with patch.dict(os.environ, {}, clear=True):
-            assert cfg.feishu_base_url == "https://open.feishu.cn/open-apis"
+            assert cfg.feishu_base_url == "https://open.feishu.cn"
 
     def test_custom_url_from_config(self) -> None:
         cfg = _make_config({"feishu": {"app_id": "id", "app_secret": "s", "base_url": "https://custom.com"}})


### PR DESCRIPTION
## Problem

`FeishuClientConfig.base_url` was write-only — `controller.py` passed it in, but `FeishuClient.__init__` only used `app_id`/`app_secret` and never called lark-oapi's `.domain()`. Self-hosted or international (Larksuite) users could not route to their own domain; the value was silently ignored.

## Solution

Derive a root domain from `base_url` in the constructor and pass it to `Client.builder().domain()`. The SDK's `.domain()` expects a root domain (`https://open.feishu.cn`), not the `/open-apis` path the old defaults carried, so strip the suffix (plus a trailing slash) for backward compat and fall back to the default when empty.

The default is unchanged for `feishu.cn` users: the SDK's built-in `FEISHU_DOMAIN` constant equals `https://open.feishu.cn`, which matches `DEFAULT_DOMAIN`.

## Changes

- `feishu.py`: constructor now computes `domain` and chains `.domain(domain)`; default value comes from the shared constant
- `config.py`: lift the default to a shared `DEFAULT_DOMAIN` constant so the dataclass default, `feishu_base_url`, and the env (`FEISHU_BASE_URL`/`LARK_BASE_URL`) fallback all reference one value; `_OPEN_APIS_SUFFIX` stays local to `feishu.py` as a transform detail
- `test_config.py`: `test_default_url` asserts the new root-domain default

## Testing

- 405 tests passed
- ruff + mypy clean
- No behavior change for default `feishu.cn` users (explicit `.domain()` value equals the SDK default that was previously relied on)