### PR TITLE
feat(config): add show_tool_use to hide tool panel in Feishu card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### 新增
+
+- `Config.show_tool_use` 配置项：支持平台级（`display.platforms.feishu.show_tool_use`）和全局（`display.show_tool_use`）两级配置，默认 `True`（向后兼容）。在飞书卡片上禁用工具调用面板展示，让最终答复更清爽。
+- `build_complete_card` 新增 `show_tool_use` 参数（默认 `True`），控制完成态卡片是否渲染 TOOL 段的工具面板。
+
+### Added
+
+- `Config.show_tool_use` property with platform-level (`display.platforms.feishu.show_tool_use`) and global (`display.show_tool_use`) fallback. Default `True` for backward compatibility. Disable the tool-use panel on Feishu cards for a cleaner final answer.
+- `build_complete_card` gains a `show_tool_use` parameter (default `True`) that controls whether the TOOL segment renders the tool panel in the completion card.
+
+---
+
 ## [0.11.2] - 2026-07-01
 
 ### 修复

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
-
-### 新增
-
-- `Config.show_tool_use` 配置项：支持平台级（`display.platforms.feishu.show_tool_use`）和全局（`display.show_tool_use`）两级配置，默认 `True`（向后兼容）。在飞书卡片上禁用工具调用面板展示，让最终答复更清爽。
-- `build_complete_card` 新增 `show_tool_use` 参数（默认 `True`），控制完成态卡片是否渲染 TOOL 段的工具面板。
-
-### Added
-
-- `Config.show_tool_use` property with platform-level (`display.platforms.feishu.show_tool_use`) and global (`display.show_tool_use`) fallback. Default `True` for backward compatibility. Disable the tool-use panel on Feishu cards for a cleaner final answer.
-- `build_complete_card` gains a `show_tool_use` parameter (default `True`) that controls whether the TOOL segment renders the tool panel in the completion card.
-
----
-
 ## [0.11.2] - 2026-07-01
 
 ### 修复

--- a/hermes_lark_streaming/cardkit/builder.py
+++ b/hermes_lark_streaming/cardkit/builder.py
@@ -466,6 +466,7 @@ def build_complete_card(
     panel_expanded: bool = False,
     header_enabled: bool = False,
     body_text_size: str = "normal_v2",
+    show_tool_use: bool = True,
 ) -> dict[str, Any]:
     """完成态流式卡片 — 按 segments 顺序渲染."""
     elements: list[dict] = []
@@ -479,6 +480,8 @@ def build_complete_card(
                     element_id=None, text_element_id=None,
                 ))
         elif seg.type == SegmentType.TOOL:
+            if not show_tool_use:
+                continue
             start = seg.tool_offset
             end = seg.tool_end_offset if seg.tool_end_offset else len(all_tool_steps)
             steps = all_tool_steps[start:end]

--- a/hermes_lark_streaming/config.py
+++ b/hermes_lark_streaming/config.py
@@ -70,6 +70,23 @@ class Config:
         return bool(display.get("show_reasoning", False))
 
     @property
+    def show_tool_use(self) -> bool:
+        """是否在卡片中展示工具调用面板.
+
+        优先级：display.platforms.feishu.show_tool_use → display.show_tool_use，
+        默认 True（保持向后兼容）。每次从磁盘重读以支持运行时切换。
+        """
+        display = self._reload().get("display")
+        if not isinstance(display, dict):
+            return True
+        platforms = display.get("platforms")
+        if isinstance(platforms, dict):
+            feishu = platforms.get("feishu")
+            if isinstance(feishu, dict) and "show_tool_use" in feishu:
+                return bool(feishu["show_tool_use"])
+        return bool(display.get("show_tool_use", True))
+
+    @property
     def feishu_app_id(self) -> str:
         return str(self._platform_cfg().get("app_id", ""))
 

