### PR TITLE
fix: prevent duplicate plain-text after card on queued follow-up drain

### DIFF
--- a/hermes_lark_streaming/controller.py
+++ b/hermes_lark_streaming/controller.py
@@ -262,7 +262,14 @@ class StreamCardController(StreamingController):
             )
             self._complete_session(old_session)
 
-        if new_message_id not in self._sessions:
+        # Create a fresh session for the follow-up turn unless an ACTIVE session
+        # already owns this id.  When new_message_id == old_message_id (internal
+        # synthetic events, e.g. background delegate_task completion re-entering
+        # with the same anchor), the old session was just aborted above and is
+        # terminal — we must replace it so the follow-up turn can stream to a
+        # new card instead of falling through to the plain-text stream consumer.
+        existing = self._sessions.get(new_message_id)
+        if existing is None or existing.state.is_terminal:
             loop = self._get_loop()
             if loop is not None:
                 reply_anchor_id = anchor_id if anchor_id and anchor_id != new_message_id else None
@@ -305,19 +312,19 @@ class StreamCardController(StreamingController):
         if not await self._wait_for_card_creation(session):
             _logger.info("on_completed_wait: msg=%s card creation not ready, yielding to gateway", message_id[:12])
             self._mark_text_fallback_needed(session)
-            self._cleanup(message_id)
+            self._cleanup_session(session)
             return False
 
         if session.state == SessionState.FAILED:
             _logger.info("on_completed_wait: msg=%s state=FAILED, yielding to gateway", message_id[:12])
             self._mark_text_fallback_needed(session)
-            self._cleanup(message_id)
+            self._cleanup_session(session)
             return False
 
         if not session.has_card:
             _logger.info("on_completed_wait: msg=%s has no card, yielding to gateway", message_id[:12])
             self._mark_text_fallback_needed(session)
