### PR TITLE
fix: adapt streaming hooks to Hermes 0.19 runtime changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ gateway/run.py (Hermes)
        ├─ on_queued_followup_result   → patch.on_queued_followup_result() (carry deepest completion ID through recursive merge)
        ├─ on_message_completed_wait → controller.on_completed_wait()
        ├─ on_message_aborted    → controller.on_aborted()
+       ├─ on_session_aborted    → controller.on_session_aborted() (busy-session /stop)
        └─ on_background_deliver → controller.on_background_deliver()
 
 cron/scheduler.py (Hermes)
@@ -55,6 +56,7 @@ cron/scheduler.py (Hermes)
 StreamCardController (singleton, controller.py)
   ├─ CardSession per message (state machine: IDLE→CREATING→STREAMING→COMPLETED/FAILED/ABORTED)
   │   └─ stream segments: CardSession.segment_state (SegmentState)
+  ├─ _session_keys — Hermes session_key → active CardSession mapping for precise /stop handling
   ├─ _interrupt_map — old_message_id → new_message_id mapping for interrupt redirect
   ├─ FlushController (streaming/flush.py) — throttles CardKit updates (100ms)
   ├─ ToolUseTracker (streaming/tooluse.py) — tracks tool call lifecycle with icon/status mapping

--- a/hermes_lark_streaming/controller.py
+++ b/hermes_lark_streaming/controller.py
@@ -31,6 +31,7 @@ class StreamCardController(StreamingController):
         self._cfg = Config()
         self._client: FeishuClient | None = None
         self._sessions: dict[str, CardSession] = {}
+        self._session_keys: dict[str, CardSession] = {}
         self._interrupt_map: dict[str, str] = {}
         self._initialized = False
         self._init_lock = asyncio.Lock()
@@ -105,6 +106,7 @@ class StreamCardController(StreamingController):
         message_id: str | None,
         chat_id: str,
         anchor_id: str | None = None,
+        session_key: str | None = None,
     ) -> None:
         """消息处理开始 — 创建会话 + 发占位卡片."""
         if not self.enabled:
@@ -122,7 +124,10 @@ class StreamCardController(StreamingController):
             _logger.warning("no event loop available, skipping: msg=%s", message_id[:12])
             return
         session = CardSession(message_id, chat_id, loop)
+        session.session_key = session_key
         self._sessions[message_id] = session
+        if session_key:
+            self._session_keys[session_key] = session
         if anchor_id and anchor_id != message_id:
             session.anchor_id = anchor_id
             self._sessions[anchor_id] = session
@@ -240,6 +245,20 @@ class StreamCardController(StreamingController):
 
         self._complete_session(session)
 
+    async def on_session_aborted(self, *, session_key: str) -> bool:
+        """Terminate the active card bound to a Hermes session key."""
+        if not self.enabled or not session_key:
+            return False
+        session = self._session_keys.pop(session_key, None)
+        if session is None or session.state.is_terminal:
+            return False
+
+        session.state = SessionState.ABORTED
+        session.flush.mark_completed()
+        _logger.info("on_session_aborted: msg=%s state=ABORTED", session.message_id[:12])
+
+        return await self._complete_session_after_creation(session)
+
     def on_interrupted(
         self,
         *,
@@ -247,12 +266,14 @@ class StreamCardController(StreamingController):
         new_message_id: str,
         chat_id: str,
         anchor_id: str | None = None,
+        session_key: str | None = None,
     ) -> None:
         """用户发送新消息导致前一条消息被中断 — abort A + create B."""
         if not self.enabled:
             return
 
         old_session = self._get_active_session(old_message_id)
+        session_key = session_key or (old_session.session_key if old_session is not None else None)
         if old_session is not None:
             old_session.state = SessionState.ABORTED
             old_session.flush.mark_completed()
@@ -268,7 +289,10 @@ class StreamCardController(StreamingController):
                 reply_anchor_id = anchor_id if anchor_id and anchor_id != new_message_id else None
                 session = CardSession(new_message_id, chat_id, loop)
                 session.anchor_id = reply_anchor_id
+                session.session_key = session_key
                 self._sessions[new_message_id] = session
+                if session_key:
+                    self._session_keys[session_key] = session
                 if reply_anchor_id:
                     self._sessions[reply_anchor_id] = session
                 _logger.info(
@@ -289,6 +313,7 @@ class StreamCardController(StreamingController):
         *,
         message_id: str,
         answer: str = "",
+        is_error: bool = False,
         duration: float = 0.0,
         model: str = "",
         tokens: dict | None = None,
@@ -335,6 +360,8 @@ class StreamCardController(StreamingController):
             tokens=tokens,
             context=context,
         )
+        if is_error:
+            session.mark_failed()
 
         return await self._complete_session_wait(session)
 
@@ -426,6 +453,9 @@ class StreamCardController(StreamingController):
         anchor = getattr(session, "anchor_id", None)
         if anchor and self._sessions.get(anchor) is session:
             del self._sessions[anchor]
+        session_key = getattr(session, "session_key", None)
+        if session_key and self._session_keys.get(session_key) is session:
+            del self._session_keys[session_key]
         stale_keys = [k for k, v in self._interrupt_map.items() if v == message_id]
         for k in stale_keys:
             del self._interrupt_map[k]
@@ -505,7 +535,13 @@ class StreamCardController(StreamingController):
     def _complete_session(self, session: CardSession) -> None:
         """异步完成当前流式卡片."""
         session.flush.mark_completed()
-        self._fire_and_forget(self._do_complete_card(session), session._loop)
+        self._fire_and_forget(self._complete_session_after_creation(session), session._loop)
+
+    async def _complete_session_after_creation(self, session: CardSession) -> bool:
+        if not await self._wait_for_card_creation(session):
+            self._cleanup(session.message_id)
+            return False
+        return await self._complete_session_wait(session)
 
     async def _complete_session_wait(self, session: CardSession) -> bool:
         """完成当前流式卡片，并等待最终 API 结果."""