--- a/hermes_lark_streaming/streaming/controller.py
+++ b/hermes_lark_streaming/streaming/controller.py
@@ -531,6 +531,7 @@ class StreamingController:
             panel_expanded=self._cfg.panel_expanded,
             header_enabled=False,
             body_text_size=self._cfg.body_text_size,
+            show_tool_use=self._cfg.show_tool_use,
         )
 
         try:
@@ -636,6 +637,7 @@ class StreamingController:
             panel_expanded=self._cfg.panel_expanded,
             header_enabled=self._cfg.header_enabled,
             body_text_size=self._cfg.body_text_size,
+            show_tool_use=self._cfg.show_tool_use,
         )
 
         streaming_closed = False

--- a/hermes_lark_streaming/streaming/controller.py
+++ b/hermes_lark_streaming/streaming/controller.py
@@ -188,6 +188,14 @@ class StreamingController:
             if i < session.split_index:
                 continue
 
+            # show_tool_use=False: 流式态跳过所有 TOOL segment 处理
+            # （新建与 dirty 更新两条路径），只保留 reasoning/answer
+            if seg.type == SegmentType.TOOL and not self._cfg.show_tool_use:
+                if not seg.created:
+                    seg.created = True  # 防止 next flush 再次进入 not created 分支
+                seg.dirty = False
+                continue
+
             if not seg.created:
                 estimated = estimate_segment_elements(seg, all_steps)
                 if (

--- a/tests/test_cardkit.py
+++ b/tests/test_cardkit.py
@@ -478,6 +478,29 @@ class TestBuildSegmentCompleteCard:
         )
         assert not any(e.get("tag") == "collapsible_panel" for e in card["body"]["elements"])
 
