### PR TITLE
fix(config): read multi-profile platforms.feishu.extra layout and source .env

### DIFF
--- a/hermes_lark_streaming/config.py
+++ b/hermes_lark_streaming/config.py
@@ -8,7 +8,37 @@ from typing import Any
 
 import yaml
 
-_HERMES_CONFIG_PATH = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))) / "config.yaml"
+_HERMES_HOME = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
+_HERMES_CONFIG_PATH = _HERMES_HOME / "config.yaml"
+_HERMES_ENV_PATH = _HERMES_HOME / ".env"
+
+
+def _load_env_file(path: Path) -> None:
+    """Parse a simple .env file into os.environ without overwriting existing values.
+
+    Hermes itself reads .env at gateway startup, but this plugin is sometimes
+    invoked from a shell (e.g. ``hermes_lark_streaming status``) where .env has
+    not been sourced. Parsing it here lets ``env_app_id`` / ``env_app_secret``
+    resolve in both contexts. Existing env values win so callers can still
+    override per-invocation.
+    """
+    if not path.is_file():
+        return
+    try:
+        for raw_line in path.read_text(encoding="utf-8").splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            key, sep, value = line.partition("=")
+            if not sep:
+                continue
+            key = key.strip()
+            value = value.strip().strip('"').strip("'")
+            if key and key not in os.environ:
+                os.environ[key] = value
+    except OSError:
+        # .env is best-effort; never let a missing/unreadable file crash config load.
+        pass
 
 
 class Config:
@@ -16,6 +46,12 @@ class Config:
 
     def __init__(self) -> None:
         self._raw: dict[str, Any] | None = None
+        # Ensure .env is sourced at construction time, not just inside _load.
+        # env_app_id is queried before _load ever runs in some code paths
+        # (e.g. _platform_cfg short-circuits on env), so the env must be live
+        # by the time ``feishu_app_id`` is first accessed. Existing env values
+        # win — callers can still override per-invocation.
+        _load_env_file(_HERMES_ENV_PATH)
 
     @property
     def enabled(self) -> bool:
@@ -142,7 +178,15 @@ class Config:
         return {}
 
     def _platform_cfg(self) -> dict[str, Any]:
-        """从环境变量或平台配置找飞书凭据."""
+        """从环境变量或平台配置找飞书凭据.
+
+        Resolution order (first match wins):
+        1. ``FEISHU_APP_ID`` + ``FEISHU_APP_SECRET`` (and ``LARK_*`` aliases) env vars
+        2. Top-level ``feishu:`` or ``lark:`` section in config.yaml (legacy layout)
+        3. ``platforms.feishu.extra:`` or ``platforms.lark.extra:`` (canonical
+           Hermes multi-profile layout — the per-profile gateway stores its
+           Feishu bot credentials there so each profile can bind a different bot)
+        """
         if self.env_app_id and self.env_app_secret:
             return {
                 "app_id": self.env_app_id,
@@ -157,11 +201,34 @@ class Config:
             pf = raw.get(key)
             if isinstance(pf, dict) and pf.get("app_id"):
                 return pf
+        # Canonical multi-profile layout: each profile's Feishu bot credentials
+        # live under platforms.<name>.extra.app_id / app_secret.
+        platforms = raw.get("platforms")
+        if isinstance(platforms, dict):
+            for key in ("feishu", "lark"):
+                pf = platforms.get(key)
+                if not isinstance(pf, dict):
+                    continue
+                extra = pf.get("extra")
+                if isinstance(extra, dict) and extra.get("app_id"):
+                    # base_url lives at the platforms.<name>.level alongside extra
+                    result: dict[str, Any] = {
+                        "app_id": extra["app_id"],
+                        "app_secret": extra.get("app_secret", ""),
+                    }
+                    base_url = pf.get("base_url")
+                    if isinstance(base_url, str) and base_url:
+                        result["base_url"] = base_url
+                    return result
         return {}
 
     def _load(self) -> dict[str, Any]:
         if self._raw is not None:
             return self._raw
+        # .env is sourced in __init__; this call is a defensive idempotent
+        # re-load in case _load is invoked before the Config is constructed
+        # (e.g. via _raw bypassed in a subclass).
+        _load_env_file(_HERMES_ENV_PATH)
         if _HERMES_CONFIG_PATH.exists():
             text = _HERMES_CONFIG_PATH.read_text(encoding="utf-8")
             self._raw = yaml.safe_load(text) or {}

--- a/hermes_lark_streaming/config.py
+++ b/hermes_lark_streaming/config.py
@@ -183,9 +183,10 @@ class Config:
         Resolution order (first match wins):
         1. ``FEISHU_APP_ID`` + ``FEISHU_APP_SECRET`` (and ``LARK_*`` aliases) env vars
         2. Top-level ``feishu:`` or ``lark:`` section in config.yaml (legacy layout)
-        3. ``platforms.feishu.extra:`` or ``platforms.lark.extra:`` (canonical
-           Hermes multi-profile layout — the per-profile gateway stores its
-           Feishu bot credentials there so each profile can bind a different bot)
+        3. ``gateway.platforms.feishu.extra:`` or ``gateway.platforms.lark.extra:``
+           (canonical Hermes multi-profile layout — the per-profile gateway
+           stores its Feishu bot credentials there so each profile can bind a
+           different bot)
         """
         if self.env_app_id and self.env_app_secret:
             return {
@@ -202,9 +203,20 @@ class Config:
             if isinstance(pf, dict) and pf.get("app_id"):
                 return pf
         # Canonical multi-profile layout: each profile's Feishu bot credentials
-        # live under platforms.<name>.extra.app_id / app_secret.
-        platforms = raw.get("platforms")
-        if isinstance(platforms, dict):
+        # live under gateway.platforms.<name>.extra.app_id / app_secret. We
+        # also walk a top-level ``platforms`` section (no gateway parent) as a
+        # defensive fallback for configs that hoist the section up — the
+        # credentials live in the same shape, so resolution is identical.
+        candidate_parents: list[dict[str, Any]] = []
+        gw = raw.get("gateway")
+        if isinstance(gw, dict) and isinstance(gw.get("platforms"), dict):
+            candidate_parents.append(gw["platforms"])
+        top_platforms = raw.get("platforms")
+        if isinstance(top_platforms, dict) and isinstance(top_platforms.get("feishu"), dict):
+            # Only add if it looks like the platforms-with-feishu shape, not
+            # a coincidentally-named "platforms" dict from another section.
+            candidate_parents.append(top_platforms)
+        for platforms in candidate_parents:
             for key in ("feishu", "lark"):
                 pf = platforms.get(key)
                 if not isinstance(pf, dict):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -273,23 +273,26 @@ class TestPlatformCfg:
 
 class TestPlatformsExtraLayout:
     """Test the canonical Hermes multi-profile layout:
-    ``platforms.feishu.extra.app_id`` / ``platforms.feishu.extra.app_secret``.
+    ``gateway.platforms.feishu.extra.app_id`` / ``gateway.platforms.feishu.extra.app_secret``.
 
     Each Hermes profile (claudia, bill, cody, hazel, laura, onix, pos) binds a
-    different Feishu bot, with credentials stored under platforms.<name>.extra
-    in its own config.yaml. The plugin must read from this layout so streaming
-    cards work per-profile instead of being silently disabled.
+    different Feishu bot, with credentials stored under
+    ``gateway.platforms.<name>.extra`` in its own config.yaml. The plugin
+    must read from this layout so streaming cards work per-profile instead
+    of being silently disabled.
     """
 
-    def test_platforms_feishu_extra(self) -> None:
+    def test_gateway_platforms_feishu_extra(self) -> None:
         cfg = _make_config(
             {
-                "platforms": {
-                    "feishu": {
-                        "extra": {
-                            "app_id": "pf_id",
-                            "app_secret": "pf_secret",
-                            "domain": "feishu",
+                "gateway": {
+                    "platforms": {
+                        "feishu": {
+                            "extra": {
+                                "app_id": "pf_id",
+                                "app_secret": "pf_secret",
+                                "domain": "feishu",
+                            }
                         }
                     }
                 }
@@ -300,14 +303,16 @@ class TestPlatformsExtraLayout:
             assert result["app_id"] == "pf_id"
             assert result["app_secret"] == "pf_secret"
 
-    def test_platforms_lark_extra(self) -> None:
+    def test_gateway_platforms_lark_extra(self) -> None:
         cfg = _make_config(
             {
-                "platforms": {
-                    "lark": {
-                        "extra": {
-                            "app_id": "lk_id",
-                            "app_secret": "lk_secret",
+                "gateway": {
+                    "platforms": {
+                        "lark": {
+                            "extra": {
+                                "app_id": "lk_id",
+                                "app_secret": "lk_secret",
+                            }
                         }
                     }
                 }
@@ -318,13 +323,15 @@ class TestPlatformsExtraLayout:
             assert result["app_id"] == "lk_id"
             assert result["app_secret"] == "lk_secret"
 
-    def test_platforms_extra_with_base_url(self) -> None:
+    def test_gateway_platforms_extra_with_base_url(self) -> None:
         cfg = _make_config(
             {
-                "platforms": {
-                    "feishu": {
-                        "base_url": "https://custom.example.com",
-                        "extra": {"app_id": "u_id", "app_secret": "u_secret"},
+                "gateway": {
+                    "platforms": {
+                        "feishu": {
+                            "base_url": "https://custom.example.com",
+                            "extra": {"app_id": "u_id", "app_secret": "u_secret"},
+                        }
                     }
                 }
             }
@@ -333,13 +340,15 @@ class TestPlatformsExtraLayout:
             assert cfg.feishu_base_url == "https://custom.example.com"
             assert cfg.feishu_app_id == "u_id"
 
-    def test_platforms_extra_missing_app_secret(self) -> None:
+    def test_gateway_platforms_extra_missing_app_secret(self) -> None:
         cfg = _make_config(
             {
-                "platforms": {
-                    "feishu": {
-                        "extra": {
-                            "app_id": "only_id",
+                "gateway": {
+                    "platforms": {
+                        "feishu": {
+                            "extra": {
+                                "app_id": "only_id",
+                            }
                         }
                     }
                 }
@@ -349,16 +358,18 @@ class TestPlatformsExtraLayout:
             assert cfg.feishu_app_id == "only_id"
             assert cfg.feishu_app_secret == ""
 
-    def test_platforms_feishu_without_extra_falls_through(self) -> None:
-        """``platforms.feishu`` may exist (with display flags) but no ``extra`` —
-        in that case resolution must continue to the next strategy rather than
-        returning an empty dict."""
+    def test_gateway_platforms_feishu_without_extra_falls_through(self) -> None:
+        """``gateway.platforms.feishu`` may exist (with display flags) but no
+        ``extra`` — in that case resolution must continue to the next strategy
+        rather than returning an empty dict."""
         cfg = _make_config(
             {
-                "platforms": {
-                    "feishu": {
-                        "streaming": True,
-                        "busy_ack_detail": False,
+                "gateway": {
+                    "platforms": {
+                        "feishu": {
+                            "streaming": True,
+                            "busy_ack_detail": False,
+                        }
                     }
                 }
             }
@@ -366,30 +377,62 @@ class TestPlatformsExtraLayout:
         with patch.dict(os.environ, {}, clear=True):
             assert cfg._platform_cfg() == {}
 
-    def test_platforms_not_dict(self) -> None:
-        cfg = _make_config({"platforms": "not_a_dict"})
+    def test_top_level_platforms_feishu_extra_still_resolves(self) -> None:
+        """Defensive fallback: future Hermes versions might hoist the section
+        from ``gateway.platforms`` to top-level ``platforms``. We accept that
+        layout too, since the credentials are functionally identical.
+        """
+        cfg = _make_config(
+            {
+                "platforms": {
+                    "feishu": {
+                        "extra": {
+                            "app_id": "top_pf_id",
+                            "app_secret": "top_pf_secret",
+                        }
+                    }
+                }
+            }
+        )
+        with patch.dict(os.environ, {}, clear=True):
+            result = cfg._platform_cfg()
+            assert result["app_id"] == "top_pf_id"
+            assert result["app_secret"] == "top_pf_secret"
+
+    def test_gateway_not_dict(self) -> None:
+        cfg = _make_config({"gateway": "not_a_dict"})
         with patch.dict(os.environ, {}, clear=True):
             assert cfg._platform_cfg() == {}
 
-    def test_platforms_feishu_not_dict(self) -> None:
-        cfg = _make_config({"platforms": {"feishu": "not_a_dict"}})
+    def test_gateway_platforms_not_dict(self) -> None:
+        cfg = _make_config({"gateway": {"platforms": "not_a_dict"}})
         with patch.dict(os.environ, {}, clear=True):
             assert cfg._platform_cfg() == {}
 
-    def test_extra_not_dict(self) -> None:
-        cfg = _make_config({"platforms": {"feishu": {"extra": "not_a_dict"}}})
+    def test_gateway_platforms_feishu_not_dict(self) -> None:
+        cfg = _make_config({"gateway": {"platforms": {"feishu": "not_a_dict"}}})
         with patch.dict(os.environ, {}, clear=True):
             assert cfg._platform_cfg() == {}
 
-    def test_top_level_feishu_still_wins_over_platforms_extra(self) -> None:
+    def test_gateway_extra_not_dict(self) -> None:
+        cfg = _make_config(
+            {"gateway": {"platforms": {"feishu": {"extra": "not_a_dict"}}}}
+        )
+        with patch.dict(os.environ, {}, clear=True):
+            assert cfg._platform_cfg() == {}
+
+    def test_top_level_feishu_still_wins_over_gateway_extra(self) -> None:
         """Backwards compat: top-level ``feishu:`` is still preferred over
-        ``platforms.feishu.extra`` when both are present (preserves the existing
-        test_feishu_before_lark / test_lark_section_fallback precedence)."""
+        ``gateway.platforms.feishu.extra`` when both are present (preserves the
+        existing test_feishu_before_lark / test_lark_section_fallback
+        precedence)."""
         cfg = _make_config(
             {
                 "feishu": {"app_id": "top_id", "app_secret": "top_secret"},
-                "platforms": {
-                    "feishu": {"extra": {"app_id": "pf_id", "app_secret": "pf_secret"}}
+                "gateway": {
+                    "platforms": {
+                        "feishu": {"extra": {"app_id": "pf_id", "app_secret": "pf_secret"}}
+                    }
                 },
             }
         )
@@ -413,18 +456,20 @@ class TestPlatformsExtraLayout:
                         }
                     }
                 },
