### PR TITLE
fix(cron): gateway loop 失效时兜底发卡片（fixes #86）

### DIFF
--- a/hermes_lark_streaming/patch.py
+++ b/hermes_lark_streaming/patch.py
@@ -268,17 +268,57 @@ def on_cron_deliver(
     task_name: str = "",
     run_time: str = "",
 ) -> bool:
-    """[注入点 10] cron 推送 — 包装为飞书卡片发送."""
-    if loop is None:
-        return False
+    """[注入点 10] cron 推送 — 包装为飞书卡片发送.
+
+    兜底修复（chenchen v1）：当 gateway loop 引用失效（loop is None）时，
+    自己起一个临时事件循环 + 临时 FeishuClient 完成卡片发送。避免退化到纯文本。
+    """
     try:
         ctrl = get_controller()
         if not ctrl.enabled:
             return False
-        return bool(ctrl.on_cron_deliver(
-            chat_id=chat_id, content=content, loop=loop,
-            task_name=task_name, run_time=run_time,
-        ))
+        if loop is not None:
+            # 正常路径：委派到 gateway 主 loop
+            return bool(ctrl.on_cron_deliver(
+                chat_id=chat_id, content=content, loop=loop,
+                task_name=task_name, run_time=run_time,
+            ))
+        # ---- 兜底：loop 失效时，自建临时 loop + 临时 client ----
+        _logger.info(
+            "on_cron_deliver: gateway loop unavailable, falling back to standalone card send "
+            "(task=%r chat=%s len=%d)",
+            task_name, chat_id[:12], len(content or ""),
+        )
+        import asyncio as _asyncio
+        from hermes_lark_streaming.cardkit.builder import build_cron_card
+        from hermes_lark_streaming.feishu import FeishuClient, FeishuClientConfig
+
+        cfg = ctrl._cfg
+        app_id = getattr(cfg, "feishu_app_id", None) or getattr(cfg, "env_app_id", None)
+        app_secret = getattr(cfg, "feishu_app_secret", None) or getattr(cfg, "env_app_secret", None)
+        base_url = getattr(cfg, "feishu_base_url", None) or "https://open.feishu.cn"
+        if not app_id or not app_secret:
+            _logger.warning("on_cron_deliver fallback: missing app_id/app_secret in config")
+            return False
+
+        card = build_cron_card(content, task_name=task_name, run_time=run_time)
+
+        async def _send_once() -> None:
+            client = FeishuClient(FeishuClientConfig(
+                app_id=app_id, app_secret=app_secret, base_url=base_url,
+            ))
+            await client.send_card_to_chat(chat_id, card)
+
+        try:
+            _asyncio.run(_send_once())
+            _logger.info(
+                "cron card delivered (standalone fallback): chat=%s len=%d",
+                chat_id[:12], len(content or ""),
+            )
+            return True
+        except Exception as exc:
+            _logger.warning("standalone card fallback failed: %s", exc, exc_info=True)
+            return False
     except Exception as exc:
         _logger.warning("on_cron_deliver error: %s", exc, exc_info=True)
         return False

--- a/hermes_lark_streaming/patch.py
+++ b/hermes_lark_streaming/patch.py
@@ -290,6 +290,7 @@ def on_cron_deliver(
             task_name, chat_id[:12], len(content or ""),
         )
         import asyncio as _asyncio
+
         from hermes_lark_streaming.cardkit.builder import build_cron_card
         from hermes_lark_streaming.feishu import FeishuClient, FeishuClientConfig
 


### PR DESCRIPTION
Fixes #86。

## 做了什么

在 `on_cron_deliver` 里加了一条**兜底路径**：当 gateway 缓存的 asyncio loop 已经失效（典型场景是 Hermes Studio Desktop 跑了几小时之后）时，cron 卡片仍能正常渲染。

## 为什么要修

`on_cron_deliver(loop, ...)` 在 Hermes Studio 管理的 gateway 里，跑一段时间后会间歇性收到 `loop=None`。修复前的逻辑直接 `return False`，导致 `cron.scheduler` 退回到纯文本飞书投递路径 —— 卡片被静默降级为纯文本。

完整根因分析见 #86。

## 怎么修的

```python
if loop is not None:
    return bool(ctrl.on_cron_deliver(...))   # 正常路径 —— 完全没动

# 兜底：loop 失效时，自建短生命周期 loop + 临时 client 完成卡片发送
cfg = ctrl._cfg
app_id     = cfg.feishu_app_id     or cfg.env_app_id
app_secret = cfg.feishu_app_secret or cfg.env_app_secret
base_url   = cfg.feishu_base_url   or "https://open.feishu.cn"
card = build_cron_card(content, task_name=task_name, run_time=run_time)

async def _send_once():
    client = FeishuClient(FeishuClientConfig(app_id=app_id, app_secret=app_secret, base_url=base_url))
    await client.send_card_to_chat(chat_id, card)

asyncio.run(_send_once())
return True
```

- **正常路径完全不改动**：`loop is not None` 时行为与修复前完全一致，逐字节相同 —— 直接跑 `hermes gateway start` 的用户不受任何影响。
- 复用现有的 `build_cron_card` 和 `FeishuClient` —— 没有重复实现卡片构建或 HTTP 逻辑。
- 凭证读取沿用插件已有的 `ctrl._cfg` 配置（`feishu_app_id / feishu_app_secret / feishu_base_url`，再以 `env_app_id / env_app_secret` 兜底），不引入新的配置项。
- 所有异常都记日志 + 返回 `False`，优雅降级到 scheduler 的纯文本路径 —— 兜底失败时不会比修复前更糟。

## 验证

在 Windows 11 + Hermes Studio Desktop 0.18.0 环境下已验证：

**修复前（loop 失效时）：**
```
cron.scheduler: Job 'xxx': delivered to feishu:oc_...    ← 纯文本
```

**修复后（loop 失效时走兜底路径）：**
```
on_cron_deliver: gateway loop unavailable, falling back to standalone card send (task='每日PCEC自主进化' chat=oc_d3f56244d len=155)
cron card delivered (standalone fallback): chat=oc_d3f56244d len=155
cron.scheduler: Job 'xxx': delivered to feishu:oc_...    ← 卡片渲染成功 ✅
```

**loop 正常时**：行为不变 —— 没有兜底日志输出，走原有 `ctrl.on_cron_deliver()` 路径。

## 涉及文件

- `hermes_lark_streaming/patch.py`：+47 −7