--- a/hermes_lark_streaming/patch.py
+++ b/hermes_lark_streaming/patch.py
@@ -113,9 +113,21 @@ def on_feishu_normalize(
 
 
 @_safe_hook()
-def on_message_started(*, ctrl: Any, message_id: str, chat_id: str, anchor_id: str | None = None) -> None:
+def on_message_started(
+    *,
+    ctrl: Any,
+    message_id: str,
+    chat_id: str,
+    anchor_id: str | None = None,
+    session_key: str | None = None,
+) -> None:
     """[注入点 1] 函数开头 — message.started."""
-    ctrl.on_message_started(message_id=message_id, chat_id=chat_id, anchor_id=anchor_id)
+    ctrl.on_message_started(
+        message_id=message_id,
+        chat_id=chat_id,
+        anchor_id=anchor_id,
+        session_key=session_key,
+    )
 
 
 @_safe_hook(default_return=False)
@@ -124,6 +136,7 @@ async def on_message_completed_wait(
     ctrl: Any,
     message_id: str,
     answer: str = "",
+    is_error: bool = False,
     duration: float = 0.0,
     model: str = "",
     tokens: dict[str, Any] | None = None,
@@ -134,6 +147,7 @@ async def on_message_completed_wait(
         await ctrl.on_completed_wait(
             message_id=message_id,
             answer=answer,
+            is_error=is_error,
             duration=duration,
             model=model,
             tokens=tokens,
@@ -158,6 +172,7 @@ async def on_queued_followup_boundary(*, ctrl: Any, message_id: str, result: dic
         await ctrl.on_completed_wait(
             message_id=message_id,
             answer=result.get("final_response") or "",
+            is_error=bool(result.get("failed")),
             duration=0.0,
             model=result.get("model", ""),
             tokens={
@@ -173,6 +188,7 @@ async def on_queued_followup_boundary(*, ctrl: Any, message_id: str, result: dic
     if sent:
         result["response_previewed"] = True
         result["already_sent"] = True
+        result["final_response"] = ""
     else:
         ctrl.consume_text_fallback(message_id)
     return sent
@@ -242,6 +258,18 @@ def on_message_aborted(*, ctrl: Any, message_id: str) -> None:
     ctrl.on_aborted(message_id=message_id)
 
 
+async def on_session_aborted(*, session_key: str) -> bool:
+    """Terminate the active card after Hermes handles a busy-session /stop."""
+    try:
+        ctrl = get_controller()
+        if not ctrl.enabled:
+            return False
+        return bool(await ctrl.on_session_aborted(session_key=session_key))
+    except Exception as exc:
+        _logger.warning("on_session_aborted error: %s", exc, exc_info=True)
+        return False
+
+
 @_safe_hook()
 def on_message_interrupted(
     *,
@@ -250,6 +278,7 @@ def on_message_interrupted(
     new_message_id: str,
     chat_id: str,
     anchor_id: str | None = None,
+    session_key: str | None = None,
 ) -> None:
     """[注入点 9] interrupt 发生 — message.interrupted."""
     ctrl.on_interrupted(
@@ -257,6 +286,7 @@ def on_message_interrupted(
         new_message_id=new_message_id,
         chat_id=chat_id,
         anchor_id=anchor_id,
+        session_key=session_key,
     )
 
 

--- a/hermes_lark_streaming/patcher.py
+++ b/hermes_lark_streaming/patcher.py
@@ -32,6 +32,7 @@ _HOOK_NAMES = [
     "REASONING",
     "BACKGROUND_REVIEW",
     "ABORT",
+    "STOP",
     "INTERRUPT",
     "BG_DELIVER",
 ]
@@ -48,8 +49,9 @@ MK_THINKING, MK_THINKING_END = MARKERS[7]
 MK_REASONING, MK_REASONING_END = MARKERS[8]
 MK_BACKGROUND_REVIEW, MK_BACKGROUND_REVIEW_END = MARKERS[9]
 MK_ABORT, MK_ABORT_END = MARKERS[10]
-MK_INTERRUPT, MK_INTERRUPT_END = MARKERS[11]
-MK_BG_DELIVER, MK_BG_DELIVER_END = MARKERS[12]
+MK_STOP, MK_STOP_END = MARKERS[11]
+MK_INTERRUPT, MK_INTERRUPT_END = MARKERS[12]
+MK_BG_DELIVER, MK_BG_DELIVER_END = MARKERS[13]
 
 _BACKUP_SUFFIX = ".hermes_lark.bak"
 
@@ -60,7 +62,7 @@ def _valid_source(path: Path) -> Path | None:
         if candidate.is_file() and candidate.suffix == ".py":
             return candidate
     except (OSError, RuntimeError):
-        pass
+        _logger.debug("Invalid Hermes source candidate: %s", path, exc_info=True)
     return None
 
 
@@ -204,6 +206,15 @@ def _make_hook(indent: str, begin: str, end: str, body_lines: list[str]) -> str:
     return f"{indent}{begin}\n" + "".join(f"{indent}{line}\n" for line in body_lines) + f"{indent}{end}\n"
 
 
+def _hook_exception_lines(hook_name: str, indent: str = "") -> list[str]:
+    return [
+        f"{indent}except Exception:",
+        f"{indent}    import logging as _lark_logging",
+        f'{indent}    _lark_logging.getLogger("hermes_lark_streaming").exception('
+        f'"injected hook failed: {hook_name}")',
+    ]
+
+
 def _feishu_normalize_hook(indent: str) -> str:
     return _make_hook(
         indent,
@@ -218,8 +229,7 @@ def _feishu_normalize_hook(indent: str) -> str:
             "        event=event,",
             "        reply_anchor_id=self._reply_anchor_for_event(event),",
             "    )",
-            "except Exception:",
-            "    pass",
+            *_hook_exception_lines("normalize"),
         ],
     )
 
@@ -238,9 +248,9 @@ def _start_hook(indent: str) -> str:
             "            message_id=event.message_id,",
             "            chat_id=source.chat_id,",
             "            anchor_id=_lark_anchor_id,",
+            "            session_key=locals().get('session_key') or locals().get('_quick_key'),",
             "        )",
-            "except Exception:",
-            "    pass",
+            *_hook_exception_lines("start"),
         ],
     )
 
@@ -257,6 +267,7 @@ def _complete_hook(indent: str) -> str:
             "    _lark_card_sent = await on_message_completed_wait(",
             "        message_id=_lark_completion_id,",
             "        answer=response,",
+            "        is_error=bool(agent_result.get('failed')),",
             "        duration=_response_time,",
             "        model=agent_result.get('model', ''),",
             "        tokens={",
@@ -270,10 +281,12 @@ def _complete_hook(indent: str) -> str:
             "    )",
             "    if _lark_card_sent:",
             "        agent_result['already_sent'] = True",
+            "        _footer_line = ''",
+            "        if agent_result.get('failed'):",
+            "            response = ''",
             "    elif on_message_needs_text_fallback(message_id=_lark_completion_id):",
             "        agent_result.pop('already_sent', None)",
-            "except Exception:",
-            "    pass",
+            *_hook_exception_lines("complete"),
         ],
     )
 
@@ -286,9 +299,15 @@ def _followup_complete_hook(indent: str) -> str:
         [
             "try:",
             "    from hermes_lark_streaming.patch import on_queued_followup_boundary",
-            "    await on_queued_followup_boundary(message_id=event_message_id, result=result)",
-            "except Exception:",
-            "    pass",
+            "    _lark_delivery_result = response if isinstance(response, dict) else result",
+            "    _lark_followup_sent = await on_queued_followup_boundary(",
+            "        message_id=event_message_id, result=_lark_delivery_result",
+            "    )",
+            "    if _lark_followup_sent and _lark_delivery_result is not result:",
+            "        result['response_previewed'] = True",
+            "        result['already_sent'] = True",
+            "        result['final_response'] = ''",
+            *_hook_exception_lines("followup_complete"),
         ],
     )
 
@@ -307,8 +326,7 @@ def _followup_result_hook(indent: str) -> str:
             "            message_id=_lark_followup_completion_id,",
             "            followup_result=followup_result,",
             "        )",
-            "except Exception:",
-            "    pass",
+            *_hook_exception_lines("followup_result"),
         ],
     )
 
@@ -321,16 +339,39 @@ def _tool_hook(indent: str) -> str:
         [
             "try:",
             "    from hermes_lark_streaming.patch import on_tool_updated",
-            "    if _run_still_current() and event_type in ('tool.started', 'tool.completed'):",
+            "    try:",
+            "        _lark_ctx = ctx",
+            "    except NameError:",
+            "        try:",
+            "            _lark_ctx = self._ctx",
+            "        except (NameError, AttributeError):",
+            "            _lark_ctx = None",
+            "    if _lark_ctx is not None:",
+            "        _lark_message_id = _lark_ctx.event_message_id",
+            "        _lark_run_current = _lark_ctx._run_still_current",
+            "    else:",
+            "        _lark_message_id = event_message_id",
+            "        _lark_run_current = _run_still_current",
+            "    if _lark_run_current() and event_type in ('tool.started', 'tool.completed'):",
             "        if on_tool_updated(",
-            "            message_id=event_message_id,",
+            "            message_id=_lark_message_id,",
             "            tool_name=tool_name or '',",
             "            status='started' if event_type == 'tool.started' else 'completed',",
             "            detail=preview or '',",
             "        ):",
+            "            _lark_log_queue = getattr(_lark_ctx, 'log_queue', None) if _lark_ctx is not None else None",
+            "            if _lark_ctx is None:",
+            "                try:",
+            "                    _lark_log_queue = log_queue",
+            "                except NameError:",
+            "                    pass",
+            "            if _lark_log_queue is not None and event_type == 'tool.started' and tool_name != '_thinking':",
+            "                from datetime import datetime as _lark_datetime",
+            "                _lark_timestamp = _lark_datetime.now().strftime('%Y-%m-%d %H:%M:%S')",
+            "                _lark_preview = f' \"{preview}\"' if preview else ''",
+            "                _lark_log_queue.put(f'{_lark_timestamp}  {tool_name}:{_lark_preview}'.rstrip())",
             "            return",
-            "except Exception:",
-            "    pass",
+            *_hook_exception_lines("tool"),
         ],
     )
 
@@ -343,10 +384,27 @@ def _answer_hook(indent: str) -> str:
         [
             "try:",
             "    from hermes_lark_streaming.patch import on_answer_delta",
-            "    if text and _run_still_current() and on_answer_delta(message_id=event_message_id, text=text):",
+            "    try:",
+            "        _lark_message_id = ctx.event_message_id",
+            "        _lark_run_current = ctx._run_still_current",
+            "    except NameError:",
+            "        _lark_message_id = event_message_id",
+            "        _lark_run_current = _run_still_current",
+            "    if text and _lark_run_current() and on_answer_delta(message_id=_lark_message_id, text=text):",
+            "        try:",
+            "            _lark_stts_consumer = _stts_consumer_ref",
+            "        except NameError:",
+            "            _lark_stts_consumer = None",
+            "        if _lark_stts_consumer is not None:",
+            "            try:",
+            "                _lark_stts_consumer.on_delta(text)",
+            "            except Exception:",
+            "                import logging as _lark_logging",
+            "                _lark_logging.getLogger(\"hermes_lark_streaming\").exception(",
+            "                    \"injected hook failed: streaming_tts\"",
+            "                )",
             "        return",
-            "except Exception:",
-            "    pass",
+            *_hook_exception_lines("answer"),
         ],
     )
 
