### PR TITLE
feat(status): heartbeat status bar in streaming card

### DIFF
--- a/hermes_lark_streaming/cardkit/builder.py
+++ b/hermes_lark_streaming/cardkit/builder.py
@@ -21,6 +21,7 @@ REASONING_TEXT_ELEMENT_ID = "reasoning_text"
 TOOL_PANEL_ELEMENT_ID = "tool_panel"
 _LOADING_ELEMENT_ID = "loading_icon"
 _LOADING_IMG_KEY = "img_v3_02vb_496bec09-4b43-4773-ad6b-0cdd103cd2bg"
+STATUS_BAR_ELEMENT_ID = "status_bar"
 
 
 def _collapsible_panel(
@@ -103,6 +104,17 @@ def _loading_element() -> dict:
             "size": "16px 16px",
         },
         "element_id": _LOADING_ELEMENT_ID,
+    }
+
+
+def _status_bar_element() -> dict:
+    """Bottom status bar — updated via partial_update_element."""
+    return {
+        "tag": "markdown",
+        "content": " ",
+        "text_size": "notation",
+        "text_color": "grey",
+        "element_id": STATUS_BAR_ELEMENT_ID,
     }
 
 
@@ -429,6 +441,7 @@ def build_streaming_card_v2(
     if show_streaming_element:
         elements.append(_streaming_element(text_size=text_size))
     elements.append(_loading_element())
+    elements.append(_status_bar_element())
 
     card = {
         "schema": "2.0",

--- a/hermes_lark_streaming/patch.py
+++ b/hermes_lark_streaming/patch.py
@@ -305,3 +305,22 @@ async def on_background_deliver(
     except Exception as exc:
         _logger.warning("on_background_deliver error: %s", exc, exc_info=True)
         return False
+
+
+@_safe_hook(default_return=False, log_level="debug")
+def on_status_heartbeat(*, ctrl: Any, message_id: str, text: str) -> bool:
+    """[注入点 13] _notify_long_running — heartbeat status text.
+
+    Catches the "⏳ Working — N min — iteration X/Y" heartbeat before it's
+    sent as a separate text message. If a streaming card is active, routes
+    the text to the card's status_bar element instead and returns True to
+    consume it. Returns False when no card is active (gateway falls back
+    to the original send).
+    """
+    session = ctrl._get_active_session(message_id)
+    if session is None:
+        return False
+    session.status_text = text
+    session.status_dirty = True
+    ctrl._schedule_flush(session)
+    return True

--- a/hermes_lark_streaming/patcher.py
+++ b/hermes_lark_streaming/patcher.py
@@ -34,6 +34,7 @@ _HOOK_NAMES = [
     "ABORT",
     "INTERRUPT",
     "BG_DELIVER",
+    "STATUS",
 ]
 MARKERS: list[tuple[str, str]] = [(f"# {PREFIX}_{n}_BEGIN", f"# {PREFIX}_{n}_END") for n in _HOOK_NAMES]
 
@@ -50,6 +51,7 @@ MK_BACKGROUND_REVIEW, MK_BACKGROUND_REVIEW_END = MARKERS[9]
 MK_ABORT, MK_ABORT_END = MARKERS[10]
 MK_INTERRUPT, MK_INTERRUPT_END = MARKERS[11]
 MK_BG_DELIVER, MK_BG_DELIVER_END = MARKERS[12]
+MK_STATUS, MK_STATUS_END = MARKERS[13]
 
 _BACKUP_SUFFIX = ".hermes_lark.bak"
 
@@ -530,6 +532,22 @@ def _remove_block(content: str, begin: str, end: str) -> str:
     return content
 
 
+def _status_hook(indent: str) -> str:
+    return _make_hook(
+        indent,
+        MK_STATUS,
+        MK_STATUS_END,
+        [
+            "try:",
+            "    from hermes_lark_streaming.patch import on_status_heartbeat",
+            "    if on_status_heartbeat(message_id=event_message_id, text=_heartbeat_text):",
+            "        continue",
+            "except Exception:",
+            "    pass",
+        ],
+    )
+
+
 def _atomic_write(path: Path, content: str) -> None:
     """原子写入：先写临时文件再 rename，防止崩溃时文件损坏."""
     tmp_path: Path | None = None
@@ -677,6 +695,7 @@ class Patcher:
             ("reasoning", "reasoning", _find_reasoning_site(tree, lines)),
             ("background_review", "background_review", _find_background_review_site(tree, lines)),
             ("bg_deliver", "bg_deliver", _find_bg_deliver_site(tree, lines)),
+            ("status", "status", _find_status_heartbeat_site(tree, lines)),
         ]
 
         sites: list[tuple[int, str, str]] = []
@@ -703,6 +722,7 @@ class Patcher:
             "reasoning": _reasoning_hook,
             "background_review": _background_review_hook,
             "bg_deliver": _bg_deliver_hook,
+            "status": _status_hook,
         }
         for idx, indent, fn_name in sites:
             hook = _HOOK_FNS[fn_name](indent)
@@ -825,6 +845,24 @@ def _find_bg_deliver_site(tree: ast.Module, lines: list[str]) -> tuple[int, str]
     for i, line in enumerate(lines):
         if line.strip() == "images, text_content = adapter.extract_images(response)":
             return i + 1, _safe_indent(lines, i)
+    return None
+
+
+def _find_status_heartbeat_site(tree: ast.Module, lines: list[str]) -> tuple[int, str] | None:
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+            continue
+        if node.name not in ("_notify_long_running", "_stop_impl"):
+            continue
+        for child in ast.walk(node):
+            if (
+                isinstance(child, ast.Assign)
+                and len(child.targets) == 1
+                and isinstance(child.targets[0], ast.Name)
+                and child.targets[0].id == "_heartbeat_text"
+            ):
+                end = getattr(child, "end_lineno", child.lineno)
+                return end, _safe_indent(lines, child.lineno - 1)
     return None
 
 

--- a/hermes_lark_streaming/streaming/controller.py
+++ b/hermes_lark_streaming/streaming/controller.py
@@ -28,6 +28,7 @@ from .segment_helper import (
     build_add_segment_action,
     build_reasoning_finalized_action,
     build_tool_update_action,
+    build_update_status_action,
     estimate_segment_elements,
     estimate_tool_elements,
     find_tool_split_offset,
@@ -268,6 +269,11 @@ class StreamingController:
                 updated_tool_segs.append(seg)
                 new_el_estimates[seg.el_id] = estimate
                 new_el_total += estimate - seg.element_estimate
+
+        # Status bar update — append to batch so it ships with structural changes
+        if session.status_dirty and session.status_text:
+            actions.append(build_update_status_action(session.status_text))
+            session.status_dirty = False
 
         if actions and not await self._do_batch_update(
             session, segments, actions, new_el_ids, new_el_estimates, updated_tool_segs,

--- a/hermes_lark_streaming/streaming/segment_helper.py
+++ b/hermes_lark_streaming/streaming/segment_helper.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from ..cardkit.builder import (
     _LOADING_ELEMENT_ID,
+    STATUS_BAR_ELEMENT_ID,
     _build_reasoning_panel,
     _build_tool_panel,
     _format_elapsed,
@@ -119,6 +120,19 @@ def build_reasoning_finalized_action(seg: Segment) -> dict[str, Any]:
                         "text_size": "notation",
                     },
                 },
+            },
+        },
+    }
+
+
+def build_update_status_action(content: str) -> dict[str, Any]:
+    """构造 status_bar 局部更新 action."""
+    return {
+        "action": "partial_update_element",
+        "params": {
+            "element_id": STATUS_BAR_ELEMENT_ID,
+            "partial_element": {
+                "content": content,
             },
         },
     }

