### PR TITLE
feat: auto-detect Hermes Python and install dir via which hermes

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,152 @@
+# Installation Guide — hermes-lark-streaming
+
+A step-by-step guide to install the hermes-lark-streaming plugin into an existing
+Hermes Agent deployment. Intended to be read and executed by an AI agent or a
+human following the commands verbatim.
+
+## Requirements
+
+- Hermes Agent `>= 0.14.0` is installed and the `hermes` command is on `PATH`
+  (`hermes --version` works).
+- If `hermes` is not on `PATH`, stop — fix the Hermes installation first.
+
+## Step 1 — Locate Hermes's Python
+
+The plugin MUST be installed into Hermes's own venv (the gateway imports it at
+runtime). Find that venv's Python interpreter:
+
+```bash
+# Read the venv path from the hermes CLI wrapper, then derive python3
+HERMES_PYTHON=$(grep -oE 'exec "[^"]+"' "$(which hermes)" | sed 's/exec "//;s/"//')
+HERMES_PYTHON=$(dirname "$HERMES_PYTHON")/python3
+
+# Fallback (per-user default) if the command above yields nothing
+[ -z "$HERMES_PYTHON" ] || [ ! -x "$HERMES_PYTHON" ] && HERMES_PYTHON=~/.hermes/hermes-agent/venv/bin/python3
+```
+
+Verify it exists and is Python 3.11+:
+
+```bash
+"$HERMES_PYTHON" --version
+```
+
+## Step 2 — Install the plugin into Hermes's venv
+
+```bash
+# Clone only if not already present (re-runs / updates skip this)
+[ -d hermes-lark-streaming ] || git clone https://github.com/Cheerwhy/hermes-lark-streaming.git
+cd hermes-lark-streaming
+"$HERMES_PYTHON" -m pip install -e .
+```
+
+## Step 3 — Verify environment and compatibility
+
+```bash
+"$HERMES_PYTHON" -m hermes_lark_streaming status
+"$HERMES_PYTHON" -m hermes_lark_streaming verify
+```
+
+`status` must show:
+
+- `Hermes Python:` pointing to `$HERMES_PYTHON`
+- `Hermes install dir:` pointing to the Hermes source tree
+- No `warning:` line under `Hermes Python:`
+
+`verify` must print `Compatible.` for both targets. If it reports
+`Incompatible:`, the Hermes version is unsupported — do not proceed.
+
+If a status warning appears, the CLI ran under the wrong interpreter — rerun
+using the exact `$HERMES_PYTHON` path printed.
+
+## Step 4 — Configure Feishu / Lark credentials
+
+The plugin needs app credentials for Feishu (or Lark / Larksuite). Set them as
+environment variables **persisted to Hermes's `.env`** (so the gateway sees them
+after restart), or in `~/.hermes/config.yaml`:
+
+```bash
+# Option A — write to ~/.hermes/.env (read by the gateway on start)
+cat >> ~/.hermes/.env <<'EOF'
+FEISHU_APP_ID=cli_xxxxx
+FEISHU_APP_SECRET=xxxxx
+EOF
+chmod 600 ~/.hermes/.env
+```
+
+```yaml
+# Option B — ~/.hermes/config.yaml
+feishu:
+  app_id: cli_xxxxx
+  app_secret: xxxxx
+```
+
+For **Lark / Larksuite** (international), use the `lark` section and set the SDK
+base URL:
+
+```yaml
+lark:
+  app_id: cli_xxxxx
+  app_secret: xxxxx
+  base_url: https://open.larksuite.com
+```
+
+Also enable streaming in the same config:
+
+```yaml
+streaming:
+  enabled: true
+```
+
+## Step 5 — Install the hooks
+
+```bash
+"$HERMES_PYTHON" -m hermes_lark_streaming install
+```
+
+This patches `gateway/run.py` and `cron/scheduler.py` in place. A `.hermes_lark.bak`
+backup is created next to each file.
+
+## Step 6 — Restart the gateway
+
+```bash
+hermes gateway restart
+```
+
+## Step 7 — Post-install verification
+
+```bash
+"$HERMES_PYTHON" -m hermes_lark_streaming status
+```
+
+All hooks should read `installed`, and `Feishu credentials:` should read
+`configured`.
+
+## Uninstall
+
+```bash
+"$HERMES_PYTHON" -m hermes_lark_streaming uninstall
+"$HERMES_PYTHON" -m pip uninstall hermes-lark-streaming
+```
+
+## Update
+
+```bash
+cd hermes-lark-streaming
+git pull
+"$HERMES_PYTHON" -m pip install -e .
+"$HERMES_PYTHON" -m hermes_lark_streaming uninstall   # remove old injection
+"$HERMES_PYTHON" -m hermes_lark_streaming verify
+"$HERMES_PYTHON" -m hermes_lark_streaming install
+hermes gateway restart
+```
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `ModuleNotFoundError: hermes_lark_streaming` | Plugin not installed in the Python you used | Reinstall using the exact `HERMES_PYTHON` from Step 1 |
+| `status` shows `warning: running under ...` | CLI invoked with wrong interpreter | Rerun with the `$HERMES_PYTHON` path shown in the warning |
+| `verify` reports `Incompatible:` | Hermes version unsupported or changed anchors | Check Hermes version `>= 0.14.0`; wait for a plugin update |
+| `gateway/run.py not found` | Hermes install layout not recognized | Run `cat "$(which hermes)"` to find the venv, then set `HERMES_PYTHON` manually |
+| Credentials `MISSING` in `status` | Env vars / config not set, or not persisted | Complete Step 4; ensure credentials are in `~/.hermes/.env` or `config.yaml`, then restart the gateway |
+| Gateway fails to load plugin after restart | Plugin installed into the wrong venv | Confirm `status` shows no warning before restarting |