@@ -359,11 +417,16 @@ def _thinking_hook(indent: str) -> str:
         [
             "try:",
             "    from hermes_lark_streaming.patch import on_thinking_delta",
-            "    if (text and not already_streamed and _run_still_current()",
-            "            and on_thinking_delta(message_id=event_message_id, text=text)):",
+            "    try:",
+            "        _lark_message_id = ctx.event_message_id",
+            "        _lark_run_current = ctx._run_still_current",
+            "    except NameError:",
+            "        _lark_message_id = event_message_id",
+            "        _lark_run_current = _run_still_current",
+            "    if (text and not already_streamed and _lark_run_current()",
+            "            and on_thinking_delta(message_id=_lark_message_id, text=text)):",
             "        return",
-            "except Exception:",
-            "    pass",
+            *_hook_exception_lines("thinking"),
         ],
     )
 
@@ -375,12 +438,17 @@ def _reasoning_hook(indent: str) -> str:
         MK_REASONING_END,
         [
             "def _reasoning_cb(text):",
-            "    if text and _run_still_current():",
+            "    try:",
             "        try:",
+            "            _lark_message_id = ctx.event_message_id",
+            "            _lark_run_current = ctx._run_still_current",
+            "        except NameError:",
+            "            _lark_message_id = event_message_id",
+            "            _lark_run_current = _run_still_current",
+            "        if text and _lark_run_current():",
             "            from hermes_lark_streaming.patch import on_reasoning_delta",
-            "            on_reasoning_delta(message_id=event_message_id, text=text)",
-            "        except Exception:",
-            "            pass",
+            "            on_reasoning_delta(message_id=_lark_message_id, text=text)",
+            *_hook_exception_lines("reasoning", indent="    "),
             "agent.reasoning_callback = _reasoning_cb",
         ],
     )
@@ -396,16 +464,19 @@ def _background_review_hook(indent: str) -> str:
             "    from hermes_lark_streaming.patch import on_background_review_message",
             "    _lark_bg_review_sender = agent.background_review_callback",
             "    def _lark_bg_review_callback(message):",
+            "        try:",
+            "            _lark_message_id = ctx.event_message_id",
+            "        except NameError:",
+            "            _lark_message_id = event_message_id",
             "        _lark_bg_review_deferred = on_background_review_message(",
-            "            message_id=event_message_id,",
+            "            message_id=_lark_message_id,",
             "            text=message,",
             "            sender=_lark_bg_review_sender,",
             "        )",
             "        if not _lark_bg_review_deferred:",
             "            _lark_bg_review_sender(message)",
             "    agent.background_review_callback = _lark_bg_review_callback",
-            "except Exception:",
-            "    pass",
+            *_hook_exception_lines("background_review"),
         ],
     )
 
@@ -419,8 +490,24 @@ def _abort_hook(indent: str) -> str:
             "try:",
             "    from hermes_lark_streaming.patch import on_message_aborted",
             "    on_message_aborted(message_id=event.message_id)",
-            "except Exception:",
-            "    pass",
+            *_hook_exception_lines("abort"),
+        ],
+    )
+
+
+def _stop_hook(indent: str) -> str:
+    return _make_hook(
+        indent,
+        MK_STOP,
+        MK_STOP_END,
+        [
+            "try:",
+            "    if source.platform.value.lower() in ('feishu', 'lark'):",
+            "        from hermes_lark_streaming.patch import on_session_aborted",
+            "        await on_session_aborted(",
+            "            session_key=locals().get('quick_key') or locals().get('_quick_key') or '',",
+            "        )",
+            *_hook_exception_lines("stop"),
         ],
     )
 
@@ -444,6 +531,7 @@ def _interrupt_hook(indent: str) -> str:
             "                new_message_id=_lark_next_message_id,",
             "                chat_id=source.chat_id,",
             "                anchor_id=_lark_next_anchor_id,",
+            "                session_key=locals().get('next_session_key') or locals().get('session_key'),",
             "            )",
             "        elif was_interrupted:",
             "            on_message_aborted(message_id=event_message_id)",
@@ -452,9 +540,9 @@ def _interrupt_hook(indent: str) -> str:
             "                message_id=_lark_next_message_id,",
             "                chat_id=getattr(next_source, 'chat_id', source.chat_id),",
             "                anchor_id=_lark_next_anchor_id,",
+            "                session_key=locals().get('next_session_key') or locals().get('session_key'),",
             "            )",
-            "except Exception:",
-            "    pass",
+            *_hook_exception_lines("interrupt"),
         ],
     )
 
@@ -466,7 +554,10 @@ def _cron_deliver_hook(indent: str) -> str:
         MK_CRON_DELIVER_END,
         [
             "try:",
-            "    if platform_name.lower() in ('feishu', 'lark'):",
+            "    if (",
+            "        platform_name.lower() in ('feishu', 'lark')",
+            "        and not getattr(locals().get('transport'), 'is_relay', False)",
+            "    ):",
             "        if '_hermes_lark_cron_seen' not in locals():",
             "            _hermes_lark_cron_seen = set()",
             "        _hermes_lark_cron_key = (str(chat_id), cleaned_delivery_content.strip())",
@@ -484,8 +575,7 @@ def _cron_deliver_hook(indent: str) -> str:
             "            _hermes_lark_cron_seen.add(_hermes_lark_cron_key)",
             "            delivered = True",
             "            continue",
-            "except Exception:",
-            "    pass",
+            *_hook_exception_lines("cron_deliver"),
         ],
     )
 
@@ -509,25 +599,30 @@ def _bg_deliver_hook(indent: str) -> str:
             "            text_content = ''",
             "            if not images and not media_files:",
             "                return",
-            "except Exception:",
-            "    pass",
+            *_hook_exception_lines("background_deliver"),
         ],
     )
 
 
 def _remove_block(content: str, begin: str, end: str) -> str:
     lines = content.splitlines(keepends=True)
