### PR TITLE
fix: recover stale segment after 300313 to break partial_update loop

### DIFF
--- a/hermes_lark_streaming/streaming/controller.py
+++ b/hermes_lark_streaming/streaming/controller.py
@@ -402,6 +402,23 @@ class StreamingController:
                 action_summary,
                 exc_info=True,
             )
+            # 缺失元素（300313）时回滚 stale segment：本地 created=True 但卡片上不存在，
+            # 下一轮 flush 会用 add_elements 重建该元素，避免反复 partial_update 死循环。
+            if missing_el_id:
+                for seg in segments[session.split_index:]:
+                    if seg.el_id == missing_el_id and seg.created:
+                        seg.created = False
+                        seg.dirty = True
+                        # 同步扣减元素计数：该 segment 当初 add 成功时已累加进 element_count，
+                        # 回滚为未创建后下一轮会重新 add 并再次累加，这里先扣除避免重复计数。
+                        session.element_count -= seg.element_estimate
+                        if session.element_count < 0:
+                            session.element_count = 0
+                        _logger.info(
+                            "CardKit recovered stale segment %s -> will re-add on next flush",
+                            seg.el_id,
+                        )
+                        break
             self._handle_flush_error(e)
             return False
         return True

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -792,6 +792,59 @@ class TestDoFlush:
         assert session.segment_state.segments[-1].created is True
 
     @pytest.mark.asyncio
+    async def test_batch_update_recovers_stale_segment_on_missing_element(self) -> None:
+        """300313 (not find elementID) 后回滚 stale segment，下一轮 flush 走 add 重建，不再死循环."""
+        ctrl = _setup_ctrl()
+        client = ctrl._client
+
+        session = _make_session("msg_stale")
+        session.state = SessionState.STREAMING
+        session.card_id = "card_stale"
+        session.card_msg_id = "msg_stale_card"
+        # 一个已创建的 tool segment（本地 created=True，但模拟卡片上已不存在）
+        session.tool_use.record_start("read", "file0")
+        session.segment_state.on_tool_event(1)
+        tool_seg = session.segment_state.segments[0]
+        tool_seg.created = True
+        tool_seg.element_estimate = estimate_segment_elements(tool_seg, session.tool_use.build_display_steps())
+        session.element_count = tool_seg.element_estimate
+        ctrl._sessions["msg_stale"] = session
+
+        stale_el_id = tool_seg.el_id
+        # 第一次 batch_update 抛 300313 — 引用了卡片上不存在的 el_id
+        client.cardkit_batch_update = AsyncMock(
+            side_effect=[
+                FeishuAPIError(
+                    f"cardkit_batch_update: code=300313, msg=ErrMsg: not find elementID : {stale_el_id};",
+                    300313,
+                ),
+                None,
+            ]
+        )
+
+        # 新增 tool step 触发 dirty → flush 走 partial_update 分支 → 300313
+        session.tool_use.record_start("read", "file1")
+        session.segment_state.on_tool_event(len(session.tool_use.build_display_steps()))
+
+        await ctrl._do_flush(session)
+
+        # 回滚：stale segment 被标记为未创建 + 脏，等下一轮重建
+        assert tool_seg.created is False
+        assert tool_seg.dirty is True
+        # element_count 同步扣减（避免下一轮 add 重复累加导致阈值虚高、误触发拆分）
+        assert session.element_count == 0
+
+        # 第二次 flush：走 add_elements 重建，batch_update 成功
+        await ctrl._do_flush(session)
+
+        assert tool_seg.created is True
+        # 重建后 element_count = 当前 tool steps（2 个）的新估算值，无重复计数
+        expected = estimate_segment_elements(tool_seg, session.tool_use.build_display_steps())
+        assert session.element_count == expected
+        # 两次 batch_update 调用：第一次失败，第二次成功（非死循环重试 N 次）
+        assert client.cardkit_batch_update.await_count == 2
+
+    @pytest.mark.asyncio
     async def test_reasoning_finalized_snapshot(self) -> None:
         ctrl = _setup_ctrl()
         session = _make_session("msg_snap")


### PR DESCRIPTION
## Problem

When a card split left a segment locally `created=True` but the element no longer existed on the target card (state drift), `cardkit_batch_update` returned **300313 (not find elementID)**. The failure path (`_do_batch_update` except branch) only logged the error and returned `False` — it did not touch segment state, so `created=True` + `dirty=True` survived unchanged.

The next flush re-entered the `partial_update_element` branch with the **same stale el_id** → same 300313 → … repeated 20+ times until text fallback, freezing the streaming card mid-response (issue #49 logs).

Reported in #49 and #63. (The original death-loop root cause was largely fixed by #44 — `created=False` reset on split — and #67 — seal range fix. This PR adds the missing **failure-path recovery** so any residual drift self-heals instead of looping.)

## Solution

In the `_do_batch_update` failure path, when `extract_missing_element_id(e)` identifies the missing element, roll the matching segment back to `created=False` + `dirty=True`:

- The next flush walks the `add_elements` branch (`build_add_segment_action`) and rebuilds the element from scratch on the current card — no more stale `partial_update_element`.
- Only matches `segments[session.split_index:]` (current card scope) **and** `seg.created` (so a genuinely-not-yet-added element is never double-rolled).
- Triggered only when the error message contains `not find elementID`; rate-limit / network / 300305 errors return an empty match and skip recovery entirely.

`element_count` is adjusted in lockstep: the segment was counted when first added, so subtract `seg.element_estimate` on rollback. Without this, re-add double-counts the estimate, inflates the threshold, and triggers spurious splits.

| Stage | element_count | seg.element_estimate |
|-------|---------------|---------------------|
| 1 step add ok | 8 | 8 |
| +file1 → partial_update fails 300313 | 8 | 8 |
| **rollback** | **8−8 = 0** | 8 |
| re-add (2 steps) ok | 0+13 = **13** | 13 |

The deduction is provably necessary: temporarily removing `element_count -= seg.element_estimate` makes the new test fail (`8` instead of `0`).

## Changes

- `streaming/controller.py` — `_do_batch_update` except branch: roll back the missing segment (`created=False`, `dirty=True`) and deduct `element_count` after the warning log, before `_handle_flush_error`.
- `tests/test_controller.py` — `test_batch_update_recovers_stale_segment_on_missing_element`: simulates 300313 on a stale tool segment, asserts rollback (`created=False`, `dirty=True`, `element_count==0`) then re-add (`created=True`, `element_count==new estimate`), and `batch_update.await_count == 2` (converges, no loop).

## Testing

- 430 tests passed (+1 new)
- ruff + mypy clean
- Verified the deduction is load-bearing via inverse experiment (disable deduction → test fails)

Closes #49, closes #63