### PR TITLE
ci: surface failures and capture verify output in hermes-check

### DIFF
--- a/.github/workflows/hermes-check.yml
+++ b/.github/workflows/hermes-check.yml
@@ -43,6 +43,7 @@ jobs:
         id: verify
         continue-on-error: true
         run: |
+          set +e
           python -c "
           import pathlib
           from hermes_lark_streaming.patcher import Patcher, CronPatcher
@@ -51,16 +52,29 @@ jobs:
           cp = CronPatcher(pathlib.Path('hermes_scheduler.py'))
           cp.verify_target()
           print('Both targets compatible.')
-          "
+          " > /tmp/verify.log 2>&1
+          code=$?
+          {
+            echo "exit=${code}"
+            if [ -s /tmp/verify.log ]; then
+              echo "log<<VERIFY_EOF"
+              cat /tmp/verify.log
+              echo "VERIFY_EOF"
+            fi
+          } >> "$GITHUB_OUTPUT"
 
       - name: Open issue on failure
-        if: steps.verify.outcome == 'failure'
+        if: always() && steps.verify.outcome != 'success'
         uses: actions/github-script@v7
+        env:
+          VERIFY_LOG: ${{ steps.verify.outputs.log }}
         with:
           script: |
             const label = 'hermes-compat';
             const title = 'Hermes compatibility check failed';
-            const body = `The daily Hermes compatibility check failed.\n\nPlease check if Hermes has updated function names or injection anchors in \`gateway/run.py\` or \`cron/scheduler.py\`.\n\nWorkflow run: ${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const log = process.env.VERIFY_LOG || '(no output captured — verify step may have been skipped, e.g. upstream fetch / install failure)';
+            const run = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const body = `The Hermes compatibility check failed.\n\nPlease check if Hermes has updated function names or injection anchors in \`gateway/run.py\` or \`cron/scheduler.py\`.\n\n<details><summary>verify output</summary>\n\n\`\`\`\n${log}\n\`\`\`\n\n</details>\n\nWorkflow run: ${run}`;
 
             // Ensure label exists
             try {
@@ -90,3 +104,7 @@ jobs:
                 labels: [label],
               });
             }
+
+      - name: Fail job on compatibility break
+        if: always() && steps.verify.outcome != 'success'
+        run: exit 1


### PR DESCRIPTION
## Problem

The daily `hermes-check` workflow could fail silently with a green job:

- `Run verify` uses `continue-on-error: true`, so a real compatibility break only opens an issue — the job never turns red.
- The `Open issue on failure` step gated on `steps.verify.outcome == 'failure'`. If an earlier step (`Fetch Hermes sources` / `Install plugin`) failed, `verify` never ran (`outcome == 'skipped'`), so **no issue was opened and the job stayed green** — an upstream fetch failure looked identical to a clean pass.
- The issue body was a static template with no error detail; you had to dig through the run logs to see what broke.

## Solution

Capture `verify`'s stdout/stderr into a step output and route it through `env` into the issue, while widening the failure guard to cover both `failure` and `skipped` outcomes:

- `if: always() && steps.verify.outcome != 'success'` fires on both a real verify failure and a skipped verify (upstream fetch / install failure).
- The trailing `Fail job on compatibility break` step (`run: exit 1`) makes a break fail the job too, not just open an issue.
- The `log` is passed via `env: VERIFY_LOG` and read as `process.env.VERIFY_LOG` instead of `${{ }}` interpolation into the JS string literal — avoids the GitHub Actions code-injection pattern (the captured log is a full Python traceback and may contain quotes / source lines).

## Changes

- `Run verify`: `set +e` + redirect to `/tmp/verify.log`, emit `exit=<code>` and a multi-line `log<<VERIFY_EOF` heredoc to `$GITHUB_OUTPUT`
- `Open issue on failure`: guard widened to `always() && steps.verify.outcome != 'success'`; body now includes the verify output in a `<details>` block, supplied via `env` (not `${{ }}`)
- New `Fail job on compatibility break` step: `if: always() && steps.verify.outcome != 'success'` → `run: exit 1`

## Testing

- YAML parses clean; 7 steps, both on-failure guards use the same condition
- Dry-run of the `Run verify` shell against real local Hermes sources: success path emits `exit=0` + correct `log` heredoc; parsed back with the `@actions/core` heredoc format (`KEY<<DELIMITER`) and both outputs resolve
- Failure-path dry-run (pointed `Patcher` at a non-Hermes file): full traceback captured into `log`, which is what the issue body now carries