-    begin_idx = end_idx = None
-    for i, line in enumerate(lines):
+    result: list[str] = []
+    in_block = False
+    for line in lines:
         stripped = line.strip()
         if stripped == begin:
-            begin_idx = i
+            if in_block:
+                return content
+            in_block = True
+            continue
         if stripped == end:
-            end_idx = i
-            break
-    if begin_idx is not None and end_idx is not None:
-        return "".join(lines[:begin_idx] + lines[end_idx + 1 :])
-    return content
+            if not in_block:
+                return content
+            in_block = False
+            continue
+        if not in_block:
+            result.append(line)
+    return content if in_block else "".join(result)
 
 
 def _atomic_write(path: Path, content: str) -> None:
@@ -552,6 +647,13 @@ class PatcherError(RuntimeError):
     pass
 
 
+def _remove_block_checked(content: str, begin: str, end: str) -> str:
+    updated = _remove_block(content, begin, end)
+    if any(line.strip() in (begin, end) for line in updated.splitlines()):
+        raise PatcherError(f"Malformed injected marker block: {begin}")
+    return updated
+
+
 class Patcher:
     """管理 AST 注入的安装和移除."""
 
@@ -572,7 +674,14 @@ class Patcher:
 
     def is_fully_patched(self) -> bool:
         content = self.run_path.read_text(encoding="utf-8")
-        return all(begin in content and end in content for begin, end in self.MARKERS)
+        tree = ast.parse(content)
+        lines = content.splitlines(keepends=True)
+        answer_sites = _find_func_bodies(tree, lines, "_stream_delta_cb")
+        for begin, end in self.MARKERS:
+            expected = len(answer_sites) if begin == MK_ANSWER else 1
+            if content.count(begin) != expected or content.count(end) != expected:
+                return False
+        return True
 
     def verify_target(self) -> None:
         content = self.run_path.read_text(encoding="utf-8")
@@ -632,9 +741,9 @@ class Patcher:
 
         self.verify_target()
         content = self.run_path.read_text(encoding="utf-8")
-        if self.is_patched():
+        if any(marker in content for pair in self.MARKERS for marker in pair):
             for begin, end in self.MARKERS:
-                content = _remove_block(content, begin, end)
+                content = _remove_block_checked(content, begin, end)
         else:
             self._backup()
         content = self._inject_all(content)
@@ -642,10 +751,10 @@ class Patcher:
 
     def remove(self) -> None:
         content = self.run_path.read_text(encoding="utf-8")
-        if not any(begin in content for begin, _ in self.MARKERS):
+        if not any(marker in content for pair in self.MARKERS for marker in pair):
             return
         for begin, end in self.MARKERS:
-            content = _remove_block(content, begin, end)
+            content = _remove_block_checked(content, begin, end)
         _atomic_write(self.run_path, content)
 
     def restore(self) -> None:
@@ -670,14 +779,18 @@ class Patcher:
             ("followup_complete", "followup_complete", _find_followup_complete_site(tree, lines)),
             ("followup_result", "followup_result", _find_followup_result_site(tree, lines)),
             ("abort", "abort", _find_handler_abort(tree, lines)),
+            ("stop", "stop", _find_stop_site(tree, lines)),
             ("interrupt", "interrupt", _find_interrupt_site(tree, lines)),
             ("tool", "tool", _find_func_body(tree, lines, "progress_callback")),
-            ("answer", "answer", _find_func_body(tree, lines, "_stream_delta_cb")),
             ("thinking", "thinking", _find_func_body(tree, lines, "_interim_assistant_cb")),
             ("reasoning", "reasoning", _find_reasoning_site(tree, lines)),
             ("background_review", "background_review", _find_background_review_site(tree, lines)),
             ("bg_deliver", "bg_deliver", _find_bg_deliver_site(tree, lines)),
         ]
+        hook_defs.extend(
+            ("answer", f"answer callback {index}", loc)
+            for index, loc in enumerate(_find_func_bodies(tree, lines, "_stream_delta_cb"), start=1)
+        )
 
         sites: list[tuple[int, str, str]] = []
         for hook_fn_name, name, loc in hook_defs:
@@ -696,6 +809,7 @@ class Patcher:
             "followup_complete": _followup_complete_hook,
             "followup_result": _followup_result_hook,
             "abort": _abort_hook,
+            "stop": _stop_hook,
             "interrupt": _interrupt_hook,
             "tool": _tool_hook,
             "answer": _answer_hook,
@@ -712,6 +826,12 @@ class Patcher:
 
 
 def _find_func_body(tree: ast.Module, lines: list[str], name: str) -> tuple[int, str] | None:
+    sites = _find_func_bodies(tree, lines, name)
+    return sites[0] if sites else None
+
+
+def _find_func_bodies(tree: ast.Module, lines: list[str], name: str) -> list[tuple[int, str]]:
+    sites: list[tuple[int, str]] = []
     for node in ast.walk(tree):
         if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == name:
             body = node.body
@@ -726,8 +846,8 @@ def _find_func_body(tree: ast.Module, lines: list[str], name: str) -> tuple[int,
             if start < len(body):
                 lineno = body[start].lineno - 1
                 indent = _safe_indent(lines, lineno)
-                return lineno, indent
-    return None
+                sites.append((lineno, indent))
+    return sites
 
 
 def _find_handle_message_source_site(tree: ast.Module, lines: list[str]) -> tuple[int, str] | None:
@@ -782,6 +902,27 @@ def _find_handler_abort(tree: ast.Module, lines: list[str]) -> tuple[int, str] |
                     indent = _safe_indent(lines, j)
                     return j, indent
             break
+    return None
+
+
+def _find_stop_site(tree: ast.Module, lines: list[str]) -> tuple[int, str] | None:
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Expr) or not isinstance(node.value, ast.Await):
+            continue
+        call = node.value.value
+        if not isinstance(call, ast.Call):
+            continue
+        func = call.func
+        if not isinstance(func, ast.Attribute) or func.attr != "_interrupt_and_clear_session":
+            continue
+        is_stop = any(
+            keyword.arg == "invalidation_reason"
+            and isinstance(keyword.value, ast.Constant)
+            and keyword.value.value == "stop_command"
+            for keyword in call.keywords
+        )
+        if is_stop:
+            return node.end_lineno or node.lineno, _safe_indent(lines, node.lineno - 1)
     return None
 
 
@@ -863,11 +1004,17 @@ class CronPatcher:
             raise PatcherError("Cannot find 'cleaned_delivery_content' in scheduler.py")
 
     def apply(self) -> None:
-        if self.is_patched():
-            return
+        content = self.cron_path.read_text(encoding="utf-8")
+        has_markers = MK_CRON_DELIVER in content or MK_CRON_DELIVER_END in content
+        if has_markers:
+            cleaned = _remove_block_checked(content, MK_CRON_DELIVER, MK_CRON_DELIVER_END)
+            if content.count(MK_CRON_DELIVER) == 1 and content.count(MK_CRON_DELIVER_END) == 1:
+                return
+            content = cleaned
         self.verify_target()
-        self._backup()
-        lines = self.cron_path.read_text(encoding="utf-8").splitlines(keepends=True)
+        if not has_markers:
+            self._backup()
+        lines = content.splitlines(keepends=True)
 
         inject_idx = None
         for i, line in enumerate(lines):
@@ -884,9 +1031,9 @@ class CronPatcher:
 
     def remove(self) -> None:
         content = self.cron_path.read_text(encoding="utf-8")
-        if MK_CRON_DELIVER not in content:
+        if MK_CRON_DELIVER not in content and MK_CRON_DELIVER_END not in content:
             return