--- a/README.en.md
+++ b/README.en.md
@@ -53,30 +53,14 @@ When long conversations or excessive tool steps cause the card to approach Feish
 
 ## Installation
 
-> **Note:** Hermes runs in its own Python venv. Install the plugin using Hermes's Python, or the gateway will fail to load it at runtime.
+For the full installation procedure see [INSTALL.md](INSTALL.md).
 
-### AI Agent
+### AI Agent install
 
-Tell your agent to read the README and follow the manual steps:
+Have the AI agent connected to Hermes read the installation guide and execute it:
 
 ```
-curl https://raw.githubusercontent.com/Cheerwhy/hermes-lark-streaming/main/README.md
-```
-
-### Manual
-
-> The plugin reads `HERMES_HOME` from Hermes to locate the installation path (default: `~/.hermes`). It also auto-discovers modules in `site-packages` for pip-installed Hermes — no manual path configuration needed.
-
-```bash
-git clone https://github.com/Cheerwhy/hermes-lark-streaming.git
-cd hermes-lark-streaming
-
-# Install into Hermes's venv so the gateway can load the plugin
-HERMES_PYTHON=~/.hermes/hermes-agent/venv/bin/python3
-$HERMES_PYTHON -m pip install -e .
-$HERMES_PYTHON -m hermes_lark_streaming verify   # Verify compatibility
-$HERMES_PYTHON -m hermes_lark_streaming install   # Inject hooks
-hermes gateway restart
+curl https://raw.githubusercontent.com/Cheerwhy/hermes-lark-streaming/main/INSTALL.md
 ```
 
 ---
@@ -154,7 +138,7 @@ $HERMES_PYTHON -m hermes_lark_streaming verify     # Verify compatibility (no fi
 $HERMES_PYTHON -m hermes_lark_streaming install    # Inject hooks
 $HERMES_PYTHON -m hermes_lark_streaming uninstall  # Remove hooks
 $HERMES_PYTHON -m hermes_lark_streaming restore    # Restore original files from backup
-$HERMES_PYTHON -m hermes_lark_streaming status     # Show status
+$HERMES_PYTHON -m hermes_lark_streaming status     # Show status (incl. Hermes Python/install dir detection)
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -53,30 +53,14 @@
 
 ## 安装
 
-> **注意：** Hermes 运行在独立的 Python 虚拟环境中，请使用 Hermes 的 Python 安装插件，否则 gateway 启动后会无法加载。
+完整安装步骤见 [INSTALL.md](INSTALL.md)。
 
-### AI Agent
+### AI Agent 安装
 
-让 Agent 读取 README 后按手动步骤操作：
+让 Hermes 对接的 AI agent 读取安装指南后自动执行：
 
 ```
-curl https://raw.githubusercontent.com/Cheerwhy/hermes-lark-streaming/main/README.md
-```
-
-### 手动安装
-
-> 插件会自动读取 Hermes 的 `HERMES_HOME` 环境变量定位安装路径（默认 `~/.hermes`），同时支持 pip 安装的 Hermes（自动发现 `site-packages` 中的模块），无需手动指定路径。
-
-```bash
-git clone https://github.com/Cheerwhy/hermes-lark-streaming.git
-cd hermes-lark-streaming
-
-# 安装到 Hermes 的 venv 中，确保 gateway 能加载插件
-HERMES_PYTHON=~/.hermes/hermes-agent/venv/bin/python3
-$HERMES_PYTHON -m pip install -e .
-$HERMES_PYTHON -m hermes_lark_streaming verify   # 验证兼容性
-$HERMES_PYTHON -m hermes_lark_streaming install   # 注入 hook
-hermes gateway restart
+curl https://raw.githubusercontent.com/Cheerwhy/hermes-lark-streaming/main/INSTALL.md
 ```
 
 ---