+    def test_show_tool_use_false_hides_tool_panel(self) -> None:
+        """show_tool_use=False → TOOL segment rendered as nothing (无工具面板)."""
+        steps = [_STEP_RUNNING, _STEP_SUCCESS]
+        card = build_complete_card(
+            segments=[_seg("tool", tool_offset=0, tool_end_offset=2), _seg("answer", "hello")],
+            all_tool_steps=steps,
+            show_tool_use=False,
+        )
+        # 无 collapsible_panel（工具面板）
+        assert not any(e.get("tag") == "collapsible_panel" for e in card["body"]["elements"])
+        # 但 answer 依然在
+        assert any(e.get("tag") == "markdown" and "hello" in str(e.get("content", ""))
+                   for e in card["body"]["elements"])
+
+    def test_show_tool_use_true_default_shows_panel(self) -> None:
+        """show_tool_use 默认 True → 工具面板保留（向后兼容）."""
+        steps = [_STEP_RUNNING, _STEP_SUCCESS]
+        card = build_complete_card(
+            segments=[_seg("tool", tool_offset=0, tool_end_offset=2)],
+            all_tool_steps=steps,
+        )
+        assert any(e.get("tag") == "collapsible_panel" for e in card["body"]["elements"])
+
     def test_summary_truncated_from_last_answer(self) -> None:
         card = build_complete_card(
             segments=[_seg("answer", "short"), _seg("answer", "x" * 200)],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -221,6 +221,55 @@ class TestShowReasoning:
         assert cfg.show_reasoning is False
 
 
+class TestShowToolUse:
+    def _make_config(self, raw: dict[str, Any]) -> Config:
+        cfg = Config()
+        cfg._reload = lambda: raw  # type: ignore[assignment]
+        return cfg
+
+    def test_platform_level_true(self) -> None:
+        cfg = self._make_config({"display": {"platforms": {"feishu": {"show_tool_use": True}}}})
+        assert cfg.show_tool_use is True
+
+    def test_platform_level_false(self) -> None:
+        cfg = self._make_config({"display": {"platforms": {"feishu": {"show_tool_use": False}}}})
+        assert cfg.show_tool_use is False
+
+    def test_global_fallback_true(self) -> None:
+        cfg = self._make_config({"display": {"show_tool_use": True}})
+        assert cfg.show_tool_use is True
+
+    def test_global_fallback_false(self) -> None:
+        cfg = self._make_config({"display": {"show_tool_use": False}})
+        assert cfg.show_tool_use is False
+
+    def test_default_true(self) -> None:
+        """Missing config → default True (backward compatible)."""
+        cfg = self._make_config({})
+        assert cfg.show_tool_use is True
+
+    def test_display_not_dict(self) -> None:
+        cfg = self._make_config({"display": "invalid"})
+        assert cfg.show_tool_use is True
+
+    def test_platforms_not_dict(self) -> None:
+        cfg = self._make_config({"display": {"platforms": "invalid"}})
+        assert cfg.show_tool_use is True
+
+    def test_feishu_section_missing_key(self) -> None:
+        cfg = self._make_config({"display": {"platforms": {"feishu": {"other": True}}}})
+        assert cfg.show_tool_use is True
+
+    def test_platform_takes_priority_over_global(self) -> None:
+        cfg = self._make_config({
+            "display": {
+                "platforms": {"feishu": {"show_tool_use": False}},
+                "show_tool_use": True,
+            }
+        })
+        assert cfg.show_tool_use is False
+
+
 class TestPlatformCfg:
     def test_env_takes_priority(self) -> None:
         cfg = _make_config({"feishu": {"app_id": "config_id", "app_secret": "config_secret"}})


### PR DESCRIPTION
## Motivation

For agents that heavily rely on tool calls (browser navigation, terminal commands, file operations…), the collapsible "Tool use" panel on the final Feishu card can drown out the actual answer. Users who want a **clean final answer** currently have no way to hide it — unlike `show_reasoning`, which already offers this exact ergonomic.

This PR mirrors `show_reasoning` with a symmetric `show_tool_use` switch.

## Change

Add a `show_tool_use` config with two-tier fallback (identical shape to `show_reasoning`):

```yaml
display:
  # global default (applies to all platforms)
  show_tool_use: false

  # or platform-specific override
  platforms:
    feishu:
      show_tool_use: false
```

- Default is `True` → **fully backward compatible**, no behavior change unless you opt in.
- When `False`, `build_complete_card` skips `SegmentType.TOOL` rendering; reasoning + answer segments are untouched.
- Live re-read from disk each access (same as `show_reasoning`), so users can toggle without restart.

## Files

| File | Change |
|---|---|
| `hermes_lark_streaming/config.py` | + `Config.show_tool_use` property |
| `hermes_lark_streaming/cardkit/builder.py` | `build_complete_card` gains `show_tool_use: bool = True` kwarg; `SegmentType.TOOL` short-circuits when `False` |
| `hermes_lark_streaming/streaming/controller.py` | Pass `cfg.show_tool_use` into both `build_complete_card` sites (main + seal) |
| `tests/test_config.py` | + `TestShowToolUse` (9 cases mirroring `TestShowReasoning`) |
| `tests/test_cardkit.py` | + 2 cases: `show_tool_use=False` hides panel & default `True` preserves it |
| `CHANGELOG.md` | Unreleased entry (CN + EN) |

## Tests

- Full `tests/test_config.py` — **55/55 pass** (all preexisting + 9 new)
- Targeted `tests/test_cardkit.py` for build_complete_card — **11/11 pass** including 2 new cases

```
$ python -m pytest tests/test_config.py tests/test_cardkit.py::TestCompleteCard -q
... 55 + 11 passed
```

Note: Some tests in `test_controller.py`, `test_image.py`, `test_patcher.py`, `test_paths.py` fail on my Windows/Python 3.14 env **both with and without** this change (unrelated env issues, verified via `git stash` diff-run).

## Backward Compatibility

`show_tool_use` default is `True`. Existing installations render identically until they explicitly set the new key to `False`.

## Related

Naturally extends the same UX principle as `show_reasoning` (#…). Same code paths, same fallback resolution, same live-reload behavior.