-        content = _remove_block(content, MK_CRON_DELIVER, MK_CRON_DELIVER_END)
+        content = _remove_block_checked(content, MK_CRON_DELIVER, MK_CRON_DELIVER_END)
         _atomic_write(self.cron_path, content)
 
     def restore(self) -> None:

--- a/hermes_lark_streaming/streaming/session.py
+++ b/hermes_lark_streaming/streaming/session.py
@@ -58,6 +58,7 @@ class CardSession:
         "message_id",
         "segment_state",
         "sequence",
+        "session_key",
         "split_disabled",
         "split_index",
         "state",
@@ -73,6 +74,7 @@ class CardSession:
         self.message_id = message_id
         self.anchor_id: str | None = None
         self.chat_id = chat_id
+        self.session_key: str | None = None
         self.create_task: asyncio.Future[Any] | ConcurrentFuture | None = None
         self.state = SessionState.IDLE
         self.card_msg_id: str | None = None

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -88,7 +88,7 @@ def test_on_interrupted_uses_new_message_id_and_anchor_alias() -> None:
     _enable(ctrl)
 
     with patch.object(ctrl, "_fire_and_forget", side_effect=lambda coro, loop: coro.close()):
-        ctrl.on_message_started(message_id="old", chat_id="chat")
+        ctrl.on_message_started(message_id="old", chat_id="chat", session_key="session:chat")
         ctrl.on_interrupted(
             old_message_id="old",
             new_message_id="new",
@@ -101,6 +101,110 @@ def test_on_interrupted_uses_new_message_id_and_anchor_alias() -> None:
     assert session.anchor_id == "quoted"
     assert ctrl._interrupt_map["old"] == "new"
     assert ctrl._sessions["old"].state == SessionState.ABORTED
+    assert session.session_key == "session:chat"
+    assert ctrl._session_keys["session:chat"] is session
+
+
+@pytest.mark.asyncio
+async def test_on_session_aborted_only_stops_matching_session_key() -> None:
+    ctrl = StreamCardController()
+    _enable(ctrl)
+
+    with patch.object(ctrl, "_fire_and_forget", side_effect=lambda coro, loop: coro.close()):
+        ctrl.on_message_started(
+            message_id="first",
+            chat_id="shared-chat",
+            session_key="session:first",
+        )
+        ctrl.on_message_started(
+            message_id="second",
+            chat_id="shared-chat",
+            session_key="session:second",
+        )
+        with patch.object(ctrl, "_complete_session_wait", new_callable=AsyncMock, return_value=True) as complete:
+            assert await ctrl.on_session_aborted(session_key="session:first") is True
+
+    assert ctrl._sessions["first"].state == SessionState.ABORTED
+    assert ctrl._sessions["second"].state == SessionState.IDLE
+    assert "session:first" not in ctrl._session_keys
+    assert ctrl._session_keys["session:second"] is ctrl._sessions["second"]
+    complete.assert_awaited_once_with(ctrl._sessions["first"])
+
+
+@pytest.mark.asyncio
+async def test_on_session_aborted_waits_for_card_creation() -> None:
+    ctrl = _setup_ctrl()
+    session = CardSession("creating", "chat", asyncio.get_running_loop())
+    session.session_key = "session:creating"
+    ctrl._sessions["creating"] = session
+    ctrl._session_keys["session:creating"] = session
+    ready = asyncio.Event()
+
+    async def finish_create() -> None:
+        session.state = SessionState.CREATING
+        await ready.wait()
+        session.card_id = "card"
+        session.card_msg_id = "card-message"
+
+    session.create_task = asyncio.create_task(finish_create())
+
+    with patch.object(ctrl, "_complete_session_wait", new_callable=AsyncMock, return_value=True) as complete:
+        waiter = asyncio.create_task(ctrl.on_session_aborted(session_key="session:creating"))
+        await asyncio.sleep(0.01)
+        assert not waiter.done()
+        assert session.state == SessionState.ABORTED
+
+        ready.set()
+        assert await waiter is True
+
+    complete.assert_awaited_once_with(session)
+
+
+@pytest.mark.asyncio
+async def test_on_interrupted_waits_for_old_card_creation_before_cleanup() -> None:
+    ctrl = _setup_ctrl()
+    old_session = CardSession("old", "chat", asyncio.get_running_loop())
+    ctrl._sessions["old"] = old_session
+    ready = asyncio.Event()
+    completed: list[str] = []
+    tasks: list[asyncio.Task[object]] = []
+
+    async def finish_create() -> None:
+        old_session.state = SessionState.CREATING
+        await ready.wait()
+        old_session.card_id = "old-card"
+        old_session.card_msg_id = "old-card-message"
+
+    async def complete_card(_session: CardSession) -> bool:
+        completed.append("old")
+        return True
+
+    def schedule(coro: object, _loop: asyncio.AbstractEventLoop) -> asyncio.Task[object]:
+        task = asyncio.create_task(coro)  # type: ignore[arg-type]
+        tasks.append(task)
+        return task
+
+    old_session.create_task = asyncio.create_task(finish_create())
+    with (
+        patch.object(ctrl, "_do_complete_card_inner", side_effect=complete_card),
+        patch.object(ctrl, "_do_create_card", new_callable=AsyncMock),
+        patch.object(ctrl, "_fire_and_forget", side_effect=schedule),
+    ):
+        ctrl.on_interrupted(
+            old_message_id="old",
+            new_message_id="new",
+            chat_id="chat",
+        )
+        await asyncio.sleep(0)
+
+        assert "old" in ctrl._sessions
+        assert completed == []
+
+        ready.set()
+        await asyncio.gather(old_session.create_task, *tasks)
+
+    assert completed == ["old"]
+    assert "old" not in ctrl._sessions
 
 
 def test_prune_stale_sessions_ignores_none_key_and_prunes_valid_key() -> None:
@@ -142,6 +246,49 @@ async def test_background_review_deferred_until_complete() -> None:
 
     assert sent == ["review"]
     assert "msg_bg" not in ctrl._sessions
+
+
+@pytest.mark.asyncio
+async def test_background_review_does_not_interrupt_replacement_card() -> None:
+    ctrl = _setup_ctrl()
+    old_session = CardSession("old", "chat", asyncio.get_running_loop())
+    old_session.state = SessionState.STREAMING
+    old_session.card_id = "old-card"
+    old_session.card_msg_id = "old-card-message"
+    ctrl._sessions["old"] = old_session
+    events: list[str] = []
+    tasks: list[asyncio.Task[object]] = []
+
+    assert ctrl.defer_background_review(
+        message_id="old",
+        text="review",
+        sender=lambda _text: events.append("review_sent"),
+    )
+
+    async def complete_card(_session: CardSession) -> bool:
+        events.append("old_card_completed")
+        return True
+
+    def schedule(coro: object, _loop: asyncio.AbstractEventLoop) -> asyncio.Task[object]:
+        task = asyncio.create_task(coro)  # type: ignore[arg-type]
+        tasks.append(task)
+        return task
+
+    with (
+        patch.object(ctrl, "_do_complete_card_inner", side_effect=complete_card),
+        patch.object(ctrl, "_do_create_card", new_callable=AsyncMock),
+        patch.object(ctrl, "_fire_and_forget", side_effect=schedule),
+    ):
+        ctrl.on_interrupted(
+            old_message_id="old",
+            new_message_id="new",
+            chat_id="chat",
+        )
+        await asyncio.gather(*tasks)
+
+    assert events == ["old_card_completed", "review_sent"]
+    assert "old" not in ctrl._sessions
+    assert ctrl._sessions["new"].deferred_background_reviews == []
 
 
 def test_background_review_without_active_session_not_deferred() -> None:
@@ -259,6 +406,22 @@ class TestAwaitedCompletion:
         assert len(session.segment_state.segments) == 1
         assert session.segment_state.segments[0].type == "answer"
         assert session.segment_state.segments[0].text == "short"
+
+    @pytest.mark.asyncio
+    async def test_agent_failure_finalizes_card_as_error(self) -> None:
+        ctrl = _setup_ctrl()
+        session = CardSession("msg_error", "chat", asyncio.get_running_loop())
+        session.state = SessionState.STREAMING
+        session.card_id = "card_error"
+        session.card_msg_id = "card_msg_error"
+        ctrl._sessions["msg_error"] = session
+
+        with patch.object(ctrl, "_complete_session_wait", new_callable=AsyncMock, return_value=True):
+            assert await ctrl.on_completed_wait(
+                message_id="msg_error", answer="request failed", is_error=True,
+            ) is True
+
+        assert session.state == SessionState.FAILED
 
 
 @pytest.mark.asyncio

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -7,10 +7,12 @@ Usage:
 from __future__ import annotations
 
 import ast
+import logging
 import shutil
 import textwrap
 import urllib.request
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -22,8 +24,13 @@ from hermes_lark_streaming.patcher import (
     CronPatcher,
     Patcher,
     PatcherError,
+    _answer_hook,
+    _complete_hook,
     _cron_deliver_hook,
+    _followup_complete_hook,
     _remove_block,
+    _stop_hook,
+    _tool_hook,
 )
 
 RUN_SRC = Path.home() / ".hermes" / "hermes-agent" / "gateway" / "run.py"
@@ -101,7 +108,7 @@ def _build_cron_hook_runner():
         }
     }
     source = (
-        "def deliver(targets, cleaned_delivery_content, loop):\n"
+        "def deliver(targets, cleaned_delivery_content, loop, transport=None):\n"
         "    fallback = []\n"
         "    for platform_name, chat_id in targets:\n"
         "        delivered = False\n"
@@ -111,6 +118,72 @@ def _build_cron_hook_runner():
     )
     exec(compile(source, "<cron-hook-test>", "exec"), namespace)
     return namespace["deliver"]