-                "platforms": {
-                    "feishu": {
-                        "extra": {
-                            "app_id": "cli_real",
-                            "app_secret": "real_secret",
-                            "connection_mode": "websocket",
-                            "default_group_policy": "open",
-                            "domain": "feishu",
-                        }
-                    },
-                    "telegram": {
-                        "extra": {"bot_token": "123:abc"},
+                "gateway": {
+                    "platforms": {
+                        "feishu": {
+                            "extra": {
+                                "app_id": "cli_real",
+                                "app_secret": "real_secret",
+                                "connection_mode": "websocket",
+                                "default_group_policy": "open",
+                                "domain": "feishu",
+                            }
+                        },
+                        "telegram": {
+                            "extra": {"bot_token": "123:abc"},
+                        },
                     },
                 },
             }
@@ -433,6 +478,31 @@ class TestPlatformsExtraLayout:
             assert cfg.enabled is True
             assert cfg.feishu_app_id == "cli_real"
             assert cfg.feishu_app_secret == "real_secret"
+
+    def test_realistic_claudia_profile_with_env(self) -> None:
+        """When ``.env`` is also present (the typical real-world setup) the
+        env path takes priority over the config — this is the same precedence
+        the gateway process uses."""
+        cfg = _make_config(
+            {
+                "gateway": {
+                    "platforms": {
+                        "feishu": {
+                            "extra": {
+                                "app_id": "cli_config",
+                                "app_secret": "config_secret",
+                            }
+                        }
+                    }
+                }
+            }
+        )
+        with patch.dict(
+            os.environ,
+            {"FEISHU_APP_ID": "cli_env", "FEISHU_APP_SECRET": "env_secret"},
+        ):
+            assert cfg.feishu_app_id == "cli_env"
+            assert cfg.feishu_app_secret == "env_secret"
 
 
 class TestEnvFileLoading:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -269,3 +269,249 @@ class TestPlatformCfg:
         cfg = _make_config({})
         with patch.dict(os.environ, {}, clear=True):
             assert cfg._platform_cfg() == {}
+
+
+class TestPlatformsExtraLayout:
+    """Test the canonical Hermes multi-profile layout:
+    ``platforms.feishu.extra.app_id`` / ``platforms.feishu.extra.app_secret``.
+
+    Each Hermes profile (claudia, bill, cody, hazel, laura, onix, pos) binds a
+    different Feishu bot, with credentials stored under platforms.<name>.extra
+    in its own config.yaml. The plugin must read from this layout so streaming
+    cards work per-profile instead of being silently disabled.
+    """
+
+    def test_platforms_feishu_extra(self) -> None:
+        cfg = _make_config(
+            {
+                "platforms": {
+                    "feishu": {
+                        "extra": {
+                            "app_id": "pf_id",
+                            "app_secret": "pf_secret",
+                            "domain": "feishu",
+                        }
+                    }
+                }
+            }
+        )
+        with patch.dict(os.environ, {}, clear=True):
+            result = cfg._platform_cfg()
+            assert result["app_id"] == "pf_id"
+            assert result["app_secret"] == "pf_secret"
+
+    def test_platforms_lark_extra(self) -> None:
+        cfg = _make_config(
+            {
+                "platforms": {
+                    "lark": {
+                        "extra": {
+                            "app_id": "lk_id",
+                            "app_secret": "lk_secret",
+                        }
+                    }
+                }
+            }
+        )
+        with patch.dict(os.environ, {}, clear=True):
+            result = cfg._platform_cfg()
+            assert result["app_id"] == "lk_id"
+            assert result["app_secret"] == "lk_secret"
+
+    def test_platforms_extra_with_base_url(self) -> None:
+        cfg = _make_config(
+            {
+                "platforms": {
+                    "feishu": {
+                        "base_url": "https://custom.example.com",
+                        "extra": {"app_id": "u_id", "app_secret": "u_secret"},
+                    }
+                }
+            }
+        )
+        with patch.dict(os.environ, {}, clear=True):
+            assert cfg.feishu_base_url == "https://custom.example.com"
+            assert cfg.feishu_app_id == "u_id"
+
+    def test_platforms_extra_missing_app_secret(self) -> None:
+        cfg = _make_config(
+            {
+                "platforms": {
+                    "feishu": {
+                        "extra": {
+                            "app_id": "only_id",
+                        }
+                    }
+                }
+            }
+        )
+        with patch.dict(os.environ, {}, clear=True):
+            assert cfg.feishu_app_id == "only_id"
+            assert cfg.feishu_app_secret == ""
+
+    def test_platforms_feishu_without_extra_falls_through(self) -> None:
+        """``platforms.feishu`` may exist (with display flags) but no ``extra`` —
+        in that case resolution must continue to the next strategy rather than
+        returning an empty dict."""
+        cfg = _make_config(
+            {
+                "platforms": {
+                    "feishu": {
+                        "streaming": True,
+                        "busy_ack_detail": False,
+                    }
+                }
+            }
+        )
+        with patch.dict(os.environ, {}, clear=True):
+            assert cfg._platform_cfg() == {}
+
+    def test_platforms_not_dict(self) -> None:
+        cfg = _make_config({"platforms": "not_a_dict"})
+        with patch.dict(os.environ, {}, clear=True):
+            assert cfg._platform_cfg() == {}
+
+    def test_platforms_feishu_not_dict(self) -> None:
+        cfg = _make_config({"platforms": {"feishu": "not_a_dict"}})
+        with patch.dict(os.environ, {}, clear=True):
+            assert cfg._platform_cfg() == {}
+
+    def test_extra_not_dict(self) -> None:
+        cfg = _make_config({"platforms": {"feishu": {"extra": "not_a_dict"}}})
+        with patch.dict(os.environ, {}, clear=True):
+            assert cfg._platform_cfg() == {}
+
+    def test_top_level_feishu_still_wins_over_platforms_extra(self) -> None:
+        """Backwards compat: top-level ``feishu:`` is still preferred over
+        ``platforms.feishu.extra`` when both are present (preserves the existing
+        test_feishu_before_lark / test_lark_section_fallback precedence)."""
+        cfg = _make_config(
+            {
+                "feishu": {"app_id": "top_id", "app_secret": "top_secret"},
+                "platforms": {
+                    "feishu": {"extra": {"app_id": "pf_id", "app_secret": "pf_secret"}}
+                },
+            }
+        )
+        with patch.dict(os.environ, {}, clear=True):
+            result = cfg._platform_cfg()
+            assert result["app_id"] == "top_id"
+            assert result["app_secret"] == "top_secret"
+
+    def test_realistic_claudia_profile_layout(self) -> None:
+        """End-to-end: a realistic per-profile config with the same shape
+        claudia/bill/cody/etc. actually use must yield the expected credentials."""
+        cfg = _make_config(
+            {
+                "model": {"provider": "minimax-cn"},
+                "streaming": {"enabled": True},
+                "display": {
+                    "platforms": {
+                        "feishu": {
+                            "busy_ack_detail": False,
+                            "tool_progress": "off",
+                        }
+                    }
+                },
+                "platforms": {
+                    "feishu": {
+                        "extra": {
+                            "app_id": "cli_real",
+                            "app_secret": "real_secret",
+                            "connection_mode": "websocket",
+                            "default_group_policy": "open",
+                            "domain": "feishu",
+                        }
+                    },
+                    "telegram": {
+                        "extra": {"bot_token": "123:abc"},
+                    },
+                },
+            }
+        )
+        with patch.dict(os.environ, {}, clear=True):
+            assert cfg.enabled is True
+            assert cfg.feishu_app_id == "cli_real"
+            assert cfg.feishu_app_secret == "real_secret"
+
+
+class TestEnvFileLoading:
+    """Test that ``$HERMES_HOME/.env`` is sourced at Config construction, so
+    CLI invocations (status, install, verify) see credentials the same way
+    the gateway process does. Existing env vars win — callers can override."""
+
+    def test_env_file_loaded_into_environ(self) -> None:
+        with patch.dict(os.environ, {}, clear=True), patch(
+            "hermes_lark_streaming.config._HERMES_ENV_PATH",
+            _FakePath("FEISHU_APP_ID=dotenv_id\nFEISHU_APP_SECRET=dotenv_secret\n"),
+        ):
+            cfg = Config()
+            assert cfg.env_app_id == "dotenv_id"
+            assert cfg.env_app_secret == "dotenv_secret"
+
+    def test_existing_env_wins_over_env_file(self) -> None:
+        with patch.dict(
+            os.environ,
+            {"FEISHU_APP_ID": "explicit_id", "FEISHU_APP_SECRET": "explicit_secret"},
+            clear=True,
+        ), patch(
+            "hermes_lark_streaming.config._HERMES_ENV_PATH",
+            _FakePath("FEISHU_APP_ID=dotenv_id\nFEISHU_APP_SECRET=dotenv_secret\n"),
+        ):
+            cfg = Config()
+            assert cfg.env_app_id == "explicit_id"
+            assert cfg.env_app_secret == "explicit_secret"
+
+    def test_env_file_quoted_values_stripped(self) -> None:
+        with patch.dict(os.environ, {}, clear=True), patch(
+            "hermes_lark_streaming.config._HERMES_ENV_PATH",
+            _FakePath('FEISHU_APP_ID="qd_id"\nFEISHU_APP_SECRET=\'qs_secret\'\n'),
+        ):
+            cfg = Config()
+            assert cfg.env_app_id == "qd_id"
+            assert cfg.env_app_secret == "qs_secret"
+
+    def test_env_file_comments_and_blank_lines_skipped(self) -> None:
+        with patch.dict(os.environ, {}, clear=True), patch(
+            "hermes_lark_streaming.config._HERMES_ENV_PATH",
+            _FakePath("# top comment\n\nFEISHU_APP_ID=skip_id\nFEISHU_APP_SECRET=skip_secret\n"),
+        ):
+            cfg = Config()
+            assert cfg.env_app_id == "skip_id"
+            assert cfg.env_app_secret == "skip_secret"
+
+    def test_env_file_malformed_lines_silently_skipped(self) -> None:
+        """Lines without ``=`` are ignored — they shouldn't crash the loader."""
+        with patch.dict(os.environ, {}, clear=True), patch(
+            "hermes_lark_streaming.config._HERMES_ENV_PATH",
+            _FakePath("garbage_no_equals\nFEISHU_APP_ID=ok_id\nFEISHU_APP_SECRET=ok_secret\n"),
+        ):
+            cfg = Config()
+            assert cfg.env_app_id == "ok_id"
+            assert cfg.env_app_secret == "ok_secret"
+
+    def test_missing_env_file_is_noop(self) -> None:
+        with patch.dict(os.environ, {}, clear=True), patch(
+            "hermes_lark_streaming.config._HERMES_ENV_PATH",
+            _FakePath(""),  # simulates nonexistent file
+        ):
+            cfg = Config()
+            assert cfg.env_app_id == ""
+            assert cfg.env_app_secret == ""
+
+
+class _FakePath:
+    """A minimal stand-in for a pathlib.Path whose .is_file() / .read_text()
+    match the bytes we hand it. Lets us patch ``_HERMES_ENV_PATH`` without
+    touching the real filesystem."""
+
+    def __init__(self, content: str) -> None:
+        self._content = content
+        self._exists = bool(content)
+
+    def is_file(self) -> bool:
+        return self._exists
+
+    def read_text(self, encoding: str = "utf-8") -> str:
+        return self._content
+


### PR DESCRIPTION
## Summary

The plugin's credential lookup was hard-coded to top-level `feishu:` /
`lark:` sections in config.yaml. With Hermes's per-profile gateway layout
each profile stores its Feishu bot credentials under
`gateway.platforms.feishu.extra.app_id` (and `gateway.platforms.lark.extra`
for the alias), so the plugin was silently disabled in every profile:
`controller.enabled` returned `False` because both `feishu_app_id` and
`env_app_id` were empty.

This affects every multi-profile setup — each profile binds a different
Feishu bot, and the credentials live in that profile's own config.yaml under
`gateway.platforms.feishu.extra`.

## Changes

1. **`_platform_cfg()`** now resolves in priority order:
   - env vars (`FEISHU_APP_ID` / `LARK_APP_ID` + secret)
   - top-level `feishu:` / `lark:` (existing behavior)
   - `gateway.platforms.feishu.extra` / `gateway.platforms.lark.extra`
     (canonical Hermes multi-profile layout)
   - `platforms.feishu.extra` / `platforms.lark.extra` as a defensive
     fallback (in case future Hermes versions hoist the section out of
     `gateway`)

2. **`/Users/peric/.hermes/profiles/claudia/.env`** is now sourced at `Config()` construction time so
   CLI invocations (`status`, `install`, `verify`) see the same credentials
   the gateway process does. Existing env values win — callers can still
   override per-invocation.

## Verification

- `pytest tests/` → 434/434 pass (12 new tests in this iteration)
- `ruff check` clean
- `mypy hermes_lark_streaming/` clean
- End-to-end against the actual claudia/bill/cody/hazel/laura/onix/pos
  profiles (with `.env` moved out of the way so resolution MUST come from
  config.yaml):

  | profile | app_id (config.yaml)        | plugin reads               |
  |---------|------------------------------|----------------------------|
  | claudia | cli_a93c3a162d781cc2         | cli_a93c3a162d781cc2 ✓    |
  | bill    | cli_a909c6eda8389cc2         | cli_a909c6eda8389cc2 ✓    |
  | cody    | cli_a909c05518f89cd0         | cli_a909c05518f89cd0 ✓    |
  | hazel   | cli_aa8544c146a29beb         | cli_aa8544c146a29beb ✓    |
  | laura   | cli_a909c09586389ced         | cli_a909c09586389ced ✓    |
  | onix    | cli_a909c10b84f8dcda         | cli_a909c10b84f8dcda ✓    |
  | pos     | cli_a9f63081c4781bd8         | cli_a9f63081c4781bd8 ✓    |

## Note on the first push

The first commit (802053f) read `platforms.feishu.extra` instead of
`gateway.platforms.feishu.extra`. I caught it during end-to-end verification
(per-profile testing against the real configs) before requesting review, and
force-pushed the corrected path in 8413f78. The corrected version is what
the verification table above is built from.

## Reproduction

Before this patch, with a standard per-profile config like:

```yaml
gateway:
  platforms:
    feishu:
      extra:
        app_id: cli_a93c3a162d781cc2
        app_secret: ...
        connection_mode: websocket
        domain: feishu
```

`hermes_lark_streaming status` reports `Feishu credentials: MISSING` and
`StreamCardController.enabled` returns `False`, silently disabling all
streaming cards for that profile. After the patch, both resolve correctly.