### PR TITLE
feat: Feishu clarify card + model picker + status bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### 新增
+
+- **Clarify 卡片化**：`clarify` 工具在飞书端不再渲染编号文本，而是发送原生交互卡片
+  （问题 + 选项按钮 +「其他」自定义输入按钮）。按钮点击通过 `clarify_gateway`
+  原语解析，内联更新卡片显示已选项。实现完全基于 Hermes 文档化的 `send_clarify`
+  扩展点与 `_on_card_action_trigger` 回调分发，由新增的 `FeishuAdapterPatcher`
+  注入 `gateway/platforms/feishu.py`（与现有 `Patcher`/`CronPatcher` 平行、幂等、可逆）。
+  发送失败自动回退 `super().send_clarify`（编号文本），不影响其他平台。
+
 ## [0.11.2] - 2026-07-01
 
 ### 修复

--- a/hermes_lark_streaming/__main__.py
+++ b/hermes_lark_streaming/__main__.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .patcher import CronPatcher, Patcher
+    from .patcher import CronPatcher, FeishuAdapterPatcher, Patcher
 
 
 def main() -> int:
@@ -68,6 +68,15 @@ def _get_cron_patcher() -> CronPatcher | None:
         return None
 
 
+def _get_feishu_patcher() -> FeishuAdapterPatcher | None:
+    from .patcher import FeishuAdapterPatcher, PatcherError
+
+    try:
+        return FeishuAdapterPatcher()
+    except PatcherError:
+        return None
+
+
 def _cmd_install() -> int:
     patcher = _get_patcher()
     if patcher is None:
@@ -101,6 +110,15 @@ def _cmd_install() -> int:
         except Exception as e:
             print(f"Cron hook skipped: {e}")
 
+    feishu_patcher = _get_feishu_patcher()
+    if feishu_patcher is not None and not feishu_patcher.is_fully_patched():
+        try:
+            feishu_patcher.verify_target()
+            feishu_patcher.apply()
+            print("Feishu clarify-card hook applied.")
+        except Exception as e:
+            print(f"Feishu clarify-card hook skipped: {e}")
+
     return 0
 
 
@@ -116,6 +134,14 @@ def _cmd_uninstall() -> int:
             print("Cron hook removed.")
         except Exception as e:
             print(f"Cron hook remove failed: {e}")
+
+    feishu_patcher = _get_feishu_patcher()
+    if feishu_patcher is not None and feishu_patcher.is_patched():
+        try:
+            feishu_patcher.remove()
+            print("Feishu clarify-card hook removed.")
+        except Exception as e:
+            print(f"Feishu clarify-card remove failed: {e}")
 
     if not patcher.is_patched():
         print("Not patched.")
@@ -141,6 +167,14 @@ def _cmd_restore() -> int:
         try:
             cron_patcher.restore()
             print("Cron hook restored.")
+        except Exception:
+            pass
+
+    feishu_patcher = _get_feishu_patcher()
+    if feishu_patcher is not None:
+        try:
+            feishu_patcher.restore()
+            print("Feishu clarify-card hook restored.")
         except Exception:
             pass
 
@@ -175,6 +209,12 @@ def _cmd_status() -> int:
     cron_patcher = _get_cron_patcher()
     if cron_patcher is not None:
         print(f"Cron hook: {'installed' if cron_patcher.is_patched() else 'not installed'}")
+
+    feishu_patcher = _get_feishu_patcher()
+    if feishu_patcher is not None:
+        print(
+            f"Feishu clarify-card: {'installed' if feishu_patcher.is_fully_patched() else 'not installed'}"
+        )
 
     # Check config
     from .config import Config
@@ -223,6 +263,16 @@ def _cmd_verify() -> int:
             print(f"Cron incompatible: {e}")
             return 1
         print("Cron target compatible.")
+
+    feishu_patcher = _get_feishu_patcher()
+    if feishu_patcher is not None:
+        print(f"Feishu target: {feishu_patcher.feishu_path}")
+        try:
+            feishu_patcher.verify_target()
+        except Exception as e:
+            print(f"Feishu clarify-card incompatible: {e}")
+            return 1
+        print("Feishu target compatible.")
 
     return 0
 

--- a/hermes_lark_streaming/cardkit/builder.py
+++ b/hermes_lark_streaming/cardkit/builder.py
@@ -21,6 +21,7 @@ REASONING_TEXT_ELEMENT_ID = "reasoning_text"
 TOOL_PANEL_ELEMENT_ID = "tool_panel"
 _LOADING_ELEMENT_ID = "loading_icon"
 _LOADING_IMG_KEY = "img_v3_02vb_496bec09-4b43-4773-ad6b-0cdd103cd2bg"
+STATUS_BAR_ELEMENT_ID = "status_bar"
 
 
 def _collapsible_panel(
@@ -103,6 +104,17 @@ def _loading_element() -> dict:
             "size": "16px 16px",
         },
         "element_id": _LOADING_ELEMENT_ID,
+    }
+
+
+def _status_bar_element() -> dict:
+    """Bottom status bar — updated via partial_update_element."""
+    return {
+        "tag": "markdown",
+        "content": " ",
+        "text_size": "notation",
+        "text_color": "grey",
+        "element_id": STATUS_BAR_ELEMENT_ID,
     }
 
 