+
+
+def _build_answer_hook_runner(*, use_turn_context: bool):
+    namespace: dict = {}
+    signature = "text, ctx" if use_turn_context else "text, event_message_id, _run_still_current"
+    source = (
+        f"def callback({signature}):\n"
+        f"{_answer_hook('    ')}"
+        "    return 'native'\n"
+    )
+    exec(compile(source, "<answer-hook-test>", "exec"), namespace)
+    return namespace["callback"]
+
+
+def _build_complete_hook_runner():
+    namespace: dict = {}
+    source = (
+        "async def complete(agent_result, event, response, _response_time, _footer_line):\n"
+        f"{_complete_hook('    ')}"
+        "    return agent_result, response, _footer_line\n"
+    )
+    exec(compile(source, "<complete-hook-test>", "exec"), namespace)
+    return namespace["complete"]
+
+
+def _build_followup_complete_hook_runner():
+    namespace: dict = {}
+    source = (
+        "async def complete(event_message_id, result, response):\n"
+        f"{_followup_complete_hook('    ')}"
+        "    return result, response\n"
+    )
+    exec(compile(source, "<followup-complete-hook-test>", "exec"), namespace)
+    return namespace["complete"]
+
+
+def _build_stop_hook_runner(key_name: str):
+    namespace: dict = {}
+    source = f"async def stop(source, {key_name}):\n{_stop_hook('    ')}"
+    exec(compile(source, "<stop-hook-test>", "exec"), namespace)
+    return namespace["stop"]
+
+
+def _build_tool_hook_runner(*, use_turn_context: bool):
+    namespace: dict = {}
+    if use_turn_context:
+        source = (
+            "class Callbacks:\n"
+            "    def __init__(self, ctx):\n"
+            "        self._ctx = ctx\n"
+            "    def callback(self, event_type, tool_name=None, preview=None):\n"
+            f"{_tool_hook('        ')}"
+            "        ctx = self._ctx\n"
+            "        return 'native'\n"
+        )
+        exec(compile(source, "<tool-hook-test>", "exec"), namespace)
+        return lambda ctx: namespace["Callbacks"](ctx).callback
+
+    source = (
+        "def callback(event_type, event_message_id, _run_still_current, "
+        "tool_name=None, preview=None):\n"
+        f"{_tool_hook('    ')}"
+        "    return 'native'\n"
+    )
+    exec(compile(source, "<tool-hook-test>", "exec"), namespace)
+    return lambda _ctx: namespace["callback"]
 
 
 class TestVerify:
@@ -211,14 +284,260 @@ class TestVerify:
             _patcher(p).verify_target()
 
 