-            self._cleanup(message_id)
+            self._cleanup_session(session)
             return False
 
         _logger.info(
@@ -427,6 +434,28 @@ class StreamCardController(StreamingController):
         if anchor and self._sessions.get(anchor) is session:
             del self._sessions[anchor]
         stale_keys = [k for k, v in self._interrupt_map.items() if v == message_id]
+        for k in stale_keys:
+            del self._interrupt_map[k]
+        session.flush.mark_completed()
+        if session.image_resolver:
+            session.image_resolver.cancel_pending()
+
+    def _cleanup_session(self, session: CardSession) -> None:
+        """Remove a session's keys using object identity.
+
+        When an internal synthetic event (e.g. background delegate_task
+        completion) re-enters with the same message_id, ``on_interrupted``
+        replaces the aborted session with a fresh one at the same key.  The
+        fire-and-forget finalizer for the OLD session still calls cleanup with
+        the old message_id — without an identity check it would pop the NEW
+        session, breaking the follow-up turn's card.
+        """
+        if self._sessions.get(session.message_id) is session:
+            self._sessions.pop(session.message_id, None)
+        anchor = getattr(session, "anchor_id", None)
+        if anchor and self._sessions.get(anchor) is session:
+            del self._sessions[anchor]
+        stale_keys = [k for k, v in self._interrupt_map.items() if v == session.message_id]
         for k in stale_keys:
             del self._interrupt_map[k]
         session.flush.mark_completed()

--- a/hermes_lark_streaming/patch.py
+++ b/hermes_lark_streaming/patch.py
@@ -173,6 +173,16 @@ async def on_queued_followup_boundary(*, ctrl: Any, message_id: str, result: dic
     if sent:
         result["response_previewed"] = True
         result["already_sent"] = True
+        # The card already delivered the full response.  Hermes's drain path
+        # (run.py ~L19752) re-sends ``final_response`` as plain text when the
+        # platform stream consumer didn't confirm delivery — and the lark
+        # plugin intercepts all stream deltas, so the stream consumer never
+        # sees any text.  Clearing ``final_response`` here makes the drain
+        # skip that resend (``first_response`` becomes empty), preventing a
+        # duplicate plain-text message after the finalized card.  The
+        # follow-up turn uses ``result["messages"]`` for history, not
+        # ``final_response``, so this is safe.
+        result["final_response"] = ""
     else:
         ctrl.consume_text_fallback(message_id)
     return sent

--- a/hermes_lark_streaming/streaming/controller.py
+++ b/hermes_lark_streaming/streaming/controller.py
@@ -69,6 +69,7 @@ class StreamingController:
     _cfg: Config
     _ensure_init: Callable[..., Coroutine[Any, Any, None]]
     _cleanup: Callable[[str], None]
+    _cleanup_session: Callable[[CardSession], None]
     _flush_deferred_background_reviews: Callable[[CardSession], None]
 
     def _schedule_flush(self, session: CardSession) -> None:
@@ -581,7 +582,7 @@ class StreamingController:
             return await self._do_complete_card_inner(session)
         finally:
             self._flush_deferred_background_reviews(session)
-            self._cleanup(session.message_id)
+            self._cleanup_session(session)
 
     async def _do_complete_card_inner(self, session: CardSession) -> bool:
         if session.guard.should_skip("_do_complete_card"):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -103,6 +103,57 @@ def test_on_interrupted_uses_new_message_id_and_anchor_alias() -> None:
     assert ctrl._sessions["old"].state == SessionState.ABORTED
 
 
+def test_on_interrupted_same_id_creates_replacement_session() -> None:
+    """Internal synthetic events (background delegate_task completion) re-enter
+    with the SAME message_id.  The aborted session must be replaced by a fresh
+    one so the follow-up turn streams to a new card instead of plain text."""
+    ctrl = StreamCardController()
+    _enable(ctrl)
+
+    with patch.object(ctrl, "_fire_and_forget", side_effect=lambda coro, loop: coro.close()):
+        ctrl.on_message_started(message_id="msg", chat_id="chat")
+        old_session = ctrl._sessions["msg"]
+        assert old_session.state == SessionState.IDLE
+
+        ctrl.on_interrupted(
+            old_message_id="msg",
+            new_message_id="msg",
+            chat_id="chat",
+            anchor_id="msg",
+        )
+
+    # Old session is aborted, a NEW session replaced it at the same key.
+    assert old_session.state == SessionState.ABORTED
+    new_session = ctrl._sessions["msg"]
+    assert new_session is not old_session
+    assert new_session.state == SessionState.IDLE
+
+
+def test_cleanup_session_preserves_replacement_session() -> None:
+    """The fire-and-forget finalizer for the OLD session must not pop the NEW
+    session that replaced it at the same key (object identity check)."""
+    ctrl = StreamCardController()
+    _enable(ctrl)
+
+    with patch.object(ctrl, "_fire_and_forget", side_effect=lambda coro, loop: coro.close()):
+        ctrl.on_message_started(message_id="msg", chat_id="chat")
+        old_session = ctrl._sessions["msg"]
+        ctrl.on_interrupted(
+            old_message_id="msg",
+            new_message_id="msg",
+            chat_id="chat",
+            anchor_id="msg",
+        )
+        new_session = ctrl._sessions["msg"]
+
+    # Simulate the old session's fire-and-forget finalizer cleaning up.
+    ctrl._cleanup_session(old_session)
+
+    # The NEW session must survive — only the old session's anchor (if any)
+    # pointing at the old object is removed.
+    assert ctrl._sessions.get("msg") is new_session
+
+
 def test_prune_stale_sessions_ignores_none_key_and_prunes_valid_key() -> None:
     ctrl = StreamCardController()
     stale_session = SimpleNamespace(

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -514,9 +514,10 @@ class TestQueuedFollowupHooks:
 
             assert result["response_previewed"] is True
             assert result["already_sent"] is True
+            assert result["final_response"] == ""
 
     @pytest.mark.asyncio
-    async def test_boundary_consumes_fallback_when_card_not_sent(self) -> None:
+    async def test_boundary_keeps_final_response_when_card_not_sent(self) -> None:
         from hermes_lark_streaming.patch import on_queued_followup_boundary
 
         with patch("hermes_lark_streaming.patch.get_controller") as mock_get:
@@ -530,6 +531,7 @@ class TestQueuedFollowupHooks:
 
             ctrl.consume_text_fallback.assert_called_once_with("msg")
             assert "response_previewed" not in result
+            assert result["final_response"] == "plain"
 
     def test_result_hook_preserves_deepest_completion_id(self) -> None:
         from hermes_lark_streaming.patch import on_queued_followup_result


### PR DESCRIPTION
When a background delegate_task subagent completes, its synthetic internal message is queued by the adapter (not interrupting). During the subsequent drain, the FOLLOWUP_COMPLETE hook finalizes the card, but Hermes's drain path (run.py ~L19752) re-sends final_response as plain text because the lark plugin intercepts all stream deltas -- the platform stream consumer never confirms delivery (has_delivered_text returns False). The drain path does not check already_sent, only _already_streamed.

Primary fix (patch.py): on_queued_followup_boundary clears result["final_response"] after successfully finalizing the card, making the drain skip the resend (first_response becomes empty). Only fires when there IS a pending event (hook is inside the 'if pending_event or pending:' block), so the no-follow-up path is unaffected.

Defensive fix (controller.py): on_interrupted now creates a replacement session when new_message_id maps to a terminal session (same-id re-entry from synthetic events). Previously the aborted session blocked creation, causing the follow-up turn to fall through to the plain-text stream consumer. Added _cleanup_session with object identity to prevent the fire-and-forget finalizer from clobbering a newer replacement session at the same key.