@@ -154,7 +138,7 @@ $HERMES_PYTHON -m hermes_lark_streaming verify     # 验证兼容性（不修改
 $HERMES_PYTHON -m hermes_lark_streaming install    # 注入 hook
 $HERMES_PYTHON -m hermes_lark_streaming uninstall  # 移除 hook
 $HERMES_PYTHON -m hermes_lark_streaming restore    # 从备份恢复原始文件
-$HERMES_PYTHON -m hermes_lark_streaming status     # 查看状态
+$HERMES_PYTHON -m hermes_lark_streaming status     # 查看状态（含 Hermes Python/安装目录检测）
 ```
 
 ---

--- a/hermes_lark_streaming/__main__.py
+++ b/hermes_lark_streaming/__main__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Callable
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -181,6 +182,21 @@ def _cmd_status() -> int:
     cfg = Config()
     print(f"Config streaming.enabled: {cfg.enabled}")
     print(f"Feishu credentials: {'configured' if (cfg.env_app_id or cfg.feishu_app_id) else 'MISSING'}")
+
+    # Python interpreter check
+    from .patcher import hermes_install_dir, hermes_python
+
+    expected_py = hermes_python()
+    if expected_py is not None:
+        print(f"Hermes Python: {expected_py}")
+        current = Path(sys.executable).resolve()
+        if current != expected_py.resolve():
+            print(f"  warning: running under {current}, but Hermes uses {expected_py}")
+            print(f"  rerun commands with: {expected_py} -m hermes_lark_streaming ...")
+
+    install_dir = hermes_install_dir()
+    if install_dir is not None:
+        print(f"Hermes install dir: {install_dir}")
     return 0
 
 

--- a/hermes_lark_streaming/config.py
+++ b/hermes_lark_streaming/config.py
@@ -16,7 +16,9 @@ def hermes_home() -> Path:
     return Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
 
 
-_HERMES_CONFIG_PATH = hermes_home() / "config.yaml"
+def _config_path() -> Path:
+    """Hermes 主配置路径，惰性计算以响应运行时 HERMES_HOME 变化."""
+    return hermes_home() / "config.yaml"
 
 
 class Config:
@@ -170,8 +172,9 @@ class Config:
     def _load(self) -> dict[str, Any]:
         if self._raw is not None:
             return self._raw
-        if _HERMES_CONFIG_PATH.exists():
-            text = _HERMES_CONFIG_PATH.read_text(encoding="utf-8")
+        path = _config_path()
+        if path.exists():
+            text = path.read_text(encoding="utf-8")
             self._raw = yaml.safe_load(text) or {}
         else:
             self._raw = {}
@@ -179,7 +182,8 @@ class Config:
 
     def _reload(self) -> dict[str, Any]:
         """从磁盘重新读取配置（不更新缓存），供运行时可变的配置项使用."""
-        if _HERMES_CONFIG_PATH.exists():
-            text = _HERMES_CONFIG_PATH.read_text(encoding="utf-8")
+        path = _config_path()
+        if path.exists():
+            text = path.read_text(encoding="utf-8")
             return yaml.safe_load(text) or {}
         return {}

--- a/hermes_lark_streaming/config.py
+++ b/hermes_lark_streaming/config.py
@@ -8,9 +8,15 @@ from typing import Any
 
 import yaml
 
-_HERMES_CONFIG_PATH = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))) / "config.yaml"
-
 DEFAULT_DOMAIN = "https://open.feishu.cn"  # SDK 根域名，Larksuite 用 https://open.larksuite.com
+
+
+def hermes_home() -> Path:
+    """Hermes 主目录，优先级 HERMES_HOME 环境变量 → ~/.hermes."""
+    return Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
+
+
+_HERMES_CONFIG_PATH = hermes_home() / "config.yaml"
 
 
 class Config:

--- a/hermes_lark_streaming/patcher.py
+++ b/hermes_lark_streaming/patcher.py
@@ -11,6 +11,8 @@ import shutil
 import tempfile
 from pathlib import Path
 
+from .config import hermes_home
+
 _logger = logging.getLogger("hermes_lark_streaming")
 
 
@@ -49,8 +51,6 @@ MK_BG_DELIVER, MK_BG_DELIVER_END = MARKERS[12]
 
 _BACKUP_SUFFIX = ".hermes_lark.bak"
 
-_HERMES_HOME = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
-
 
 def _valid_source(path: Path) -> Path | None:
     try:
@@ -62,34 +62,47 @@ def _valid_source(path: Path) -> Path | None:
     return None
 
 
-def _resolve_module_path(module_name: str, hardcoded: Path) -> Path:
-    """Discover the actual file path of a Hermes module.
+def _module_to_path(module_name: str) -> Path:
+    """gateway.run → gateway/run.py."""
+    return Path(*module_name.split(".")).with_suffix(".py")
 
-    Uses the standard Hermes home layout when available, then falls back to
-    module discovery for pip-install scenarios without importing parent packages.
-    """
-    if candidate := _valid_source(hardcoded):
-        return candidate
 
+# 候选代码根目录，按优先级排列（来源: Hermes 官方安装文档 Install Layout）。
+# - per-user git installer: <HERMES_HOME>/hermes-agent/
+# - root-mode (sudo curl|bash): /usr/local/lib/hermes-agent/
+def _code_roots() -> list[Path]:
+    return [hermes_home() / "hermes-agent", Path("/usr/local/lib/hermes-agent")]
+
+
+def _resolve_module_path(module_name: str, roots: list[Path]) -> Path:
+    """定位 Hermes 模块文件，候选代码根优先，importlib 兜底."""
+    rel = _module_to_path(module_name)
+    for root in roots:
+        if candidate := _valid_source(root / rel):
+            return candidate
+
+    package = module_name.partition(".")[0]
     try:
-        package_name, _, relative_name = module_name.partition(".")
-        spec = importlib.util.find_spec(package_name)
-        if spec and spec.submodule_search_locations:
-            relative_path = Path(*relative_name.split(".")).with_suffix(".py")
-            for location in spec.submodule_search_locations:
-                if candidate := _valid_source(Path(location) / relative_path):
-                    return candidate
+        spec = importlib.util.find_spec(package)
+        locations = spec.submodule_search_locations if spec else None
+        # submodule_search_locations 指向包目录（如 .../gateway），
+        # 因此需剥掉包名前缀，得到包内子路径。
+        in_pkg = rel.relative_to(Path(package)) if rel.parts[0] == package else rel
+        for location in locations or []:
+            if candidate := _valid_source(Path(location) / in_pkg):
+                return candidate
     except Exception:
         _logger.debug("Failed to resolve Hermes module %s", module_name, exc_info=True)
-    return hardcoded
+    return roots[0] / rel if roots else rel
 
 
-_RUN_PATH = _resolve_module_path(
-    "gateway.run", _HERMES_HOME / "hermes-agent" / "gateway" / "run.py"
-)
-_CRON_PATH = _resolve_module_path(
-    "cron.scheduler", _HERMES_HOME / "hermes-agent" / "cron" / "scheduler.py"
-)
+def _default_run_path() -> Path:
+    return _resolve_module_path("gateway.run", _code_roots())
+
+
+def _default_cron_path() -> Path:
+    return _resolve_module_path("cron.scheduler", _code_roots())
+
 
 MK_CRON_DELIVER = f"# {PREFIX}_CRON_DELIVER_BEGIN"
 MK_CRON_DELIVER_END = f"# {PREFIX}_CRON_DELIVER_END"
@@ -461,10 +474,15 @@ class Patcher:
 
     MARKERS: list[tuple[str, str]] = MARKERS
 
-    def __init__(self, run_path: Path = _RUN_PATH) -> None:
-        self.run_path = run_path
-        if not run_path.exists():
-            raise PatcherError(f"run.py not found: {run_path}")
+    def __init__(self, run_path: Path | None = None) -> None:
+        self.run_path = run_path or _default_run_path()
+        if not self.run_path.exists():
+            tried = ", ".join(str(r) for r in _code_roots())
+            raise PatcherError(
+                f"gateway/run.py not found: {self.run_path} "
+                f"(tried: {tried}). "
+                f"Set HERMES_HOME to the dir containing hermes-agent/ and rerun."
+            )
 
     def is_patched(self) -> bool:
         return MK_START in self.run_path.read_text(encoding="utf-8")
@@ -741,10 +759,15 @@ def _safe_indent(lines: list[str], lineno: int) -> str:
 class CronPatcher:
     """注入 CRON_DELIVER hook 到 cron/scheduler.py 的 _deliver_result."""
 
-    def __init__(self, cron_path: Path = _CRON_PATH) -> None:
-        self.cron_path = cron_path
-        if not cron_path.exists():
-            raise PatcherError(f"scheduler.py not found: {cron_path}")
+    def __init__(self, cron_path: Path | None = None) -> None:
+        self.cron_path = cron_path or _default_cron_path()
+        if not self.cron_path.exists():
+            tried = ", ".join(str(r) for r in _code_roots())
+            raise PatcherError(
+                f"cron/scheduler.py not found: {self.cron_path} "
+                f"(tried: {tried}). "
+                f"Set HERMES_HOME to the dir containing hermes-agent/ and rerun."
+            )
 
     def is_patched(self) -> bool:
         return MK_CRON_DELIVER in self.cron_path.read_text(encoding="utf-8")

--- a/hermes_lark_streaming/patcher.py
+++ b/hermes_lark_streaming/patcher.py
@@ -7,7 +7,9 @@ import contextlib
 import importlib.util
 import logging
 import os
+import re
 import shutil
+import subprocess
 import tempfile
 from pathlib import Path
 
@@ -72,6 +74,85 @@ def _module_to_path(module_name: str) -> Path:
 # - root-mode (sudo curl|bash): /usr/local/lib/hermes-agent/
 def _code_roots() -> list[Path]:
     return [hermes_home() / "hermes-agent", Path("/usr/local/lib/hermes-agent")]
+
+
+# venv 内 python 解释器候选（覆盖 venv/.venv 命名变体）。
+_VENV_PYTHONS: tuple[tuple[str, ...], ...] = (
+    ("venv", "bin", "python3"),
+    ("venv", "bin", "python"),
+    (".venv", "bin", "python3"),
+    (".venv", "bin", "python"),
+)
+
+
+def _python_from_hermes_cli() -> Path | None:
+    """从 which hermes 反推 venv 内的 python3。"""
+    cli = shutil.which("hermes")
+    if cli is None:
+        return None
+    cli_path = Path(cli)
+    # 读脚本内容，依次试 exec 行(bash wrapper) 和 shebang(console_scripts)
+    try:
+        text = cli_path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return None
+    # 1. bash wrapper: exec "venv/bin/hermes" → 同目录 python3
+    m = re.search(r'''exec\s+["']([^"']+)["']''', text)
+    if m:
+        venv_bin = Path(m.group(1)).parent  # venv/bin
+        for name in ("python3", "python"):
+            py = venv_bin / name
+            if py.exists():
+                return py
+    # 2. console_scripts: shebang #!/path/to/python3 直接指向 python
+    m = re.match(r'^#!\s*(\S+)', text)
+    if m:
+        py = Path(m.group(1))
+        if py.exists() and "python" in py.name.lower():
+            return py
+    return None
+
+
+def hermes_python() -> Path | None:
+    """定位 Hermes 的 Python: which hermes 优先, _code_roots 兜底."""
+    # 1. which hermes (覆盖所有官方安装方式，跨平台)
+    if py := _python_from_hermes_cli():
+        return py
+    # 2. 兜底: 已知代码根下的 venv
+    for root in _code_roots():
+        for parts in _VENV_PYTHONS:
+            py = root.joinpath(*parts)
+            if py.exists():
+                return py
+    return None
+
+
+def hermes_install_dir() -> Path | None:
+    """定位 Hermes 安装目录 (含 gateway/run.py): hermes_constants 优先, _code_roots 兜底."""
+    # 1. 用 Hermes Python 调用官方 API (single source of truth)
+    py = hermes_python()
+    if py is not None:
+        try:
+            result = subprocess.run(
+                [str(py), "-c", "from hermes_constants import get_hermes_home; print(get_hermes_home())"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except (OSError, subprocess.SubprocessError):
+            _logger.debug("hermes_constants lookup failed", exc_info=True)
+        else:
+            if result.returncode == 0:
+                home = Path(result.stdout.strip())
+                install = home / "hermes-agent"
+                if install.exists():
+                    return install
+    # 2. 兜底: _code_roots 里含 gateway/run.py 的那个
+    rel = _module_to_path("gateway.run")
+    for root in _code_roots():
+        if (root / rel).exists():
+            return root
+    return None
 
 
 def _resolve_module_path(module_name: str, roots: list[Path]) -> Path:

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,122 @@
+"""Hermes 路径发现测试 — 单一来源、HERMES_HOME 响应、多候选代码根、importlib 兜底."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+from hermes_lark_streaming import config as config_mod
+from hermes_lark_streaming import patcher as patcher_mod
+from hermes_lark_streaming.config import hermes_home
+from hermes_lark_streaming.patcher import (
+    CronPatcher,
+    Patcher,
+    PatcherError,
+    _code_roots,
+    _default_cron_path,
+    _default_run_path,
+    _resolve_module_path,
+)
+
+
+def test_single_source() -> None:
+    """hermes_home() 是 Hermes 主目录的唯一定义方，patcher 不应重复定义。"""
+    assert not hasattr(patcher_mod, "_HERMES_HOME")
+    assert patcher_mod.hermes_home is config_mod.hermes_home
+
+
+def test_hermes_home_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    assert hermes_home() == Path.home() / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "a"))
+    assert hermes_home() == tmp_path / "a"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "b"))
+    assert hermes_home() == tmp_path / "b"
+
+
+def test_code_roots_includes_root_mode(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """_code_roots() 含 root-mode 固定路径 /usr/local/lib/hermes-agent."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    roots = _code_roots()
+    assert tmp_path / "hermes-agent" in roots
+    assert Path("/usr/local/lib/hermes-agent") in roots
+
+
+@pytest.mark.parametrize(
+    ("module_name", "rel"),
+    [("gateway.run", "gateway/run.py"), ("cron.scheduler", "cron/scheduler.py")],
+)
+def test_resolve_first_root_hit(module_name: str, rel: str, tmp_path: Path) -> None:
+    """第一个候选根命中标准布局。"""
+    target = tmp_path / "hermes-agent" / rel
+    target.parent.mkdir(parents=True)
+    target.write_text("# stub\n")
+    assert _resolve_module_path(module_name, [tmp_path / "hermes-agent"]) == target.resolve()
+
+
+def test_resolve_falls_through_to_second_root(tmp_path: Path) -> None:
+    """第一个候选不存在时，落到第二个候选命中。"""
+    second = tmp_path / "lib" / "hermes-agent"
+    target = second / "gateway" / "run.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("# stub\n")
+    # 第一个候选 tmp_path/hermes-agent 不存在，应继续到 second
+    assert _resolve_module_path("gateway.run", [tmp_path / "hermes-agent", second]) == target.resolve()
+
+
+def test_resolve_falls_back_to_first_root_when_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """所有候选和 importlib 都找不到时，返回第一个候选下的路径（即使不存在）。
+
+    屏蔽 find_spec，避免命中测试环境真实安装的 gateway/cron 包。
+    """
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
+    root = tmp_path / "hermes-agent"
+    assert _resolve_module_path("gateway.run", [root]) == (root / "gateway" / "run.py")
+
+
+@pytest.mark.parametrize(
+    ("default_path", "rel"),
+    [(_default_run_path, "gateway/run.py"), (_default_cron_path, "cron/scheduler.py")],
+)
+def test_default_path_respects_hermes_home(
+    default_path: object, rel: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """默认路径用当前 HERMES_HOME 计算，不冻结于 import 时。"""
+    target = tmp_path / "hermes-agent" / rel
+    target.parent.mkdir(parents=True)
+    target.write_text("# stub\n")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    assert default_path() == target.resolve()  # type: ignore[operator]
+
+
+@pytest.mark.parametrize(
+    ("cls", "label"),
+    [(Patcher, "gateway/run.py"), (CronPatcher, "scheduler.py")],
+)
+def test_not_found_diagnostic_lists_tried_roots(
+    cls: type, label: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """找不到目标时报错列出所有尝试过的候选根 + HERMES_HOME 提示。"""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
+    with pytest.raises(PatcherError) as exc_info:
+        cls()
+    msg = str(exc_info.value)
+    assert label in msg
+    assert "tried:" in msg
+    assert str(tmp_path / "hermes-agent") in msg
+    assert "/usr/local/lib/hermes-agent" in msg
+    assert "HERMES_HOME" in msg
+
+
+def test_explicit_path_bypasses_discovery(tmp_path: Path) -> None:
+    """显式传 path 时不走发现逻辑，直接用传入值。"""
+    run_py = tmp_path / "run.py"
+    run_py.write_text("# stub\n")
+    assert Patcher(run_path=run_py).run_path == run_py

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -131,6 +131,9 @@ def test_hermes_python_found_via_code_roots(
     """which hermes 不可用时，_code_roots 兜底命中 <code_root>/venv/bin/python3。"""
     # 屏蔽 which hermes，强制走兜底
     monkeypatch.setattr("hermes_lark_streaming.patcher.shutil.which", lambda _: None)
+    # 屏蔽系统级 root-mode 路径，避免 CI 机器命中真实安装
+    monkeypatch.setattr("hermes_lark_streaming.patcher._code_roots",
+                        lambda: [tmp_path / "hermes-agent"])
     py = tmp_path / "hermes-agent" / "venv" / "bin" / "python3"
     py.parent.mkdir(parents=True)
     py.write_text("#!/bin/sh\n")
@@ -141,6 +144,8 @@ def test_hermes_python_found_via_code_roots(
 def test_hermes_python_not_found(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """which hermes 和 _code_roots 都失败时返回 None。"""
     monkeypatch.setattr("hermes_lark_streaming.patcher.shutil.which", lambda _: None)
+    monkeypatch.setattr("hermes_lark_streaming.patcher._code_roots",
+                        lambda: [tmp_path / "hermes-agent"])
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     assert hermes_python() is None
 
@@ -185,6 +190,9 @@ def test_hermes_install_dir_falls_back_to_code_roots(
     """hermes_constants 不可用时（subprocess 失败），_code_roots 兜底命中含 gateway/run.py 的目录。"""
     # 让 hermes_python 返回一个不存在的 python（强制 subprocess 失败）
     monkeypatch.setattr("hermes_lark_streaming.patcher.shutil.which", lambda _: None)
+    # 屏蔽系统级 root-mode 路径，避免 CI 机器命中真实安装
+    monkeypatch.setattr("hermes_lark_streaming.patcher._code_roots",
+                        lambda: [tmp_path / "hermes-agent"])
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     # 构造 <home>/hermes-agent/gateway/run.py
     run_py = tmp_path / "hermes-agent" / "gateway" / "run.py"

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -17,7 +17,10 @@ from hermes_lark_streaming.patcher import (
     _code_roots,
     _default_cron_path,
     _default_run_path,
+    _python_from_hermes_cli,
     _resolve_module_path,
+    hermes_install_dir,
+    hermes_python,
 )
 
 
@@ -120,3 +123,71 @@ def test_explicit_path_bypasses_discovery(tmp_path: Path) -> None:
     run_py = tmp_path / "run.py"
     run_py.write_text("# stub\n")
     assert Patcher(run_path=run_py).run_path == run_py
+
+
+def test_hermes_python_found_via_code_roots(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """which hermes 不可用时，_code_roots 兜底命中 <code_root>/venv/bin/python3。"""
+    # 屏蔽 which hermes，强制走兜底
+    monkeypatch.setattr("hermes_lark_streaming.patcher.shutil.which", lambda _: None)
+    py = tmp_path / "hermes-agent" / "venv" / "bin" / "python3"
+    py.parent.mkdir(parents=True)
+    py.write_text("#!/bin/sh\n")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    assert hermes_python() == py
+
+
+def test_hermes_python_not_found(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """which hermes 和 _code_roots 都失败时返回 None。"""
+    monkeypatch.setattr("hermes_lark_streaming.patcher.shutil.which", lambda _: None)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    assert hermes_python() is None
+
+
+def test_python_from_hermes_cli_unix(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Unix: hermes 是 bash 脚本，解析 exec 行得到 venv/bin/python3。"""
+    venv_bin = tmp_path / "hermes-agent" / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    (venv_bin / "python3").write_text("#!/bin/sh\n")
+    cli_script = tmp_path / "hermes"
+    cli_script.write_text(f'#!/usr/bin/env bash\nexec "{venv_bin / "hermes"}" "$@"\n')
+    monkeypatch.setattr("hermes_lark_streaming.patcher.shutil.which", lambda _: str(cli_script))
+    assert _python_from_hermes_cli() == venv_bin / "python3"
+
+
+def test_python_from_hermes_cli_console_scripts(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """pip/console_scripts 安装: hermes 是 Python 脚本，shebang 直接指向 python3。"""
+    venv_bin = tmp_path / "hermes-agent" / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    py = venv_bin / "python3"
+    py.write_text("#!/bin/sh\n")
+    cli_script = tmp_path / "hermes"
+    # console_scripts 格式: 无 exec 行，shebang 是 python 路径
+    cli_script.write_text(f"#!{py}\n# -*- coding: utf-8 -*-\nimport sys\nfrom hermes_cli.main import main\n")
+    monkeypatch.setattr("hermes_lark_streaming.patcher.shutil.which", lambda _: str(cli_script))
+    assert _python_from_hermes_cli() == py
+
+
+def test_python_from_hermes_cli_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """hermes 不在 PATH 时返回 None。"""
+    monkeypatch.setattr("hermes_lark_streaming.patcher.shutil.which", lambda _: None)
+    assert _python_from_hermes_cli() is None
+
+
+def test_hermes_install_dir_falls_back_to_code_roots(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """hermes_constants 不可用时（subprocess 失败），_code_roots 兜底命中含 gateway/run.py 的目录。"""
+    # 让 hermes_python 返回一个不存在的 python（强制 subprocess 失败）
+    monkeypatch.setattr("hermes_lark_streaming.patcher.shutil.which", lambda _: None)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    # 构造 <home>/hermes-agent/gateway/run.py
+    run_py = tmp_path / "hermes-agent" / "gateway" / "run.py"
+    run_py.parent.mkdir(parents=True)
+    run_py.write_text("# stub\n")
+    assert hermes_install_dir() == (tmp_path / "hermes-agent").resolve()


### PR DESCRIPTION
## Problem

Hermes path discovery had three gaps:

1. **`_HERMES_HOME` was duplicated** in `config.py` and `patcher.py` — each computed `HERMES_HOME` independently, so a future change to one (e.g. a new default) would silently desync the patched source-file path from the `config.yaml` path.

2. **Python interpreter was undocumented guesswork.** README hardcoded `HERMES_PYTHON=~/.hermes/hermes-agent/venv/bin/python3`, which is wrong for root-mode installs (`/usr/local/lib/hermes-agent/venv/`) and custom `HERMES_HOME`. There was no way to detect the right interpreter — the plugin just assumed the default per-user path.

3. **Install layout assumptions were narrow.** `_code_roots()` only covered `<home>/hermes-agent/` and `/usr/local/lib/hermes-agent/`; custom `HERMES_HOME`, Homebrew, and Nix installs fell through to an importlib fallback that rarely hit.

## Solution

Adopt `which hermes` as the primary location signal — it is the one entry point every official install method wires into `PATH`, and it carries the venv path in its wrapper script. Layer `_code_roots()` as a fallback for when `hermes` isn't on `PATH`.

**Path discovery (`patcher.py`):**
- Consolidate `HERMES_HOME` into a single `config.hermes_home()` source; `patcher` imports it instead of redefining.
- `_resolve_module_path` takes a list of candidate code roots (`<home>/hermes-agent`, `/usr/local/lib/hermes-agent`) and resolves per-call — runtime `HERMES_HOME` changes take effect without re-importing.
- Fix a latent bug where the standard-layout path dropped the package dir (resolved to `hermes-agent/run.py` instead of `hermes-agent/gateway/run.py`).

**Python & install dir detection (`patcher.py`):**
- `hermes_python()`: reads the `hermes` CLI wrapper — parses the `exec` line (git installer) or the `#!` shebang (pip/console_scripts) — to find the venv's `python3`. Falls back to `_VENV_PYTHONS` candidates under `_code_roots()`.
- `hermes_install_dir()`: runs `hermes_constants.get_hermes_home()` (Hermes's own single source of truth) via the detected Python, appends `/hermes-agent`. Falls back to `_code_roots()` when the subprocess fails (e.g. root-mode where data dir ≠ code dir).

**CLI (`__main__.py`):**
- `status` now prints `Hermes Python:` and `Hermes install dir:`, and warns when the CLI runs under a different interpreter than Hermes uses.

**Docs:**
- New `INSTALL.md`: a structured, AI-agent-executable installation guide (locate Python → install → verify → configure credentials → inject hooks → restart), with Update/Uninstall/Troubleshooting sections. Feishu *and* Lark/Larksuite credential setup covered; env vars must be persisted to `~/.hermes/.env`.
- README install sections simplified to point at `INSTALL.md`; AI agent curl target changed from `README.md` to `INSTALL.md`.

## Changes

- `config.py`: extract `hermes_home()` as the single source of truth
- `patcher.py`: `hermes_python()` (which hermes → exec/shebang → venv python), `hermes_install_dir()` (hermes_constants subprocess + fallback), `_code_roots()` multi-root, lazy `_default_run_path`/`_default_cron_path`
- `__main__.py`: status shows Hermes Python + install dir + mismatch warning
- `INSTALL.md`: new AI-agent-executable installation guide
- `README.md` / `README.en.md`: simplified install sections, link to INSTALL.md
- `tests/test_paths.py`: 18 tests covering single-source, HERMES_HOME override, multi-root hit order, importlib fallback, which-hermes parsing (bash exec / console_scripts shebang), install_dir fallback, not-found diagnostics

## Testing

- 429 tests passed
- ruff + mypy clean
- `status` smoke test: `Hermes Python:` and `Hermes install dir:` correct, no warning under the right interpreter
- End-to-end reinstall (uninstall → install → status → verify → syntax check): all pass
- INSTALL.md executed step-by-step: Step 1 locates Python, Step 3 status clean, Step 4 verify Compatible
- Verified `which hermes` failure gracefully falls back to `_code_roots()`

> Windows native support is intentionally deferred — code and docs cover macOS/Linux only for now.