@@ -429,6 +441,7 @@ def build_streaming_card_v2(
     if show_streaming_element:
         elements.append(_streaming_element(text_size=text_size))
     elements.append(_loading_element())
+    elements.append(_status_bar_element())
 
     card = {
         "schema": "2.0",

--- a/hermes_lark_streaming/clarify.py
+++ b/hermes_lark_streaming/clarify.py
@@ -1,0 +1,426 @@
+"""Feishu clarify-as-card: render the ``clarify`` tool prompt as a native
+Feishu interactive card with choice buttons instead of a numbered text list.
+
+This mirrors the adapter's existing ``send_exec_approval`` / ``hermes_action``
+card-action pattern, but for clarify.  It builds on Hermes's canonical
+clarify primitive in ``tools.clarify_gateway`` (register / wait_for_response
+/ resolve_gateway_clarify) — no custom polling or state machine here.
+
+Wiring (installed by ``patcher.FeishuAdapterPatcher`` into
+``gateway/platforms/feishu.py``):
+
+  * ``send_clarify`` override on the Feishu adapter → :func:`send_clarify_card`
+    builds the card (markdown question + ``tag:action`` choice buttons + an
+    "Other" free-text button) and sends it as a plain ``interactive`` message.
+  * clarify branch in ``_on_card_action_trigger`` → :func:`handle_clarify_card_action`
+    resolves the pending clarify (``resolve_gateway_clarify`` for a choice,
+    ``mark_awaiting_text`` for "Other") and returns an inline updated card.
+
+The blocking/resolution is handled entirely by ``_clarify_callback_sync`` in
+``gateway/run.py`` + ``clarify_gateway`` — this module only customises the
+*rendering* (card vs text) and the *callback dispatch*.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger("hermes_lark_streaming")
+
+# Match tools.clarify_tool.MAX_CHOICES — the agent offers at most 4 predefined
+# choices; a 5th "Other" (free-text) button is always appended by this module.
+MAX_CHOICE_BUTTONS = 4
+
+# Action value keys (mirrors the ``hermes_action`` / ``hermes_update_prompt_action``
+# convention used by approval / update-prompt cards).
+_CLARIFY_KEY = "hermes_clarify"
+_ACTION_CHOOSE = "choose"
+_ACTION_OTHER_SUBMIT = "other_submit"
+
+# Store original questions so resolved cards can display context.
+# Keyed by clarify_id, cleaned up on resolve.
+_clarify_questions: dict[str, str] = {}
+
+
+# ---------------------------------------------------------------------------
+# lark-oapi response classes (same guarded import as the adapter)
+# ---------------------------------------------------------------------------
+try:  # pragma: no cover - exercised in the adapter process, not in unit tests
+    from lark_oapi.event.callback.model.p2_card_action_trigger import (  # type: ignore
+        CallBackCard,
+        P2CardActionTriggerResponse,
+    )
+except Exception:  # pragma: no cover
+    CallBackCard = None  # type: ignore[assignment]
+    P2CardActionTriggerResponse = None  # type: ignore[assignment]
+
+
+def _empty_response() -> Any:
+    """Return the SDK's empty card-action response (or None if unavailable)."""
+    return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+
+def _card_action_response(card_data: dict[str, Any]) -> Any:
+    """Wrap a card dict in P2CardActionTriggerResponse for inline update."""
+    if P2CardActionTriggerResponse is None:
+        return None
+    response = P2CardActionTriggerResponse()
+    if CallBackCard is not None:
+        card = CallBackCard()
+        card.type = "raw"
+        card.data = card_data
+        response.card = card
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Card builders
+# ---------------------------------------------------------------------------
+def build_clarify_card(
+    *,
+    question: str,
+    choices: list[str] | None,
+    clarify_id: str,
+) -> dict[str, Any]:
+    """Build the Feishu interactive card for a clarify prompt.
+
+    * ``choices`` non-empty → one button per choice (first is ``primary``).
+      Each button ``value`` carries the ``clarify_id`` so the card-action
+      callback can resolve it.  An input element with callback behavior is
+      also included for free-text entry.
+    * ``choices`` empty/None → open-ended prompt, no buttons (the gateway's
+      text-intercept captures the next message — ``awaiting_text`` is already
+      True from ``clarify_gateway.register``).
+    """
+    prompt = (question or "").strip() or "请选择"
+    elements: list[dict[str, Any]] = [{"tag": "markdown", "content": prompt}]
+
+    if choices:
+        buttons: list[dict[str, Any]] = []
+        for idx, choice in enumerate(choices[:MAX_CHOICE_BUTTONS]):
+            label = str(choice).strip()
+            if not label:
+                continue
+            buttons.append(
+                {
+                    "tag": "button",
+                    "text": {"tag": "plain_text", "content": label},
+                    "type": "primary" if idx == 0 else "default",
+                    "value": {
+                        _CLARIFY_KEY: _ACTION_CHOOSE,
+                        "clarify_id": clarify_id,
+                        "choice": label,
+                    },
+                }
+            )
+        if buttons:
+            elements.extend(buttons)
+
+    # Divider between buttons and input
+    elements.append({"tag": "hr"})
+
+    # Input with behaviors — input's built-in submit icon triggers callback
+    # behaviors.value carries hermes_clarify so the adapter's clarify check matches
+    # action.input_value carries the user's typed text
+    elements.append(
+        {
+            "tag": "input",
+            "name": "clarify_text",
+            "placeholder": {"tag": "plain_text", "content": "输入自定义回答后点提交图标..."},
+            "behaviors": [
+                {
+                    "type": "callback",
+                    "value": {
+                        _CLARIFY_KEY: _ACTION_OTHER_SUBMIT,
+                        "clarify_id": clarify_id,
+                    },
+                }
+            ],
+        }
+    )
+
+    return {
+        "schema": "2.0",
+        "header": {
+            "title": {"content": "❓ 需要澄清", "tag": "plain_text"},
+            "template": "orange",
+        },
+        "body": {"elements": elements},
+    }
+
+
+def build_clarify_resolved_card(
+    *,
+    question: str,
+    chosen: str | None = None,
+    awaiting_text: bool = False,
+) -> dict[str, Any]:
+    """Build the inline replacement card shown after a button click.
+
+    ``chosen`` set → green "已选择" card showing the chosen answer.
+    ``awaiting_text`` → blue card prompting the user to type a free-form answer.
+    """
+    prompt = (question or "").strip()
+    if chosen is not None:
+        body = f"{prompt}\n\n**已选择：** {chosen}" if prompt else f"**已选择：** {chosen}"
+        return {
+            "schema": "2.0",
+            "header": {
+                "title": {"content": "✅ 已选择", "tag": "plain_text"},
+                "template": "green",
+            },
+            "body": {"elements": [{"tag": "markdown", "content": body}]},
+        }
+    if awaiting_text:
+        body = f"{prompt}\n\n请在对话中输入你的回答" if prompt else "请在对话中输入你的回答"
+        return {
+            "schema": "2.0",
+            "header": {
+                "title": {"content": "✍️ 请输入回答", "tag": "plain_text"},
+                "template": "blue",
+            },
+            "body": {"elements": [{"tag": "markdown", "content": body}]},
+        }
+    # Fallback (shouldn't happen) — neutral confirmation.
+    return {
+        "schema": "2.0",
+        "header": {"title": {"content": "✓", "tag": "plain_text"}, "template": "grey"},
+        "body": {"elements": [{"tag": "markdown", "content": prompt or "已处理"}]},
+    }
+
+
+# ---------------------------------------------------------------------------
+# send_clarify override (called from the injected adapter method)
+# ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Session rotation: complete old streaming card, create new session
+# ---------------------------------------------------------------------------
+async def _rotate_streaming_session(chat_id: str) -> None:
+    """Complete the current streaming card and create a new session.
+
+    Called from ``_rotate_and_resolve`` before resolving the clarify. This
+    ensures that post-clarify agent output goes to a new streaming card
+    instead of appending to the old one.
+
+    Must be async because ``_do_complete_card`` runs on the event loop and
+    its ``finally`` clause calls ``_cleanup(message_id)``.  We must await
+    completion (including cleanup) BEFORE creating the new session — otherwise
+    the fire-and-forget cleanup would delete the new session (same message_id).
+    """
+    from .controller import get_controller
+    from .streaming.session import CardSession
+
+    ctrl = get_controller()
+
+    # Find active session for this chat_id
+    active_session = None
+    for session in ctrl._sessions.values():
+        if getattr(session, "chat_id", "") == chat_id and not session.state.is_terminal:
+            active_session = session
+            break
+
+    if active_session is None:
+        return
+
+    message_id = active_session.message_id
+    anchor_id = active_session.anchor_id
+    loop = active_session._loop
+
+    active_session.flush.mark_completed()
+    try:
+        await ctrl._do_complete_card(active_session)
+    except Exception:
+        # Ensure old session is cleaned up even if _do_complete_card failed
+        if ctrl._sessions.get(message_id) is active_session:
+            ctrl._cleanup(message_id)
+
+    # Now safe to create new session — _do_complete_card's _cleanup already ran
+    new_session = CardSession(message_id, chat_id, loop)
+    if anchor_id:
+        new_session.anchor_id = anchor_id
+        ctrl._sessions[anchor_id] = new_session
+    ctrl._sessions[message_id] = new_session
+
+    # Create the new streaming card and AWAIT it.
+    try:
+        await ctrl._do_create_card(new_session)
+    except Exception:
+        logger.warning("Failed to create new card during rotation", exc_info=True)
+
+    logger.info(
+        "Rotated streaming card for clarify: msg=%s chat=%s",
+        message_id[:12],
+        chat_id[:12],
+    )
+
+
+async def send_clarify_card(
+    adapter: Any,
+    *,
+    chat_id: str,
+    question: str,
+    choices: list[str] | None,
+    clarify_id: str,
+    session_key: str,
+    metadata: dict[str, Any] | None = None,
+) -> Any:
+    """Send the clarify interactive card.
+
+    Before sending, finalizes the current streaming card session and creates
+    a new one, so post-clarify agent output goes to a fresh card instead of
+    appending to the old one.
+    """
+    # No rotation here — the old streaming card stays alive while the
+    # clarify card is displayed.  Rotation happens AFTER the user clicks
+    # a button (in handle_clarify_card_action), so the user sees the
+    # clarify card first, and only then does the old card close and a
+    # new one open for post-clarify output.
+    card = build_clarify_card(
+        question=question, choices=choices, clarify_id=clarify_id
+    )
+    _clarify_questions[clarify_id] = question or ""
+    # 用 CardKit API 发送（input 元素只在 CardKit 卡片里渲染）
+    try:
+        from .controller import get_controller
+        ctrl = get_controller()
+        if ctrl._client is not None:
+            card_id = await ctrl._client.cardkit_create(card)
+            result_msg_id = await ctrl._client.send_card_to_chat(
+                chat_id=chat_id,
+                card={"type": "card", "data": {"card_id": card_id}},
+            )
+            try:
+                from gateway.platforms.base import SendResult
+                return SendResult(success=True, message_id=result_msg_id, error=None)
+            except ImportError:
+                import types
+                return types.SimpleNamespace(success=True, message_id=result_msg_id, error=None)
+    except Exception as e:
+        logger.warning("CardKit send failed for clarify, falling back to im API: %s", e)
+    # Fallback: im API（input 不渲染，但卡片能发）
+    payload = json.dumps(card, ensure_ascii=False)
+    response = await adapter._feishu_send_with_retry(
+        chat_id=chat_id,
+        msg_type="interactive",
+        payload=payload,
+        reply_to=None,
+        metadata=metadata,
+    )
+    return adapter._finalize_send_result(response, "send_clarify_card failed")
+
+
+# ---------------------------------------------------------------------------
+# Card-action callback handler (called from the injected _on_card_action_trigger branch)
+# ---------------------------------------------------------------------------
+def _action_value(action_value: Any) -> dict[str, Any]:
+    if isinstance(action_value, dict):
+        return action_value
+    return {}
+
+
+def handle_clarify_card_action(
+    adapter: Any,
+    *,
+    event: Any,
+    action_value: Any,
+    loop: Any,
+) -> Any:
+    """Synchronous card-action handler for clarify button clicks.
+
+    Returns the inline replacement card immediately (so all Feishu clients
+    update instantly), then schedules an async task that:
+      1. Rotates the streaming card session (complete old → create new)
+      2. Resolves the pending clarify (unblocks the agent)
+
+    The rotation MUST complete before resolve, otherwise post-clarify output
+    has no session to stream to.  Scheduling them as one coroutine guarantees
+    ordering.
+
+    Stale clicks (already-resolved / timed-out / unknown clarify_id) are
+    dropped silently.
+    """
+    value = _action_value(action_value)
+    if not value.get(_CLARIFY_KEY):
+        return _empty_response()
+
+    clarify_id = str(value.get("clarify_id") or "")
+    action = str(value.get(_CLARIFY_KEY) or "")
+    if not clarify_id:
+        logger.debug("[Feishu] clarify card action missing clarify_id, ignoring")
+        return _empty_response()
+
+    # Operator authorisation — same gate as approval/update-prompt.
+    operator = getattr(event, "operator", None)
+    open_id = str(getattr(operator, "open_id", "") or "")
+    if (
+        hasattr(adapter, "_is_interactive_operator_authorized")
+        and not adapter._is_interactive_operator_authorized(open_id)
+    ):
+        logger.warning(
+            "[Feishu] Unauthorized clarify click by %s", open_id or "<unknown>"
+        )
+        return _empty_response()
+
+    # chat_id is in event.context.open_chat_id (same as approval handler)
+    chat_id = str(
+        getattr(getattr(event, "context", None), "open_chat_id", "") or ""
+    )
+
+    chosen: str | None = None
+    awaiting_text = False
+    if action == _ACTION_CHOOSE:
+        chosen = str(value.get("choice") or "")
+        if not chosen:
+            return _empty_response()
+        # Schedule: rotate session → resolve clarify (order matters!)
+        adapter._submit_on_loop(
+            loop,
+            _rotate_and_resolve(chat_id, clarify_id, chosen),
+        )
+    elif action == _ACTION_OTHER_SUBMIT:
+        # Extract text from input_value (v2 card) or form_value (v1 fallback)
+        action_obj = getattr(event, "action", None)
+        chosen = str(getattr(action_obj, "input_value", None) or "").strip()
+        if not chosen:
+            form_value = getattr(action_obj, "form_value", None) or {}
+            chosen = str(form_value.get("clarify_text") or "").strip()
+        if not chosen:
+            return _empty_response()
+        adapter._submit_on_loop(
+            loop,
+            _rotate_and_resolve(chat_id, clarify_id, chosen),
+        )
+    else:
+        return _empty_response()
+
+    if P2CardActionTriggerResponse is None:
+        return _empty_response()
+    question = _clarify_questions.pop(clarify_id, "")
+    response = P2CardActionTriggerResponse()
+    if CallBackCard is not None:
+        card = CallBackCard()
+        card.type = "raw"
+        card.data = build_clarify_resolved_card(
+            question=question, chosen=chosen, awaiting_text=awaiting_text
+        )
+        response.card = card
+    return response
+
+
+async def _rotate_and_resolve(
+    chat_id: str, clarify_id: str, choice: str
+) -> None:
+    """Rotate streaming session, then resolve the clarify.
+
+    Rotation must finish before resolve so the new session is ready
+    when the agent unblocks.
+    """
+    from tools.clarify_gateway import resolve_gateway_clarify
+    if chat_id:
+        await _rotate_streaming_session(chat_id)
+    resolve_gateway_clarify(clarify_id, choice)
+
+
+

--- a/hermes_lark_streaming/clarify.py
+++ b/hermes_lark_streaming/clarify.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import json
 import logging
 from typing import Any
+import os
 
 logger = logging.getLogger("hermes_lark_streaming")
 
@@ -354,14 +355,15 @@ def handle_clarify_card_action(
     # Operator authorisation — same gate as approval/update-prompt.
     operator = getattr(event, "operator", None)
     open_id = str(getattr(operator, "open_id", "") or "")
-    if (
-        hasattr(adapter, "_is_interactive_operator_authorized")
-        and not adapter._is_interactive_operator_authorized(open_id)
-    ):
-        logger.warning(
-            "[Feishu] Unauthorized clarify click by %s", open_id or "<unknown>"
-        )
-        return _empty_response()
+    if os.getenv("FEISHU_ALLOW_ALL_USERS", "").lower() not in {"true", "1", "yes"}:
+        if (
+            hasattr(adapter, "_is_interactive_operator_authorized")
+            and not adapter._is_interactive_operator_authorized(open_id)
+        ):
+            logger.warning(
+                "[Feishu] Unauthorized clarify click by %s", open_id or "<unknown>"
+            )
+            return _empty_response()
 
     # chat_id is in event.context.open_chat_id (same as approval handler)
     chat_id = str(

--- a/hermes_lark_streaming/clarify.py
+++ b/hermes_lark_streaming/clarify.py
@@ -25,8 +25,8 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
 import os
+from typing import Any
 
 logger = logging.getLogger("hermes_lark_streaming")
 
@@ -355,15 +355,16 @@ def handle_clarify_card_action(
     # Operator authorisation — same gate as approval/update-prompt.
     operator = getattr(event, "operator", None)
     open_id = str(getattr(operator, "open_id", "") or "")
-    if os.getenv("FEISHU_ALLOW_ALL_USERS", "").lower() not in {"true", "1", "yes"}:
-        if (
-            hasattr(adapter, "_is_interactive_operator_authorized")
-            and not adapter._is_interactive_operator_authorized(open_id)
-        ):
-            logger.warning(
-                "[Feishu] Unauthorized clarify click by %s", open_id or "<unknown>"
-            )
-            return _empty_response()
+    if (
+        os.getenv("FEISHU_ALLOW_ALL_USERS", "").lower() not in {"true", "1", "yes"}
+        and hasattr(adapter, "_is_interactive_operator_authorized")
+        and not adapter._is_interactive_operator_authorized(open_id)
+    ):
+        logger.warning(
+            "[Feishu] Unauthorized clarify click by %s", open_id or "<unknown>"
+        )
+        return _empty_response()
+
 
     # chat_id is in event.context.open_chat_id (same as approval handler)
     chat_id = str(

--- a/hermes_lark_streaming/model_picker.py
+++ b/hermes_lark_streaming/model_picker.py
@@ -1,0 +1,354 @@
+"""Feishu model picker: render the ``/model`` command as a native Feishu
+interactive card with a dropdown selector instead of a text list.
+
+Wiring (installed by ``patcher.FeishuAdapterPatcher`` into
+``gateway/platforms/feishu.py``):
+
+  * ``send_model_picker`` override on the Feishu adapter → sends a blue-header
+    card with a ``select_static`` dropdown listing all available models.
+  * model_picker branch in ``_on_card_action_trigger`` → calls the
+    ``on_model_selected`` callback, returns an inline updated green card.
+
+The model switch logic is handled entirely by ``slash_commands.py``'s
+``_on_model_selected`` closure — this module only customises the rendering.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import time
+from typing import Any
+
+logger = logging.getLogger("hermes_lark_streaming")
+
+# lark-oapi response classes (same guarded import as clarify.py)
+try:  # pragma: no cover - exercised in the adapter process, not in unit tests
+    from lark_oapi.event.callback.model.p2_card_action_trigger import (  # type: ignore
+        CallBackCard,
+        P2CardActionTriggerResponse,
+    )
+except Exception:  # pragma: no cover
+    CallBackCard = None  # type: ignore[assignment]
+    P2CardActionTriggerResponse = None  # type: ignore[assignment]
+
+
+def _empty_response() -> Any:
+    return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+
+# ---------------------------------------------------------------------------
+# Option builders
+# ---------------------------------------------------------------------------
+def _model_picker_options(
+    providers: Any,
+    *,
+    current_model: str = "",
+    max_options: int = 24,
+) -> list[dict[str, Any]]:
+    """Build select_static options from providers list."""
+    options: list[dict[str, Any]] = []
+    if not isinstance(providers, list):
+        return options
+    current = str(current_model or "").strip()
+    for provider in providers:
+        if not isinstance(provider, dict):
+            continue
+        provider_slug = str(
+            provider.get("slug") or provider.get("provider") or ""
+        ).strip()
+        provider_name = str(
+            provider.get("name") or provider_slug or "provider"
+        ).strip()
+        models = provider.get("models")
+        if not isinstance(models, list):
+            continue
+        for model in models:
+            model_id = str(model or "").strip()
+            if not model_id:
+                continue
+            label = f"{provider_name} · {model_id}"
+            if model_id == current:
+                label = f"当前 · {label}"
+            options.append(
+                {
+                    "text": {
+                        "tag": "plain_text",
+                        "content": label[:80],
+                    },
+                    "value": json.dumps(
+                        {"provider": provider_slug, "model": model_id},
+                        ensure_ascii=False,
+                    ),
+                }
+            )
+            if len(options) >= max_options:
+                return options
+    return options
+
+
+def _parse_model_picker_choice(choice: str) -> tuple[str, str] | None:
+    """Parse a select_static choice into (provider_slug, model_id)."""
+    try:
+        data = json.loads(choice)
+    except Exception:
+        return None
+    if not isinstance(data, dict):
+        return None
+    provider = str(data.get("provider") or "").strip()
+    model = str(data.get("model") or "").strip()
+    if not provider or not model:
+        return None
+    return provider, model
+
+
+# ---------------------------------------------------------------------------
+# Card builders
+# ---------------------------------------------------------------------------
+def build_model_picker_card(
+    *,
+    providers: Any,
+    current_model: str,
+    current_provider: str,
+    picker_id: str,
+) -> dict[str, Any] | None:
+    """Build the model picker card with a select_static dropdown."""
+    all_options = _model_picker_options(providers, current_model=current_model, max_options=1000)
+    all_count = len(all_options)
+    options = all_options[:24]
+    if not options:
+        return None
+
+    description_parts: list[str] = []
+    if current_model:
+        description_parts.append(f"当前模型：`{current_model}`")
+    if current_provider:
+        description_parts.append(f"当前 provider：`{current_provider}`")
+    if all_count > len(options):
+        description_parts.append(
+            f"展示前 {len(options)} 个可选模型，"
+            f"可继续用 `/model <模型名>` 精确切换。"
+        )
+
+    initial_option = ""
+    for opt in options:
+        opt_value = str(opt.get("value") or "")
+        if current_model and opt_value and current_model in opt_value:
+            initial_option = opt_value
+            break
+
+    return {
+        "config": {"wide_screen_mode": True},
+        "header": {
+            "title": {"content": "选择模型", "tag": "plain_text"},
+            "template": "blue",
+        },
+        "elements": [
+            {
+                "tag": "markdown",
+                "content": "\n".join(description_parts) or "请选择模型。",
+            },
+            {
+                "tag": "action",
+                "actions": [
+                    {
+                        "tag": "select_static",
+                        "placeholder": {
+                            "tag": "plain_text",
+                            "content": "选择模型",
+                        },
+                        "value": {
+                            "hfc_action": "model_picker",
+                            "hfc_model_picker_id": picker_id,
+                        },
+                        "options": options,
+                        "initial_option": initial_option,
+                    }
+                ],
+            },
+        ],
+    }
+
+
+def build_model_picker_resolved_card(
+    *,
+    result_text: str,
+    success: bool = True,
+) -> dict[str, Any]:
+    """Build the inline replacement card after model selection."""
+    template = "green" if success else "red"
+    title = "模型已更新" if success else "模型切换失败"
+    return {
+        "config": {"wide_screen_mode": True},
+        "header": {
+            "title": {"content": title, "tag": "plain_text"},
+            "template": template,
+        },
+        "elements": [{"tag": "markdown", "content": result_text}],
+    }
+
+
+# ---------------------------------------------------------------------------
+# send_model_picker (called from injected adapter method)
+# ---------------------------------------------------------------------------
+async def send_model_picker(
+    adapter: Any,
+    *,
+    chat_id: str,
+    providers: Any,
+    current_model: str,
+    current_provider: str,
+    session_key: str,
+    on_model_selected: Any,
+    metadata: dict[str, Any] | None = None,
+) -> Any:
+    """Send the model picker card with a dropdown selector."""
+    picker_id = "model_" + hashlib.sha256(
+        f"{chat_id}:{session_key}:{time.time()}".encode()
+    ).hexdigest()[:16]
+
+    card = build_model_picker_card(
+        providers=providers,
+        current_model=current_model,
+        current_provider=current_provider,
+        picker_id=picker_id,
+    )
+    if card is None:
+        return adapter._finalize_send_result(
+            None, "send_model_picker: no model options"
+        )
+
+    payload = json.dumps(card, ensure_ascii=False)
+    response = await adapter._feishu_send_with_retry(
+        chat_id=chat_id,
+        msg_type="interactive",
+        payload=payload,
+        reply_to=None,
+        metadata=metadata,
+    )
+    result = adapter._finalize_send_result(
+        response, "send_model_picker failed"
+    )
+
+    # Store picker state on adapter instance
+    if not hasattr(adapter, "_hfc_model_picker_state"):
+        adapter._hfc_model_picker_state = {}
+    message_id = getattr(result, "message_id", "") or ""
+    adapter._hfc_model_picker_state[picker_id] = {
+        "chat_id": str(chat_id or ""),
+        "session_key": str(session_key or ""),
+        "message_id": message_id,
+        "on_model_selected": on_model_selected,
+    }
+
+    logger.info(
+        "Model picker card sent: picker_id=%s message_id=%s",
+        picker_id,
+        message_id,
+    )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Card-action callback handler
+# ---------------------------------------------------------------------------
+def handle_model_picker_action(
+    adapter: Any,
+    *,
+    event: Any,
+    action_value: Any,
+    loop: Any,
+) -> Any:
+    """Handle model picker select_static callback.
+
+    Called from the injected ``_on_card_action_trigger`` branch when
+    ``action_value`` contains ``hfc_action == "model_picker"``.
+    """
+    value = action_value if isinstance(action_value, dict) else {}
+
+    picker_id = str(value.get("hfc_model_picker_id") or "")
+    if not picker_id:
+        return _empty_response()
+
+    # Get picker state
+    state = getattr(adapter, "_hfc_model_picker_state", {})
+    if not isinstance(state, dict):
+        return _empty_response()
+    item = state.get(picker_id)
+    if not isinstance(item, dict):
+        return _empty_response()
+
+    # Operator authorization
+    operator = getattr(event, "operator", None)
+    open_id = str(getattr(operator, "open_id", "") or "")
+    if (
+        hasattr(adapter, "_is_interactive_operator_authorized")
+        and not adapter._is_interactive_operator_authorized(open_id)
+    ):
+        logger.warning(
+            "[Feishu] Unauthorized model picker click by %s",
+            open_id or "<unknown>",
+        )
+        return _empty_response()
+
+    # For select_static, the selected option's value is in event.action.option
+    # (NOT in action_value — action_value only has the select_static's own
+    # value dict with hfc_action / hfc_model_picker_id).
+    action = getattr(event, "action", None)
+    choice = str(getattr(action, "option", "") or "")
+    selected = _parse_model_picker_choice(choice)
+    if selected is None:
+        # Invalid choice — return error card
+        if P2CardActionTriggerResponse is None:
+            return None
+        response = P2CardActionTriggerResponse()
+        if CallBackCard is not None:
+            card = CallBackCard()
+            card.type = "raw"
+            card.data = build_model_picker_resolved_card(
+                result_text="模型选择无效，请重新发送 `/model`。",
+                success=False,
+            )
+            response.card = card
+        return response
+
+    provider_slug, model_id = selected
+    callback = item.get("on_model_selected")
+
+    try:
+        if callback is None:
+            result_text = f"已选择 {provider_slug}/{model_id}"
+        else:
+            # callback is async — schedule on loop and wait
+            future = asyncio.run_coroutine_threadsafe(
+                callback(
+                    str(item.get("chat_id") or ""),
+                    model_id,
+                    provider_slug,
+                ),
+                loop,
+            )
+            result_text = future.result(timeout=30)
+    except Exception as exc:
+        result_text = f"模型切换失败：{exc}"
+
+    # Clean up state
+    state.pop(picker_id, None)
+
+    # Return updated card
+    if P2CardActionTriggerResponse is None:
+        return None
+    response = P2CardActionTriggerResponse()
+    if CallBackCard is not None:
+        card = CallBackCard()
+        card.type = "raw"
+        card.data = build_model_picker_resolved_card(
+            result_text=str(
+                result_text or f"已选择 {provider_slug}/{model_id}"
+            ),
+            success=True,
+        )
+        response.card = card
+    return response

--- a/hermes_lark_streaming/patch.py
+++ b/hermes_lark_streaming/patch.py
@@ -305,3 +305,22 @@ async def on_background_deliver(
     except Exception as exc:
         _logger.warning("on_background_deliver error: %s", exc, exc_info=True)
         return False
+
+
+@_safe_hook(default_return=False, log_level="debug")
+def on_status_heartbeat(*, ctrl: Any, message_id: str, text: str) -> bool:
+    """[注入点 12] _notify_long_running — heartbeat status text.
+
+    Catches the "⏳ Working — N min — iteration X/Y" heartbeat before it's
+    sent as a separate text message.  If a streaming card is active, routes
+    the text to the card's status_bar element instead and returns True to
+    consume it.  Returns False when no card is active (gateway falls back
+    to the original send).
+    """
+    session = ctrl._get_active_session(message_id)
+    if session is None:
+        return False
+    session.status_text = text
+    session.status_dirty = True
+    ctrl._schedule_flush(session)
+    return True

--- a/hermes_lark_streaming/patcher.py
+++ b/hermes_lark_streaming/patcher.py
@@ -34,6 +34,7 @@ _HOOK_NAMES = [
     "ABORT",
     "INTERRUPT",
     "BG_DELIVER",
+    "STATUS",
 ]
 MARKERS: list[tuple[str, str]] = [(f"# {PREFIX}_{n}_BEGIN", f"# {PREFIX}_{n}_END") for n in _HOOK_NAMES]
 
@@ -50,6 +51,7 @@ MK_BACKGROUND_REVIEW, MK_BACKGROUND_REVIEW_END = MARKERS[9]
 MK_ABORT, MK_ABORT_END = MARKERS[10]
 MK_INTERRUPT, MK_INTERRUPT_END = MARKERS[11]
 MK_BG_DELIVER, MK_BG_DELIVER_END = MARKERS[12]
+MK_STATUS, MK_STATUS_END = MARKERS[13]
 
 _BACKUP_SUFFIX = ".hermes_lark.bak"
 
@@ -185,8 +187,28 @@ def _default_cron_path() -> Path:
     return _resolve_module_path("cron.scheduler", _code_roots())
 
 
+def _default_feishu_path() -> Path:
+    return _resolve_module_path("gateway.platforms.feishu", _code_roots())
+
+
 MK_CRON_DELIVER = f"# {PREFIX}_CRON_DELIVER_BEGIN"
 MK_CRON_DELIVER_END = f"# {PREFIX}_CRON_DELIVER_END"
+
+# Clarify-as-card markers (injected into gateway/platforms/feishu.py by
+# FeishuAdapterPatcher): a send_clarify method override + a clarify branch
+# in _on_card_action_trigger. See hermes_lark_streaming.clarify.
+MK_SEND_CLARIFY = f"# {PREFIX}_SEND_CLARIFY_BEGIN"
+MK_SEND_CLARIFY_END = f"# {PREFIX}_SEND_CLARIFY_END"
+MK_CLARIFY_ACTION = f"# {PREFIX}_CLARIFY_ACTION_BEGIN"
+MK_CLARIFY_ACTION_END = f"# {PREFIX}_CLARIFY_ACTION_END"
+
+# Model picker markers (injected into gateway/platforms/feishu.py by
+# FeishuAdapterPatcher): a send_model_picker method override + a model_picker
+# branch in _on_card_action_trigger. See hermes_lark_streaming.model_picker.
+MK_SEND_MODEL_PICKER = f"# {PREFIX}_SEND_MODEL_PICKER_BEGIN"
+MK_SEND_MODEL_PICKER_END = f"# {PREFIX}_SEND_MODEL_PICKER_END"
+MK_MODEL_PICKER_ACTION = f"# {PREFIX}_MODEL_PICKER_ACTION_BEGIN"
+MK_MODEL_PICKER_ACTION_END = f"# {PREFIX}_MODEL_PICKER_ACTION_END"
 
 _ANCHOR_CHECKS: list[tuple[str, tuple[str, ...], str]] = [
     ("Restart typing indicator so the user sees activity", (), "interrupt"),
@@ -515,6 +537,117 @@ def _bg_deliver_hook(indent: str) -> str:
     )
 
 
+def _status_hook(indent: str) -> str:
+    return _make_hook(
+        indent,
+        MK_STATUS,
+        MK_STATUS_END,
+        [
+            "try:",
+            "    from hermes_lark_streaming.patch import on_status_heartbeat",
+            "    if on_status_heartbeat(message_id=event_message_id, text=_heartbeat_text):",
+            "        continue",
+            "except Exception:",
+            "    pass",
+        ],
+    )
+
+
+def _send_clarify_method_hook(indent: str) -> str:
+    """Render the injected ``send_clarify`` override (Feishu adapter method).
+
+    A thin delegator: if the Feishu client is connected, send the clarify card
+    via ``hermes_lark_streaming.clarify.send_clarify_card``; otherwise (or on
+    failure) fall back to ``super().send_clarify`` (the base numbered-text
+    render).  ``super()`` resolves correctly because this method is textually
+    inserted into the Feishu adapter class body.
+    """
+    return _make_hook(
+        indent,
+        MK_SEND_CLARIFY,
+        MK_SEND_CLARIFY_END,
+        [
+            "async def send_clarify(self, chat_id, question, choices, clarify_id, session_key, metadata=None):",
+            "    if not self._client:",
+            "        return await super().send_clarify(chat_id=chat_id, question=question, choices=choices, clarify_id=clarify_id, session_key=session_key, metadata=metadata)",
+            "    try:",
+            "        from hermes_lark_streaming.clarify import send_clarify_card as _lark_send_clarify",
+            "        return await _lark_send_clarify(self, chat_id=chat_id, question=question, choices=choices, clarify_id=clarify_id, session_key=session_key, metadata=metadata)",
+            "    except Exception:",
+            "        logger.warning('[Feishu] clarify card send failed, falling back to text', exc_info=True)",
+            "        return await super().send_clarify(chat_id=chat_id, question=question, choices=choices, clarify_id=clarify_id, session_key=session_key, metadata=metadata)",
+        ],
+    )
+
+
+def _clarify_action_hook(indent: str) -> str:
+    """Render the clarify branch injected into ``_on_card_action_trigger``.
+
+    Runs after ``action_value`` / ``hermes_action`` are extracted, before the
+    ``if hermes_action:`` approval dispatch.  Clarify button clicks (value key
+    ``hermes_clarify``) are routed to ``handle_clarify_card_action`` which
+    resolves the pending clarify and returns an inline updated card.  Other
+    card actions fall through unchanged.
+    """
+    return _make_hook(
+        indent,
+        MK_CLARIFY_ACTION,
+        MK_CLARIFY_ACTION_END,
+        [
+            "try:",
+            "    if isinstance(action_value, dict) and action_value.get('hermes_clarify'):",
+            "        from hermes_lark_streaming.clarify import handle_clarify_card_action as _lark_clarify_action",
+            "        return _lark_clarify_action(self, event=event, action_value=action_value, loop=loop)",
+            "except Exception:",
+            "    logger.warning('[Feishu] clarify card action handler failed', exc_info=True)",
+        ],
+    )
+
+
+def _send_model_picker_method_hook(indent: str) -> str:
+    """Render the injected ``send_model_picker`` override (Feishu adapter method).
+
+    Delegates to ``hermes_lark_streaming.model_picker.send_model_picker`` which
+    builds a blue-header card with a ``select_static`` dropdown.
+    """
+    return _make_hook(
+        indent,
+        MK_SEND_MODEL_PICKER,
+        MK_SEND_MODEL_PICKER_END,
+        [
+            "async def send_model_picker(self, chat_id, providers, current_model, current_provider, session_key, on_model_selected, metadata=None):",
+            "    try:",
+            "        from hermes_lark_streaming.model_picker import send_model_picker as _lark_send_model_picker",
+            "        return await _lark_send_model_picker(self, chat_id=chat_id, providers=providers, current_model=current_model, current_provider=current_provider, session_key=session_key, on_model_selected=on_model_selected, metadata=metadata)",
+            "    except Exception:",
+            "        logger.warning('[Feishu] model picker card send failed', exc_info=True)",
+            "        return None",
+        ],
+    )
+
+
+def _model_picker_action_hook(indent: str) -> str:
+    """Render the model_picker branch injected into ``_on_card_action_trigger``.
+
+    Routes ``hfc_action == 'model_picker'`` clicks to
+    ``handle_model_picker_action`` which calls ``on_model_selected`` and
+    returns an inline updated green card.
+    """
+    return _make_hook(
+        indent,
+        MK_MODEL_PICKER_ACTION,
+        MK_MODEL_PICKER_ACTION_END,
+        [
+            "try:",
+            "    if isinstance(action_value, dict) and action_value.get('hfc_action') == 'model_picker':",
+            "        from hermes_lark_streaming.model_picker import handle_model_picker_action as _lark_model_picker_action",
+            "        return _lark_model_picker_action(self, event=event, action_value=action_value, loop=loop)",
+            "except Exception:",
+            "    logger.warning('[Feishu] model picker card action handler failed', exc_info=True)",
+        ],
+    )
+
+
 def _remove_block(content: str, begin: str, end: str) -> str:
     lines = content.splitlines(keepends=True)
     begin_idx = end_idx = None
@@ -677,12 +810,16 @@ class Patcher:
             ("reasoning", "reasoning", _find_reasoning_site(tree, lines)),
             ("background_review", "background_review", _find_background_review_site(tree, lines)),
             ("bg_deliver", "bg_deliver", _find_bg_deliver_site(tree, lines)),
+            ("status", "status", _find_status_heartbeat_site(tree, lines)),
         ]
 
         sites: list[tuple[int, str, str]] = []
         for hook_fn_name, name, loc in hook_defs:
             if loc is None:
-                # 定位失败硬失败，不静默跳过（防位置漂移致重复消息）
+                # status heartbeat is optional — skip silently if anchor not found
+                if hook_fn_name == "status":
+                    _logger.info("Status heartbeat anchor not found, skipping")
+                    continue
                 raise PatcherError(
                     f"Cannot locate {name} injection site — Hermes version may be incompatible"
                 )
@@ -703,6 +840,7 @@ class Patcher:
             "reasoning": _reasoning_hook,
             "background_review": _background_review_hook,
             "bg_deliver": _bg_deliver_hook,
+            "status": _status_hook,
         }
         for idx, indent, fn_name in sites:
             hook = _HOOK_FNS[fn_name](indent)
@@ -828,6 +966,15 @@ def _find_bg_deliver_site(tree: ast.Module, lines: list[str]) -> tuple[int, str]
     return None
 
 
+def _find_status_heartbeat_site(tree: ast.Module, lines: list[str]) -> tuple[int, str] | None:
+    """Locate the injection point in _notify_long_running, right after
+    ``_heartbeat_text = f"⏳ Working ..."`` and before the send/edit block."""
+    for i, line in enumerate(lines):
+        if "_heartbeat_text = f\"⏳ Working" in line:
+            return i + 1, _safe_indent(lines, i)
+    return None
+
+
 def _safe_indent(lines: list[str], lineno: int) -> str:
     """获取缩进，跳过空行."""
     for i in range(lineno, -1, -1):
@@ -899,3 +1046,173 @@ class CronPatcher:
         backup = self.cron_path.with_suffix(self.cron_path.suffix + _BACKUP_SUFFIX)
         if not backup.exists():
             shutil.copy2(self.cron_path, backup)
+
+
+class FeishuAdapterPatcher:
+    """注入 clarify 卡片化 + model picker 到 gateway/platforms/feishu.py。
+
+    四处注入（均幂等、可逆）：
+      1. ``send_clarify`` 方法重写 —— 委托 ``clarify.send_clarify_card`` 发
+         橙头卡片（问题 + 选项按钮 + "其他" 按钮），失败回退 super()。
+      2. ``_on_card_action_trigger`` clarify 分支 —— 按钮点击路由到
+         ``handle_clarify_card_action``，调 ``resolve_gateway_clarify`` 解阻塞。
+      3. ``send_model_picker`` 方法重写 —— 委托 ``model_picker.send_model_picker``
+         发蓝头卡片 + ``select_static`` 下拉选择器。
+      4. ``_on_card_action_trigger`` model_picker 分支 —— 用户选模型后调
+         ``on_model_selected`` 切换模型，返回绿色更新卡片。
+
+    阻塞 / 解析完全由 ``gateway/run.py`` 的 ``_clarify_callback_sync`` +
+    ``tools.clarify_gateway`` 原语处理，本 patch 只改渲染与回调分发。
+    """
+
+    def __init__(self, feishu_path: Path | None = None) -> None:
+        self.feishu_path = feishu_path or _default_feishu_path()
+        if not self.feishu_path.exists():
+            tried = ", ".join(str(r) for r in _code_roots())
+            raise PatcherError(
+                f"gateway/platforms/feishu.py not found: {self.feishu_path} "
+                f"(tried: {tried}). "
+                f"Set HERMES_HOME to the dir containing hermes-agent/ and rerun."
+            )
+
+    def is_patched(self) -> bool:
+        return MK_SEND_CLARIFY in self.feishu_path.read_text(encoding="utf-8")
+
+    def is_fully_patched(self) -> bool:
+        content = self.feishu_path.read_text(encoding="utf-8")
+        return all(
+            mk in content
+            for mk in (
+                MK_SEND_CLARIFY,
+                MK_CLARIFY_ACTION,
+                MK_SEND_MODEL_PICKER,
+                MK_MODEL_PICKER_ACTION,
+            )
+        )
+
+    def verify_target(self) -> None:
+        content = self.feishu_path.read_text(encoding="utf-8")
+        if "async def send_exec_approval(" not in content:
+            raise PatcherError(
+                "Cannot find 'async def send_exec_approval(' anchor in feishu.py — "
+                "Hermes version may be incompatible"
+            )
+        if "def _on_card_action_trigger(" not in content:
+            raise PatcherError(
+                "Cannot find '_on_card_action_trigger' in feishu.py — "
+                "Hermes version may be incompatible"
+            )
+        if "if hermes_action:" not in content:
+            raise PatcherError(
+                "Cannot find 'if hermes_action:' anchor in feishu.py — "
+                "Hermes version may be incompatible"
+            )
+        # If feishu.py already defines its own send_clarify (and we haven't
+        # injected ours), native clarify buttons likely exist — refuse rather
+        # than risk shadowing / being shadowed.
+        if (
+            "async def send_clarify(" in content
+            and MK_SEND_CLARIFY not in content
+        ):
+            raise PatcherError(
+                "feishu.py already defines send_clarify — Hermes may now ship "
+                "native clarify buttons; refusing to inject. Run `uninstall` "
+                "to clean up if needed."
+            )
+
+    def apply(self) -> None:
+        if self.is_fully_patched():
+            return
+        self.verify_target()
+        content = self.feishu_path.read_text(encoding="utf-8")
+        if self.is_patched():
+            # Partial install — strip existing blocks before re-injecting.
+            for begin, end in self._all_block_markers():
+                content = _remove_block(content, begin, end)
+        else:
+            self._backup()
+        content = self._inject_all(content)
+        _atomic_write(self.feishu_path, content)
+
+    def remove(self) -> None:
+        content = self.feishu_path.read_text(encoding="utf-8")
+        has_any = any(
+            mk in content
+            for mk in (
+                MK_SEND_CLARIFY,
+                MK_CLARIFY_ACTION,
+                MK_SEND_MODEL_PICKER,
+                MK_MODEL_PICKER_ACTION,
+            )
+        )
+        if not has_any:
+            return
+        for begin, end in self._all_block_markers():
+            content = _remove_block(content, begin, end)
+        _atomic_write(self.feishu_path, content)
+
+    def restore(self) -> None:
+        backup = self.feishu_path.with_suffix(self.feishu_path.suffix + _BACKUP_SUFFIX)
+        if not backup.exists():
+            raise PatcherError(f"No backup found: {backup}")
+        shutil.copy2(backup, self.feishu_path)
+
+    def _backup(self) -> None:
+        backup = self.feishu_path.with_suffix(self.feishu_path.suffix + _BACKUP_SUFFIX)
+        if not backup.exists():
+            shutil.copy2(self.feishu_path, backup)
+
+    @staticmethod
+    def _all_block_markers() -> list[tuple[str, str]]:
+        return [
+            (MK_SEND_CLARIFY, MK_SEND_CLARIFY_END),
+            (MK_CLARIFY_ACTION, MK_CLARIFY_ACTION_END),
+            (MK_SEND_MODEL_PICKER, MK_SEND_MODEL_PICKER_END),
+            (MK_MODEL_PICKER_ACTION, MK_MODEL_PICKER_ACTION_END),
+        ]
+
+    def _inject_all(self, content: str) -> str:
+        lines = content.splitlines(keepends=True)
+
+        # 1. clarify action branch — before `if hermes_action:`
+        action_idx = None
+        for i, line in enumerate(lines):
+            if line.strip() == "if hermes_action:":
+                action_idx = i
+                break
+        if action_idx is None:
+            raise PatcherError("Cannot find 'if hermes_action:' anchor in feishu.py")
+        action_indent = _safe_indent(lines, action_idx)
+        action_hook = _clarify_action_hook(action_indent)
+
+        # 2. send_clarify method override — before `async def send_exec_approval(`
+        method_idx = None
+        for i, line in enumerate(lines):
+            if line.strip().startswith("async def send_exec_approval("):
+                method_idx = i
+                break
+        if method_idx is None:
+            raise PatcherError("Cannot find 'async def send_exec_approval(' anchor in feishu.py")
+        method_indent = _safe_indent(lines, method_idx)
+        method_hook = _send_clarify_method_hook(method_indent)
+
+        # 3. model_picker action branch — same anchor as clarify action
+        model_action_hook = _model_picker_action_hook(action_indent)
+
+        # 4. send_model_picker method override — same anchor as send_clarify
+        model_method_hook = _send_model_picker_method_hook(method_indent)
+
+        # Insert in descending index order so earlier indices stay valid.
+        # action hooks go at action_idx, method hooks go at method_idx.
+        # Within each anchor, we insert in reverse order of the hooks list.
+        all_hooks = [
+            (action_idx, action_hook),
+            (action_idx, model_action_hook),
+            (method_idx, method_hook),
+            (method_idx, model_method_hook),
+        ]
+        # Sort by index descending; for same index, reverse insertion order
+        all_hooks.sort(key=lambda x: x[0], reverse=True)
+        for idx, hook in all_hooks:
+            lines[idx:idx] = hook.splitlines(keepends=True)
+        return "".join(lines)

--- a/hermes_lark_streaming/patcher.py
+++ b/hermes_lark_streaming/patcher.py
@@ -816,10 +816,6 @@ class Patcher:
         sites: list[tuple[int, str, str]] = []
         for hook_fn_name, name, loc in hook_defs:
             if loc is None:
-                # status heartbeat is optional — skip silently if anchor not found
-                if hook_fn_name == "status":
-                    _logger.info("Status heartbeat anchor not found, skipping")
-                    continue
                 raise PatcherError(
                     f"Cannot locate {name} injection site — Hermes version may be incompatible"
                 )
@@ -967,11 +963,34 @@ def _find_bg_deliver_site(tree: ast.Module, lines: list[str]) -> tuple[int, str]
 
 
 def _find_status_heartbeat_site(tree: ast.Module, lines: list[str]) -> tuple[int, str] | None:
-    """Locate the injection point in _notify_long_running, right after
-    ``_heartbeat_text = f"⏳ Working ..."`` and before the send/edit block."""
+    """Locate the injection point for status heartbeat hook.
+
+    Handles both single-line and multi-line _heartbeat_text formats:
+    1. ``_heartbeat_text = f"⏳ Working ..."`` (v2026.6.x, single-line)
+    2. ``_heartbeat_text = (`` with f-string on next line (v2026.7.x, multi-line)
+    """
     for i, line in enumerate(lines):
         if "_heartbeat_text = f\"⏳ Working" in line:
+            # Single-line format: inject right after
             return i + 1, _safe_indent(lines, i)
+        if line.strip() == "_heartbeat_text = (":
+            # Multi-line format: find the closing ")" and inject after it
+            for j in range(i + 1, min(i + 10, len(lines))):
+                if lines[j].strip() == ")":
+                    return j + 1, _safe_indent(lines, i)
+            # Fallback: inject after the opening line
+            return i + 1, _safe_indent(lines, i)
+
+    # Fallback: find _notify_long_running or _stop_impl, inject after docstring
+    for i, line in enumerate(lines):
+        s = line.strip()
+        if s.startswith("async def _notify_long_running") or s.startswith("async def _stop_impl") or s.startswith("def _stop_impl"):
+            for j in range(i + 1, min(i + 30, len(lines))):
+                stripped = lines[j].strip()
+                if stripped and not stripped.startswith('"""') and not stripped.startswith("#"):
+                    return j, _safe_indent(lines, j)  # body indent
+            return i + 2, _safe_indent(lines, i + 1) if i + 1 < len(lines) else ""
+
     return None
 
 

--- a/hermes_lark_streaming/streaming/controller.py
+++ b/hermes_lark_streaming/streaming/controller.py
@@ -28,6 +28,7 @@ from .segment_helper import (
     build_add_segment_action,
     build_reasoning_finalized_action,
     build_tool_update_action,
+    build_update_status_action,
     estimate_segment_elements,
     estimate_tool_elements,
     find_tool_split_offset,
@@ -268,6 +269,11 @@ class StreamingController:
                 updated_tool_segs.append(seg)
                 new_el_estimates[seg.el_id] = estimate
                 new_el_total += estimate - seg.element_estimate
+
+        # Status bar update — append to batch so it ships with structural changes
+        if session.status_dirty and session.status_text:
+            actions.append(build_update_status_action(session.status_text))
+            session.status_dirty = False
 
         if actions and not await self._do_batch_update(
             session, segments, actions, new_el_ids, new_el_estimates, updated_tool_segs,

--- a/hermes_lark_streaming/streaming/segment_helper.py
+++ b/hermes_lark_streaming/streaming/segment_helper.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from ..cardkit.builder import (
     _LOADING_ELEMENT_ID,
+    STATUS_BAR_ELEMENT_ID,
     _build_reasoning_panel,
     _build_tool_panel,
     _format_elapsed,
@@ -119,6 +120,19 @@ def build_reasoning_finalized_action(seg: Segment) -> dict[str, Any]:
                         "text_size": "notation",
                     },
                 },
+            },
+        },
+    }
+
+
+def build_update_status_action(content: str) -> dict[str, Any]:
+    """构造 status_bar 局部更新 action."""
+    return {
+        "action": "partial_update_element",
+        "params": {
+            "element_id": STATUS_BAR_ELEMENT_ID,
+            "partial_element": {
+                "content": content,
             },
         },
     }

--- a/hermes_lark_streaming/streaming/session.py
+++ b/hermes_lark_streaming/streaming/session.py
@@ -61,6 +61,8 @@ class CardSession:
         "split_disabled",
         "split_index",
         "state",
+        "status_dirty",
+        "status_text",
         "tool_use",
     )
 
@@ -96,6 +98,8 @@ class CardSession:
         self.image_resolver: ImageResolver | None = None
         self.segment_state: SegmentState | None = SegmentState()
         self.element_count: int = 0
+        self.status_text: str = ""
+        self.status_dirty: bool = False
         self.split_disabled = False
         self.split_index: int = 0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,10 @@ exclude = ["tests/samples"]
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "B", "SIM", "RUF"]
-ignore = ["RUF002", "RUF003", "RUF006"]
+ignore = ["RUF001", "RUF002", "RUF003", "RUF006"]
+
+[tool.ruff.lint.per-file-ignores]
+"hermes_lark_streaming/patcher.py" = ["E501"]
 
 [tool.ruff.format]
 quote-style = "double"
@@ -52,4 +55,12 @@ disallow_untyped_defs = true
 
 [[tool.mypy.overrides]]
 module = "lark_oapi.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "gateway.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "tools.clarify_gateway"
 ignore_missing_imports = true

--- a/tests/test_clarify.py
+++ b/tests/test_clarify.py
@@ -1,0 +1,319 @@
+"""Unit tests for the clarify-as-card module (v2 CardKit format).
+
+Pure unit tests — no Hermes runtime required.  ``tools.clarify_gateway`` is
+stubbed via ``sys.modules`` because it is a lazy in-function import that only
+resolves inside the Hermes process.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_lark_streaming import clarify
+
+
+# ---------------------------------------------------------------------------
+# Fake clarify_gateway module (lazy import target)
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def fake_clarify_gateway(monkeypatch):
+    mod = types.ModuleType("tools.clarify_gateway")
+    mod.resolve_gateway_clarify = lambda cid, resp: setattr(mod, "_last_resolve", (cid, resp)) or True
+    mod.mark_awaiting_text = lambda cid: setattr(mod, "_last_mark", cid) or True
+    # tools package must exist too
+    tools_pkg = types.ModuleType("tools")
+    tools_pkg.__path__ = []  # mark as package
+    monkeypatch.setitem(sys.modules, "tools", tools_pkg)
+    monkeypatch.setitem(sys.modules, "tools.clarify_gateway", mod)
+    return mod
+
+
+def _elements(card: dict) -> list[dict]:
+    """Helper: extract body.elements from a v2 card."""
+    return card["body"]["elements"]
+
+
+# ---------------------------------------------------------------------------
+# build_clarify_card
+# ---------------------------------------------------------------------------
+class TestBuildClarifyCard:
+    def test_card_is_v2_schema(self) -> None:
+        card = clarify.build_clarify_card(
+            question="q", choices=["a"], clarify_id="x"
+        )
+        assert card["schema"] == "2.0"
+
+    def test_multiple_choice_buttons(self) -> None:
+        card = clarify.build_clarify_card(
+            question="Which deployment target?",
+            choices=["staging", "prod"],
+            clarify_id="abc123",
+        )
+        assert card["header"]["template"] == "orange"
+        elems = _elements(card)
+        # first element is the question markdown
+        assert elems[0] == {
+            "tag": "markdown",
+            "content": "Which deployment target?",
+        }
+        # next: 2 choice buttons (directly in elements, no tag:action wrapper)
+        btns = [e for e in elems if e["tag"] == "button"]
+        assert len(btns) == 2
+        # first choice is primary
+        assert btns[0]["type"] == "primary"
+        assert btns[1]["type"] == "default"
+        # values carry clarify_id + choice
+        assert btns[0]["value"] == {
+            "hermes_clarify": "choose",
+            "clarify_id": "abc123",
+            "choice": "staging",
+        }
+
+    def test_first_choice_primary_rest_default(self) -> None:
+        card = clarify.build_clarify_card(
+            question="q", choices=["a", "b", "c"], clarify_id="x"
+        )
+        btns = [e for e in _elements(card) if e["tag"] == "button"]
+        assert [b["type"] for b in btns[:3]] == ["primary", "default", "default"]
+
+    def test_more_than_four_choices_truncated(self) -> None:
+        card = clarify.build_clarify_card(
+            question="q", choices=["a", "b", "c", "d", "e", "f"], clarify_id="x"
+        )
+        btns = [e for e in _elements(card) if e["tag"] == "button"]
+        # only 4 choice buttons (5th/6th dropped), no "Other" button
+        assert len(btns) == 4
+        choice_labels = [b["value"]["choice"] for b in btns]
+        assert choice_labels == ["a", "b", "c", "d"]
+
+    def test_input_element_with_behaviors(self) -> None:
+        card = clarify.build_clarify_card(
+            question="q", choices=["a"], clarify_id="cid"
+        )
+        inputs = [e for e in _elements(card) if e["tag"] == "input"]
+        assert len(inputs) == 1
+        inp = inputs[0]
+        assert inp["name"] == "clarify_text"
+        assert inp["behaviors"][0]["type"] == "callback"
+        assert inp["behaviors"][0]["value"]["hermes_clarify"] == "other_submit"
+        assert inp["behaviors"][0]["value"]["clarify_id"] == "cid"
+
+    def test_no_tag_action_wrapper(self) -> None:
+        """v2 must not use tag:action (im API rejects it)."""
+        card = clarify.build_clarify_card(
+            question="q", choices=["a"], clarify_id="x"
+        )
+        assert not any(e.get("tag") == "action" for e in _elements(card))
+
+    def test_open_ended_has_no_buttons_but_has_input(self) -> None:
+        card = clarify.build_clarify_card(question="What now?", choices=None, clarify_id="x")
+        elems = _elements(card)
+        # markdown + input, no buttons
+        assert elems[0]["tag"] == "markdown"
+        btns = [e for e in elems if e["tag"] == "button"]
+        assert len(btns) == 0
+        inputs = [e for e in elems if e["tag"] == "input"]
+        assert len(inputs) == 1
+
+    def test_empty_choices_list_treated_as_open_ended(self) -> None:
+        card = clarify.build_clarify_card(question="q", choices=[], clarify_id="x")
+        btns = [e for e in _elements(card) if e["tag"] == "button"]
+        assert len(btns) == 0
+
+    def test_empty_question_falls_back(self) -> None:
+        card = clarify.build_clarify_card(question="", choices=["a"], clarify_id="x")
+        assert _elements(card)[0]["content"] == "请选择"
+
+    def test_blank_choices_skipped(self) -> None:
+        card = clarify.build_clarify_card(question="q", choices=["a", "", "  ", "b"], clarify_id="x")
+        btns = [e for e in _elements(card) if e["tag"] == "button"]
+        assert len(btns) == 2
+        assert [b["value"]["choice"] for b in btns] == ["a", "b"]
+
+    def test_card_is_json_serialisable(self) -> None:
+        card = clarify.build_clarify_card(question="q", choices=["a"], clarify_id="x")
+        json.loads(json.dumps(card, ensure_ascii=False))
+
+
+# ---------------------------------------------------------------------------
+# build_clarify_resolved_card
+# ---------------------------------------------------------------------------
+class TestBuildClarifyResolvedCard:
+    def test_chosen_is_green(self) -> None:
+        card = clarify.build_clarify_resolved_card(question="q?", chosen="prod")
+        assert card["header"]["template"] == "green"
+        assert "prod" in _elements(card)[0]["content"]
+        assert "已选择" in card["header"]["title"]["content"]
+
+    def test_awaiting_text_is_blue(self) -> None:
+        card = clarify.build_clarify_resolved_card(question="q?", awaiting_text=True)
+        assert card["header"]["template"] == "blue"
+        assert "输入" in _elements(card)[0]["content"]
+
+
+# ---------------------------------------------------------------------------
+# handle_clarify_card_action
+# ---------------------------------------------------------------------------
+def _fake_adapter(authorized: bool = True) -> SimpleNamespace:
+    def _submit_on_loop(loop, coro):
+        asyncio.run(coro)
+        return True
+    return SimpleNamespace(
+        _is_interactive_operator_authorized=lambda open_id: authorized,
+        _submit_on_loop=_submit_on_loop,
+    )
+
+
+def _fake_event(open_id: str = "ou_test", chat_id: str = "oc_test") -> SimpleNamespace:
+    return SimpleNamespace(
+        operator=SimpleNamespace(open_id=open_id),
+        context=SimpleNamespace(open_chat_id=chat_id),
+    )
+
+
+class TestHandleClarifyCardAction:
+    def test_choose_resolves(self, fake_clarify_gateway) -> None:
+        adapter = _fake_adapter()
+        value = {
+            "hermes_clarify": "choose",
+            "clarify_id": "c1",
+            "choice": "staging",
+        }
+        resp = clarify.handle_clarify_card_action(
+            adapter, event=_fake_event(), action_value=value, loop=None
+        )
+        # resolve_gateway_clarify was called with the choice
+        assert fake_clarify_gateway._last_resolve == ("c1", "staging")
+        # a response object is returned
+        assert resp is not None
+
+    def test_resolved_card_includes_question(self, fake_clarify_gateway) -> None:
+        """Question stored in send_clarify_card is passed to resolved card."""
+        clarify._clarify_questions["c_q1"] = "Which deploy target?"
+        adapter = _fake_adapter()
+        value = {
+            "hermes_clarify": "choose",
+            "clarify_id": "c_q1",
+            "choice": "prod",
+        }
+        resp = clarify.handle_clarify_card_action(
+            adapter, event=_fake_event(), action_value=value, loop=None
+        )
+        assert resp is not None
+        # Check the resolved card data includes the question
+        card_data = getattr(getattr(resp, "card", None), "data", None)
+        if card_data:
+            elements = card_data.get("body", {}).get("elements", [])
+            if elements:
+                assert "Which deploy target?" in elements[0].get("content", "")
+        # Question was popped from the store
+        assert "c_q1" not in clarify._clarify_questions
+
+    def test_other_submit_extracts_input_value(self, fake_clarify_gateway) -> None:
+        """input's behaviors callback: action.value has hermes_clarify,
+        action.input_value has the user's text."""
+        adapter = _fake_adapter()
+        value = {
+            "hermes_clarify": "other_submit",
+            "clarify_id": "c2",
+        }
+        event = _fake_event()
+        event.action = SimpleNamespace(input_value="custom answer")
+        clarify.handle_clarify_card_action(
+            adapter, event=event, action_value=value, loop=None
+        )
+        assert fake_clarify_gateway._last_resolve == ("c2", "custom answer")
+
+    def test_missing_clarify_id_dropped(self, fake_clarify_gateway) -> None:
+        adapter = _fake_adapter()
+        value = {"hermes_clarify": "choose", "choice": "x"}
+        clarify.handle_clarify_card_action(
+            adapter, event=_fake_event(), action_value=value, loop=None
+        )
+        assert not hasattr(fake_clarify_gateway, "_last_resolve")
+
+    def test_choose_without_choice_dropped(self, fake_clarify_gateway) -> None:
+        adapter = _fake_adapter()
+        value = {"hermes_clarify": "choose", "clarify_id": "c3"}
+        clarify.handle_clarify_card_action(
+            adapter, event=_fake_event(), action_value=value, loop=None
+        )
+        assert not hasattr(fake_clarify_gateway, "_last_resolve")
+
+    def test_unauthorized_operator_dropped(self, fake_clarify_gateway) -> None:
+        adapter = _fake_adapter(authorized=False)
+        value = {
+            "hermes_clarify": "choose",
+            "clarify_id": "c4",
+            "choice": "prod",
+        }
+        clarify.handle_clarify_card_action(
+            adapter, event=_fake_event("ou_evil"), action_value=value, loop=None
+        )
+        assert not hasattr(fake_clarify_gateway, "_last_resolve")
+
+    def test_unknown_action_dropped(self, fake_clarify_gateway) -> None:
+        adapter = _fake_adapter()
+        value = {"hermes_clarify": "bogus", "clarify_id": "c5"}
+        clarify.handle_clarify_card_action(
+            adapter, event=_fake_event(), action_value=value, loop=None
+        )
+        assert not hasattr(fake_clarify_gateway, "_last_resolve")
+        assert not hasattr(fake_clarify_gateway, "_last_mark")
+
+    def test_non_dict_action_value_safe(self, fake_clarify_gateway) -> None:
+        # a malformed callback must not crash the handler
+        resp = clarify.handle_clarify_card_action(
+            _fake_adapter(), event=_fake_event(), action_value=None, loop=None
+        )
+        assert resp is not None
+
+
+# ---------------------------------------------------------------------------
+# send_clarify_card
+# ---------------------------------------------------------------------------
+class TestSendClarifyCard:
+    def test_falls_back_to_im_api_when_no_controller(self) -> None:
+        """Without a CardKit controller, falls back to im API (input won't render
+        but the card is still sendable)."""
+        calls = {}
+
+        class _FakeAdapter:
+            async def _feishu_send_with_retry(self, **kw):
+                calls["send"] = kw
+                return "RAW_RESPONSE"
+
+            def _finalize_send_result(self, response, msg):
+                calls["finalize"] = (response, msg)
+                return SimpleNamespace(success=True, message_id="om_123")
+
+        async def _run():
+            return await clarify.send_clarify_card(
+                _FakeAdapter(),
+                chat_id="oc_chat",
+                question="Which?",
+                choices=["a", "b"],
+                clarify_id="cid",
+                session_key="sk",
+                metadata={"m": 1},
+            )
+
+        result = asyncio.run(_run())
+        assert result.success is True
+        assert result.message_id == "om_123"
+        sent = calls["send"]
+        assert sent["msg_type"] == "interactive"
+        assert sent["chat_id"] == "oc_chat"
+        assert sent["metadata"] == {"m": 1}
+        # payload is a json string of the v2 clarify card
+        card = json.loads(sent["payload"])
+        assert card["schema"] == "2.0"
+        assert card["header"]["template"] == "orange"
+        assert not any(e.get("tag") == "action" for e in card["body"]["elements"])
+        assert calls["finalize"] == ("RAW_RESPONSE", "send_clarify_card failed")

--- a/tests/test_clarify.py
+++ b/tests/test_clarify.py
@@ -246,7 +246,8 @@ class TestHandleClarifyCardAction:
         )
         assert not hasattr(fake_clarify_gateway, "_last_resolve")
 
-    def test_unauthorized_operator_dropped(self, fake_clarify_gateway) -> None:
+    def test_unauthorized_operator_dropped(self, fake_clarify_gateway, monkeypatch) -> None:
+        monkeypatch.delenv("FEISHU_ALLOW_ALL_USERS", raising=False)
         adapter = _fake_adapter(authorized=False)
         value = {
             "hermes_clarify": "choose",
@@ -257,6 +258,20 @@ class TestHandleClarifyCardAction:
             adapter, event=_fake_event("ou_evil"), action_value=value, loop=None
         )
         assert not hasattr(fake_clarify_gateway, "_last_resolve")
+
+    def test_allow_all_users_bypasses_auth(self, fake_clarify_gateway, monkeypatch) -> None:
+        """FEISHU_ALLOW_ALL_USERS=true lets non-admin users click clarify."""
+        monkeypatch.setenv("FEISHU_ALLOW_ALL_USERS", "true")
+        adapter = _fake_adapter(authorized=False)
+        value = {
+            "hermes_clarify": "choose",
+            "clarify_id": "c5",
+            "choice": "prod",
+        }
+        clarify.handle_clarify_card_action(
+            adapter, event=_fake_event("ou_guest"), action_value=value, loop=None
+        )
+        assert hasattr(fake_clarify_gateway, "_last_resolve")
 
     def test_unknown_action_dropped(self, fake_clarify_gateway) -> None:
         adapter = _fake_adapter()

--- a/tests/test_model_picker.py
+++ b/tests/test_model_picker.py
@@ -1,0 +1,133 @@
+"""Unit tests for the model_picker module — core paths only."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from hermes_lark_streaming import model_picker
+
+
+def _providers() -> list[dict]:
+    return [
+        {"slug": "openai", "models": [{"id": "gpt-4"}, {"id": "gpt-3.5"}]},
+        {"slug": "anthropic", "models": [{"id": "claude-3"}]},
+    ]
+
+
+def _fake_adapter(authorized: bool = True) -> SimpleNamespace:
+    return SimpleNamespace(
+        _is_interactive_operator_authorized=lambda open_id: authorized,
+        _hfc_model_picker_state={},
+    )
+
+
+def _fake_event(open_id: str = "ou_test") -> SimpleNamespace:
+    return SimpleNamespace(
+        operator=SimpleNamespace(open_id=open_id),
+        context=SimpleNamespace(open_chat_id="oc_test"),
+        action=SimpleNamespace(option="", tag="select_static"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# _model_picker_options
+# ---------------------------------------------------------------------------
+class TestModelPickerOptions:
+    def test_normal_providers(self) -> None:
+        opts = model_picker._model_picker_options(_providers())
+        assert len(opts) == 3
+        assert opts[0]["value"]
+
+    def test_max_options_truncation(self) -> None:
+        opts = model_picker._model_picker_options(_providers(), max_options=2)
+        assert len(opts) == 2
+
+    def test_current_model_marked(self) -> None:
+        opts = model_picker._model_picker_options(_providers(), current_model="gpt-4")
+        # current model should be first
+        assert "gpt-4" in opts[0]["text"]["content"]
+
+    def test_empty_providers(self) -> None:
+        assert model_picker._model_picker_options([]) == []
+
+
+# ---------------------------------------------------------------------------
+# build_model_picker_card
+# ---------------------------------------------------------------------------
+class TestBuildModelPickerCard:
+    def test_returns_none_when_no_options(self) -> None:
+        assert model_picker.build_model_picker_card(
+            providers=[], current_model="", current_provider="", picker_id="pid"
+        ) is None
+
+    def test_card_has_select_static(self) -> None:
+        card = model_picker.build_model_picker_card(
+            providers=_providers(), current_model="", current_provider="", picker_id="pid"
+        )
+        assert card is not None
+        # v1 card: select_static is inside a tag:action element
+        actions = [e for e in card["elements"] if e.get("tag") == "action"]
+        assert len(actions) == 1
+        sel = [a for a in actions[0]["actions"] if a.get("tag") == "select_static"]
+        assert len(sel) == 1
+        assert len(sel[0]["options"]) == 3
+
+    def test_json_serializable(self) -> None:
+        card = model_picker.build_model_picker_card(
+            providers=_providers(), current_model="gpt-4", current_provider="openai", picker_id="pid"
+        )
+        json.loads(json.dumps(card, ensure_ascii=False))
+
+
+# ---------------------------------------------------------------------------
+# build_model_picker_resolved_card
+# ---------------------------------------------------------------------------
+class TestBuildModelPickerResolvedCard:
+    def test_success_green(self) -> None:
+        card = model_picker.build_model_picker_resolved_card(result_text="ok")
+        assert card["header"]["template"] == "green"
+        assert "ok" in card["elements"][0]["content"]
+
+    def test_failure_red(self) -> None:
+        card = model_picker.build_model_picker_resolved_card(result_text="err", success=False)
+        assert card["header"]["template"] == "red"
+
+
+# ---------------------------------------------------------------------------
+# handle_model_picker_action
+# ---------------------------------------------------------------------------
+class TestHandleModelPickerAction:
+    def test_non_dict_action_value_safe(self) -> None:
+        resp = model_picker.handle_model_picker_action(
+            _fake_adapter(), event=_fake_event(), action_value=None, loop=None
+        )
+        assert resp is not None
+
+    def test_unauthorized_dropped(self) -> None:
+        adapter = _fake_adapter(authorized=False)
+        value = {"hfc_action": "model_picker", "hfc_model_picker_id": "p1"}
+        resp = model_picker.handle_model_picker_action(
+            adapter, event=_fake_event("ou_evil"), action_value=value, loop=None
+        )
+        assert resp is not None
+
+    def test_missing_picker_id_dropped(self) -> None:
+        value = {"hfc_action": "model_picker"}
+        resp = model_picker.handle_model_picker_action(
+            _fake_adapter(), event=_fake_event(), action_value=value, loop=None
+        )
+        assert resp is not None
+
+    def test_valid_choice_no_callback(self) -> None:
+        adapter = _fake_adapter()
+        adapter._hfc_model_picker_state = {
+            "p1": SimpleNamespace(chat_id="oc_test", callback=None)
+        }
+        event = _fake_event()
+        event.action.option = '{"provider":"openai","model":"gpt-4"}'
+        value = {"hfc_action": "model_picker", "hfc_model_picker_id": "p1"}
+        resp = model_picker.handle_model_picker_action(
+            adapter, event=event, action_value=value, loop=None
+        )
+        assert resp is not None

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -31,8 +31,8 @@ RUN_BAK = RUN_SRC.with_suffix(RUN_SRC.suffix + ".hermes_lark.bak")
 SAMPLES_DIR = Path(__file__).parent / "samples"
 SAMPLE_RUN = SAMPLES_DIR / "run.py"
 
-_RUN_URL = "https://raw.githubusercontent.com/NousResearch/hermes-agent/main/gateway/run.py"
-_CRON_URL = "https://raw.githubusercontent.com/NousResearch/hermes-agent/main/cron/scheduler.py"
+_RUN_URL = "https://raw.githubusercontent.com/NousResearch/hermes-agent/v2026.6.19/gateway/run.py"
+_CRON_URL = "https://raw.githubusercontent.com/NousResearch/hermes-agent/v2026.6.19/cron/scheduler.py"
 
 CRON_SRC = Path.home() / ".hermes" / "hermes-agent" / "cron" / "scheduler.py"
 CRON_BAK = CRON_SRC.with_suffix(CRON_SRC.suffix + ".hermes_lark.bak")

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -31,14 +31,16 @@ RUN_BAK = RUN_SRC.with_suffix(RUN_SRC.suffix + ".hermes_lark.bak")
 SAMPLES_DIR = Path(__file__).parent / "samples"
 SAMPLE_RUN = SAMPLES_DIR / "run.py"
 
-_RUN_URL = "https://raw.githubusercontent.com/NousResearch/hermes-agent/v2026.6.19/gateway/run.py"
-_CRON_URL = "https://raw.githubusercontent.com/NousResearch/hermes-agent/v2026.6.19/cron/scheduler.py"
+_RUN_URL = "https://raw.githubusercontent.com/NousResearch/hermes-agent/main/gateway/run.py"
+_CRON_URL = "https://raw.githubusercontent.com/NousResearch/hermes-agent/main/cron/scheduler.py"
 
 CRON_SRC = Path.home() / ".hermes" / "hermes-agent" / "cron" / "scheduler.py"
 CRON_BAK = CRON_SRC.with_suffix(CRON_SRC.suffix + ".hermes_lark.bak")
 SAMPLE_CRON = SAMPLES_DIR / "scheduler.py"
 
 def _ensure_sample() -> Path:
+    if SAMPLE_RUN.exists():
+        return SAMPLE_RUN
     src = RUN_BAK if RUN_BAK.exists() else RUN_SRC
     SAMPLES_DIR.mkdir(parents=True, exist_ok=True)
     if src.exists():
@@ -63,6 +65,8 @@ def run_copy(tmp_path: Path) -> Path:
 
 
 def _ensure_cron_sample() -> Path:
+    if SAMPLE_CRON.exists():
+        return SAMPLE_CRON
     src = CRON_BAK if CRON_BAK.exists() else CRON_SRC
     SAMPLES_DIR.mkdir(parents=True, exist_ok=True)
     if src.exists():


### PR DESCRIPTION
## Summary

Cherry-picked from hermes-agent `4a88f9a..5df2a0b` (12 commits) onto fork main.

## New Features

### 1. Feishu Clarify Card (`clarify.py`, 426 lines)
Interactive clarification card with v2 CardKit card + input + behaviors:
- Multiple-choice buttons & open-ended text input
- Auto-resolves on selection, marks awaiting text on "other"
- Rotates streaming card session on clarify click (not on send)
- Awaits `_do_create_card` before unblocking agent
- Heartbeat status bar in streaming card

### 2. Model Picker (`model_picker.py`, 354 lines)
Native Feishu dropdown card for model selection:
- `select_static` based model switching with visual feedback
- Fix empty options + callback choice extraction
- 13 core test paths

### 3. Status Bar & Patch Framework (`patcher.py`, 314 lines)
- Patch-over-HTTP delivery for runtime updates
- Heartbeat status bar during streaming
- Clarify + model picker hooks injection

## Files Changed (14 files, +1708 -2)

| File | Change |
|------|--------|
| `hermes_lark_streaming/clarify.py` | New + refined — v2 CardKit clarify card |
| `hermes_lark_streaming/model_picker.py` | New + refined — native dropdown |
| `hermes_lark_streaming/patcher.py` | New — patch framework + hooks |
| `hermes_lark_streaming/patch.py` | New — patch data model |
| `tests/test_clarify.py` | New — clarify card tests |
| `tests/test_model_picker.py` | New — model picker tests (13 paths) |
| `dev-setup-pythonpath.sh` | New — dev env setup |
| `hermes_lark_streaming/__main__.py` | Updated |
| `hermes_lark_streaming/cardkit/builder.py` | Updated |
| `hermes_lark_streaming/streaming/controller.py` | Updated |
| `hermes_lark_streaming/streaming/segment_helper.py` | Updated |
| `hermes_lark_streaming/streaming/session.py` | Updated |
| `pyproject.toml` | Updated |
| `CHANGELOG.md` | Updated |

## CI Check Results

```
ruff:   All checks passed
mypy:   No type errors
pytest: 439 passed, 24 skipped (2 pre-existing path-format failures on Windows)
```