+class TestGeneratedAnswerHook:
+    def test_patch_hook_requires_message_id(self) -> None:
+        from hermes_lark_streaming.patch import on_answer_delta
+
+        with pytest.raises(TypeError):
+            on_answer_delta(text="delta")  # type: ignore[call-arg]
+
+    def test_consumed_delta_still_reaches_streaming_tts(self) -> None:
+        namespace: dict = {}
+        source = (
+            "def callback(text, ctx, _stts_consumer_ref):\n"
+            f"{_answer_hook('    ')}"
+            "    _stts_consumer_ref.on_delta(text)\n"
+        )
+        exec(compile(source, "<answer-hook-tts-test>", "exec"), namespace)
+        ctx = MagicMock()
+        ctx.event_message_id = "modern-message"
+        ctx._run_still_current.return_value = True
+        streaming_tts = MagicMock()
+
+        with patch("hermes_lark_streaming.patch.on_answer_delta", return_value=True):
+            namespace["callback"]("delta", ctx, streaming_tts)
+
+        streaming_tts.on_delta.assert_called_once_with("delta")
+
+    def test_turn_context_scope_consumes_delta(self) -> None:
+        callback = _build_answer_hook_runner(use_turn_context=True)
+        ctx = MagicMock()
+        ctx.event_message_id = "modern-message"
+        ctx._run_still_current.return_value = True
+
+        with patch(
+            "hermes_lark_streaming.patch.on_answer_delta",
+            return_value=True,
+        ) as on_answer_delta:
+            result = callback("delta", ctx)
+
+        assert result is None
+        on_answer_delta.assert_called_once_with(message_id="modern-message", text="delta")
+
+    def test_legacy_scope_consumes_delta(self) -> None:
+        callback = _build_answer_hook_runner(use_turn_context=False)
+        run_still_current = MagicMock(return_value=True)
+
+        with patch(
+            "hermes_lark_streaming.patch.on_answer_delta",
+            return_value=True,
+        ) as on_answer_delta:
+            result = callback("delta", "legacy-message", run_still_current)
+
+        assert result is None
+        on_answer_delta.assert_called_once_with(message_id="legacy-message", text="delta")
+
+    def test_unconsumed_delta_falls_through_to_native_stream(self) -> None:
+        callback = _build_answer_hook_runner(use_turn_context=True)
+        ctx = MagicMock()
+        ctx.event_message_id = "modern-message"
+        ctx._run_still_current.return_value = True
+
+        with patch("hermes_lark_streaming.patch.on_answer_delta", return_value=False):
+            result = callback("delta", ctx)
+
+        assert result == "native"
+
+
+class TestGeneratedToolHook:
+    def test_turn_callbacks_scope_consumes_tool_event_before_ctx_binding(self) -> None:
+        ctx = MagicMock()
+        ctx.event_message_id = "modern-message"
+        ctx._run_still_current.return_value = True
+        ctx.log_queue = None
+        callback = _build_tool_hook_runner(use_turn_context=True)(ctx)
+
+        with patch(
+            "hermes_lark_streaming.patch.on_tool_updated",
+            return_value=True,
+        ) as on_tool_updated:
+            result = callback("tool.started", tool_name="search", preview="query")
+
+        assert result is None
+        on_tool_updated.assert_called_once_with(
+            message_id="modern-message",
+            tool_name="search",
+            status="started",
+            detail="query",
+        )
+
+    def test_consumed_tool_event_preserves_log_mode(self) -> None:
+        ctx = MagicMock()
+        ctx.event_message_id = "modern-message"
+        ctx._run_still_current.return_value = True
+        ctx.log_queue = MagicMock()
+        callback = _build_tool_hook_runner(use_turn_context=True)(ctx)
+
+        with patch("hermes_lark_streaming.patch.on_tool_updated", return_value=True):
+            result = callback("tool.started", tool_name="search", preview="query")
+
+        assert result is None
+        logged = ctx.log_queue.put.call_args.args[0]
+        assert logged.endswith('  search: "query"')
+
+    def test_legacy_scope_consumes_tool_event(self) -> None:
+        callback = _build_tool_hook_runner(use_turn_context=False)(None)
+        run_still_current = MagicMock(return_value=True)
+
+        with patch(
+            "hermes_lark_streaming.patch.on_tool_updated",
+            return_value=True,
+        ) as on_tool_updated:
+            result = callback(
+                "tool.completed",
+                "legacy-message",
+                run_still_current,
+                tool_name="search",
+                preview="done",
+            )
+
+        assert result is None
+        on_tool_updated.assert_called_once_with(
+            message_id="legacy-message",
+            tool_name="search",
+            status="completed",
+            detail="done",
+        )
+
+    def test_exception_is_logged_before_native_fallback(self, caplog: pytest.LogCaptureFixture) -> None:
+        ctx = MagicMock()
+        ctx.event_message_id = "modern-message"
+        ctx._run_still_current.return_value = True
+        ctx.log_queue = None
+        callback = _build_tool_hook_runner(use_turn_context=True)(ctx)
+
+        with (
+            caplog.at_level(logging.ERROR, logger="hermes_lark_streaming"),
+            patch(
+                "hermes_lark_streaming.patch.on_tool_updated",
+                side_effect=RuntimeError("tool hook exploded"),
+            ),
+        ):
+            result = callback("tool.started", tool_name="search")
+
+        assert result == "native"
+        record = next(record for record in caplog.records if "injected hook failed: tool" in record.message)
+        assert record.exc_info is not None
+
+
+@pytest.mark.parametrize("key_name", ["quick_key", "_quick_key"])
+@pytest.mark.asyncio
+async def test_generated_stop_hook_uses_available_session_key(key_name: str) -> None:
+    stop = _build_stop_hook_runner(key_name)
+    source = SimpleNamespace(platform=SimpleNamespace(value="feishu"))
+
+    with patch(
+        "hermes_lark_streaming.patch.on_session_aborted",
+        new_callable=AsyncMock,
+    ) as on_session_aborted:
+        await stop(source, "session:chat")
+
+    on_session_aborted.assert_awaited_once_with(session_key="session:chat")
+
+
+@pytest.mark.asyncio
+async def test_generated_complete_hook_keeps_footer_in_card_without_native_resend() -> None:
+    complete = _build_complete_hook_runner()
+    agent_result: dict = {}
+    event = SimpleNamespace(message_id="message")
+
+    with (
+        patch(
+            "hermes_lark_streaming.patch.on_message_completed_wait",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as on_completed,
+        patch("hermes_lark_streaming.patch.on_message_needs_text_fallback", return_value=False),
+    ):
+        result, response, footer = await complete(
+            agent_result,
+            event,
+            "answer\n\nruntime footer",
+            1.0,
+            "runtime footer",
+        )
+
+    assert on_completed.await_args.kwargs["answer"] == "answer\n\nruntime footer"
+    assert result["already_sent"] is True
+    assert response == "answer\n\nruntime footer"
+    assert footer == ""
+
+
+@pytest.mark.asyncio
+async def test_generated_complete_hook_suppresses_native_error_after_error_card() -> None:
+    complete = _build_complete_hook_runner()
+    agent_result = {"failed": True}
+    event = SimpleNamespace(message_id="message")
+
+    with (
+        patch(
+            "hermes_lark_streaming.patch.on_message_completed_wait",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as on_completed,
+        patch("hermes_lark_streaming.patch.on_message_needs_text_fallback", return_value=False),
+    ):
+        result, response, _footer = await complete(
+            agent_result, event, "request failed", 1.0, "",
+        )
+
+    assert on_completed.await_args.kwargs["is_error"] is True
+    assert result["failed"] is True
+    assert response == ""
+
+
+@pytest.mark.asyncio
+async def test_generated_followup_hook_handles_distinct_delivery_result() -> None:
+    complete = _build_followup_complete_hook_runner()
+    raw_result = {"final_response": "raw answer"}
+    delivery_result = {"final_response": "normalized answer"}
+
+    with patch("hermes_lark_streaming.patch.get_controller") as mock_get:
+        ctrl = MagicMock()
+        ctrl.enabled = True
+        ctrl.on_completed_wait = AsyncMock(return_value=True)
+        mock_get.return_value = ctrl
+        raw_result, delivery_result = await complete("message", raw_result, delivery_result)
+
+    assert ctrl.on_completed_wait.await_args.kwargs["answer"] == "normalized answer"
+    assert raw_result["final_response"] == ""
+    assert delivery_result["final_response"] == ""
+
+
 class TestApplyRemove:
     def test_apply_injects_all_markers(self, run_copy: Path) -> None:
+        original = run_copy.read_text(encoding="utf-8")
+        expected_answer_hooks = sum(
+            isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == "_stream_delta_cb"
+            for node in ast.walk(ast.parse(original))
+        )
         patcher = _patcher(run_copy)
         patcher.apply()
         content = run_copy.read_text(encoding="utf-8")
         for begin, end in MARKERS:
             assert begin in content, f"Missing marker: {begin}"
             assert end in content, f"Missing marker: {end}"
+        assert content.count("# HERMES_LARK_ANSWER_BEGIN") == expected_answer_hooks
+        assert content.count("# HERMES_LARK_ANSWER_END") == expected_answer_hooks
+
+        for begin, end in MARKERS:
+            search_from = 0
+            while (block_start := content.find(begin, search_from)) != -1:
+                block_end = content.index(end, block_start)
+                block = content[block_start:block_end]
+                assert "injected hook failed:" in block, f"Missing exception log in {begin}"
+                assert "except Exception:\n" not in block or "\n    pass" not in block
+                search_from = block_end + len(end)
 
     def test_apply_produces_valid_python(self, run_copy: Path) -> None:
         patcher = _patcher(run_copy)
@@ -238,12 +557,15 @@ class TestApplyRemove:
         assert "_lark_anchor_id = self._reply_anchor_for_event(event)" in content
         assert "message_id=event.message_id" in content
         assert "anchor_id=_lark_anchor_id" in content
+        assert "session_key=locals().get('session_key') or locals().get('_quick_key')" in content
         assert "_lark_next_message_id = getattr(pending_event, 'message_id', None) or next_message_id" in content
         assert "new_message_id=_lark_next_message_id" in content
         assert "anchor_id=_lark_next_anchor_id" in content
+        assert "session_key=locals().get('next_session_key') or locals().get('session_key')" in content
         assert "# HERMES_LARK_FOLLOWUP_COMPLETE_BEGIN" in content
         assert "message_id=event_message_id" in content
-        assert "on_queued_followup_boundary(message_id=event_message_id, result=result)" in content
+        assert "_lark_delivery_result = response if isinstance(response, dict) else result" in content
+        assert "message_id=event_message_id, result=_lark_delivery_result" in content
         assert "# HERMES_LARK_FOLLOWUP_RESULT_BEGIN" in content
         assert "on_queued_followup_result(" in content
         assert "on_message_completed_wait(" in content
@@ -252,14 +574,23 @@ class TestApplyRemove:
         assert "agent_result.pop('already_sent', None)" in content
         assert "_lark_completion_id = agent_result.get('_hermes_lark_completion_id') or event.message_id" in content
         assert "message_id=_lark_completion_id" in content
-        assert "on_answer_delta(message_id=event_message_id" in content
-        assert "on_thinking_delta(message_id=event_message_id" in content
-        assert "on_reasoning_delta(message_id=event_message_id" in content
+        assert "_lark_message_id = ctx.event_message_id" in content
+        assert "_lark_run_current = ctx._run_still_current" in content
+        assert "on_answer_delta(message_id=_lark_message_id" in content
+        assert "on_thinking_delta(message_id=_lark_message_id" in content
+        assert "on_reasoning_delta(message_id=_lark_message_id" in content
         assert "on_background_deliver(" in content
         assert "_bg_preview = prompt[:60] + ('...' if len(prompt) > 60 else '')" in content
         assert "content=text_content" in content
         assert "reply_to_message_id=event_message_id" in content
         assert "if not images and not media_files:" in content
+
+        stop_call = content.index('invalidation_reason="stop_command"')
+        stop_hook = content.index("# HERMES_LARK_STOP_BEGIN", stop_call)
+        stop_return = content.index("return EphemeralReply", stop_call)
+        assert stop_call < stop_hook < stop_return
+        assert "on_session_aborted" in content[stop_hook:stop_return]
+        assert "await on_session_aborted" in content[stop_hook:stop_return]
 
     def test_apply_idempotent(self, run_copy: Path) -> None:
         patcher = _patcher(run_copy)
@@ -318,6 +649,24 @@ class TestApplyRemove:
             patcher.apply()
             patcher.remove()
         assert run_copy.read_text(encoding="utf-8") == original
+
+    def test_remove_block_leaves_malformed_marker_order_unchanged(self) -> None:
+        begin, end = MARKERS[0]
+        content = f"before\n{end}\nmiddle\n{begin}\nafter\n"
+
+        assert _remove_block(content, begin, end) == content
+
+    def test_apply_rejects_malformed_existing_markers(self, run_copy: Path) -> None:
+        patcher = _patcher(run_copy)
+        patcher.apply()
+        _, answer_end = next(pair for pair in MARKERS if "ANSWER" in pair[0])
+        malformed = run_copy.read_text(encoding="utf-8").replace(answer_end, "", 1)
+        run_copy.write_text(malformed, encoding="utf-8")
+
+        with pytest.raises(PatcherError, match="Malformed injected marker"):
+            patcher.apply()
+
+        assert run_copy.read_text(encoding="utf-8") == malformed
 
 
 class TestBackupRestore:
@@ -381,6 +730,22 @@ class TestCronApplyRemove:
         cp.apply()
         assert scheduler_copy.read_text(encoding="utf-8") == first
 
+    def test_apply_normalizes_duplicate_marker_blocks(self, scheduler_copy: Path) -> None:
+        cp = _cron_patcher(scheduler_copy)
+        cp.apply()
+        content = scheduler_copy.read_text(encoding="utf-8")
+        begin = content.index(MK_CRON_DELIVER)
+        end = content.index(MK_CRON_DELIVER_END, begin) + len(MK_CRON_DELIVER_END)
+        end = content.find("\n", end) + 1
+        block = content[begin:end]
+        scheduler_copy.write_text(content[:begin] + block + block + content[end:], encoding="utf-8")
+
+        cp.apply()
+
+        normalized = scheduler_copy.read_text(encoding="utf-8")
+        assert normalized.count(MK_CRON_DELIVER) == 1
+        assert normalized.count(MK_CRON_DELIVER_END) == 1
+
     def test_remove_restores_original(self, scheduler_copy: Path) -> None:
         cp = _cron_patcher(scheduler_copy)
         original = scheduler_copy.read_text(encoding="utf-8")
@@ -400,6 +765,8 @@ class TestCronApplyRemove:
         content = scheduler_copy.read_text(encoding="utf-8")
         assert "on_cron_deliver" in content
         assert "platform_name.lower()" in content
+        assert "is_relay" in content
+        assert "injected hook failed: cron_deliver" in content
         assert "delivered = True" in content
 
     def test_injected_hook_skips_duplicate_card_target(self) -> None:
@@ -440,6 +807,17 @@ class TestCronApplyRemove:
 
         assert mock_deliver.call_count == 2
         assert fallback == ["oc_same"]
+
+    def test_injected_hook_skips_relay_transport(self) -> None:
+        deliver = _build_cron_hook_runner()
+        transport = MagicMock()
+        transport.is_relay = True
+
+        with patch("hermes_lark_streaming.patch.on_cron_deliver") as mock_deliver:
+            fallback = deliver([("feishu", "oc_relay")], "report", None, transport=transport)
+
+        assert fallback == ["oc_relay"]
+        mock_deliver.assert_not_called()
 
 
 class TestCronBackupRestore:
@@ -514,6 +892,7 @@ class TestQueuedFollowupHooks:
 
             assert result["response_previewed"] is True
             assert result["already_sent"] is True
+            assert result["final_response"] == ""
 
     @pytest.mark.asyncio
     async def test_boundary_consumes_fallback_when_card_not_sent(self) -> None:


### PR DESCRIPTION
## Problem

Hermes 0.19 and the post-0.19 runtime moved message execution into `TurnRunner`, `TurnContext`, and `TurnCallbacks`. The existing AST markers could still be injected, but several hooks referenced legacy closure variables that were no longer in scope. Those failures were swallowed by injected `except Exception: pass` blocks, so CardKit streaming silently stopped and Hermes fell back to native Feishu messages.

The new control flow also introduced multiple `_stream_delta_cb` functions and side effects after the old hook return points. Consuming answer or tool events too early skipped streaming TTS and `tool_progress: log`, while completion, runtime footer, error, and queued follow-up paths could deliver duplicate native content after a card had already been finalized. Busy-session `/stop` no longer exposed a message ID, so the active card could remain streaming after Hermes stopped the run.

## Solution

Adapt generated hooks to both the legacy closure layout and the new TurnRunner context layout, preserving native non-delivery side effects when CardKit consumes an event. Active cards are additionally indexed by Hermes `session_key`, allowing `/stop` and interrupt transitions to terminate the exact session even when no message ID is available.

All injected hook failures now log the hook name and traceback before falling through to the native delivery path. Marker handling validates ordering, completeness, and expected callback counts before modifying source, preventing malformed or partial installations from truncating upstream files.

## Changes

- Resolve answer, thinking, reasoning, tool, and background-review state from `TurnContext` / `TurnCallbacks` with legacy closure fallback.
- Inject answer hooks into every `_stream_delta_cb` and preserve streaming TTS and tool log side effects before suppressing native delivery.
- Track `session_key -> CardSession` and add an async `/stop` hook that waits for in-flight card creation before finalizing the aborted card.
- Carry session identity through interrupts and avoid orphaned cards when interruption races CardKit creation.
- Finalize failed runs as error cards and suppress duplicate native error text, runtime footer, and normalized queued follow-up responses after successful card delivery.
- Let cron relay transports use the upstream delivery path and retain standalone CardKit interception for direct Feishu/Lark targets.
- Replace silent injected exceptions with named traceback logging.
- Reject malformed gateway/cron marker blocks, normalize duplicate cron blocks, and verify the exact number of answer markers.
- Add controller race tests and executable generated-hook coverage for modern and legacy upstream layouts.

## Compatibility

Validated patch apply, Python compilation, marker counts, removal, and byte-for-byte source restoration against:

- Hermes 0.14.0 (declared minimum)
- Hermes 0.18.0
- Hermes 0.19.0
- local post-0.19 upstream runtime

## Testing

- 453 tests passed
- Ruff clean
- mypy clean across 22 source files
- live gateway reinstall completed with Feishu WebSocket connected and no hook/CardKit traceback after startup