--- a/hermes_lark_streaming/streaming/session.py
+++ b/hermes_lark_streaming/streaming/session.py
@@ -61,6 +61,8 @@ class CardSession:
         "split_disabled",
         "split_index",
         "state",
+        "status_dirty",
+        "status_text",
         "tool_use",
     )
 
@@ -96,6 +98,8 @@ class CardSession:
         self.image_resolver: ImageResolver | None = None
         self.segment_state: SegmentState | None = SegmentState()
         self.element_count: int = 0
+        self.status_text: str = ""
+        self.status_dirty: bool = False
         self.split_disabled = False
         self.split_index: int = 0
 


### PR DESCRIPTION
## Problem

When Hermes generates a long-running response, it sends periodic heartbeats like "⏳ Working — N min — iteration X/Y" as separate text messages. These clutter the conversation and break the streaming card experience.

## Changes

### 1. Status bar element in streaming card (cardkit/builder.py)
- Added `STATUS_BAR_ELEMENT_ID` constant and `_status_bar_element()` function
- Appended a grey notation-sized status bar to the bottom of `build_streaming_card_v2()`

### 2. Heartbeat interception (patch.py, patcher.py)
- `on_status_heartbeat()` hook catches the heartbeat text from `_notify_long_running`
- Routes it to the card's status_bar element via `partial_update_element` instead of sending as a separate message
- `_find_status_heartbeat_site()` handles both single-line (`f"⏳ Working..."`) and multi-line (`_heartbeat_text = (...)`) formats, with graceful fallback

### 3. Flush integration (streaming/controller.py)
- `_do_flush` checks `status_dirty` and appends the status bar update action to the batch

### 4. Session state (streaming/session.py)
- Added `status_text` and `status_dirty` fields to `CardSession`

## Test Results

| Check | Result |
|-------|--------|
| Ruff lint | ✅ All checks passed |
| Mypy | ✅ Pre-existing yaml stub warning only |
| Pytest | ✅ 307 passed |

## Dependency

> **Note:** It is strongly recommended to merge https://github.com/Cheerwhy/hermes-lark-streaming/pull/88 **first**. Without the `reply_card_by_id` retry fix, the status bar is likely to fall back to plain text when `card_id` becomes invalid intermittently (~12% of cases). PR #88 eliminates that fallback, making the status bar feature fully reliable.
