### PR TITLE
fix: support standalone cron card delivery

### DIFF
--- a/hermes_lark_streaming/controller.py
+++ b/hermes_lark_streaming/controller.py
@@ -34,7 +34,7 @@ class StreamCardController(StreamingController):
         self._session_keys: dict[str, CardSession] = {}
         self._interrupt_map: dict[str, str] = {}
         self._initialized = False
-        self._init_lock = asyncio.Lock()
+        self._init_lock = threading.Lock()
         self._session_ttl = self._cfg.card_duration_sec
         self._loop: asyncio.AbstractEventLoop | None = None
         self._text_fallback_needed: set[str] = set()
@@ -47,7 +47,7 @@ class StreamCardController(StreamingController):
     async def _ensure_init(self) -> None:
         if self._initialized:
             return
-        async with self._init_lock:
+        with self._init_lock:
             if self._initialized:
                 return
             app_id = self._cfg.feishu_app_id or self._cfg.env_app_id
@@ -370,18 +370,26 @@ class StreamCardController(StreamingController):
         *,
         chat_id: str,
         content: str,
-        loop: asyncio.AbstractEventLoop,
+        loop: asyncio.AbstractEventLoop | None,
         task_name: str = "",
         run_time: str = "",
     ) -> bool:
         """Cron 推送 — 包装为静态卡片发送，成功返回 True."""
         if not self.enabled or not content or not chat_id:
             return False
-        future = asyncio.run_coroutine_threadsafe(
-            self._do_cron_deliver(chat_id, content, task_name=task_name, run_time=run_time), loop
+        coroutine = self._do_cron_deliver(
+            chat_id, content, task_name=task_name, run_time=run_time
         )
         try:
-            future.result(timeout=30)
+            if loop is not None and loop.is_running() and not loop.is_closed():
+                try:
+                    future = asyncio.run_coroutine_threadsafe(coroutine, loop)
+                except Exception:
+                    coroutine.close()
+                    raise
+                future.result(timeout=30)
+            else:
+                asyncio.run(coroutine)
             _logger.info("cron card delivered: chat=%s len=%d", chat_id[:12], len(content))
             return True
         except Exception:

--- a/hermes_lark_streaming/patch.py
+++ b/hermes_lark_streaming/patch.py
@@ -299,8 +299,6 @@ def on_cron_deliver(
     run_time: str = "",
 ) -> bool:
     """[注入点 10] cron 推送 — 包装为飞书卡片发送."""
-    if loop is None:
-        return False
     try:
         ctrl = get_controller()
         if not ctrl.enabled:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1419,6 +1420,93 @@ class TestCronDeliver:
             assert "hello" in card["body"]["elements"][0]["content"]
         finally:
             loop.call_soon_threadsafe(loop.stop)
+
+    def test_sends_card_without_gateway_loop(self) -> None:
+        ctrl = StreamCardController()
+        ctrl._cfg = MagicMock()
+        ctrl._cfg.enabled = True
+        ctrl._cfg.feishu_app_id = "app_id"
+        ctrl._cfg.feishu_app_secret = "app_secret"
+        ctrl._cfg.env_app_id = ""
+        ctrl._cfg.env_app_secret = ""
+
+        mock_client = AsyncMock()
+        mock_client.send_card_to_chat.return_value = "msg_123"
+        with patch("hermes_lark_streaming.controller.FeishuClient", return_value=mock_client):
+            result = ctrl.on_cron_deliver(chat_id="c1", content="hello", loop=None)
+
+        assert result is True
+        assert ctrl._initialized is True
+        mock_client.send_card_to_chat.assert_called_once()
+
+    def test_initializes_once_across_standalone_workers(self) -> None:
+        ctrl = StreamCardController()
+        ctrl._cfg = MagicMock()
+        ctrl._cfg.feishu_app_id = "app_id"
+        ctrl._cfg.feishu_app_secret = "app_secret"
+        ctrl._cfg.env_app_id = ""
+        ctrl._cfg.env_app_secret = ""
+        constructor_entered = threading.Event()
+        release_constructor = threading.Event()
+        errors: list[BaseException] = []
+        mock_client = AsyncMock()
+
+        def slow_client(*args: object, **kwargs: object) -> AsyncMock:
+            constructor_entered.set()
+            assert release_constructor.wait(timeout=1)
+            return mock_client
+
+        def initialize() -> None:
+            try:
+                asyncio.run(ctrl._ensure_init())
+            except BaseException as exc:
+                errors.append(exc)
+
+        with patch("hermes_lark_streaming.controller.FeishuClient", side_effect=slow_client) as cls:
+            first = threading.Thread(target=initialize)
+            second = threading.Thread(target=initialize)
+            first.start()
+            assert constructor_entered.wait(timeout=1)
+            second.start()
+            release_constructor.set()
+            first.join(timeout=1)
+            second.join(timeout=1)
+
+        assert not first.is_alive()
+        assert not second.is_alive()
+        assert errors == []
+        cls.assert_called_once()
+
+    def test_returns_false_on_standalone_send_failure(self) -> None:
+        ctrl = StreamCardController()
+        ctrl._cfg = MagicMock()
+        ctrl._cfg.enabled = True
+        mock_client = AsyncMock()
+        mock_client.send_card_to_chat.side_effect = RuntimeError("API error")
+        ctrl._client = mock_client
+        ctrl._initialized = True
+
+        assert ctrl.on_cron_deliver(chat_id="c1", content="hello", loop=None) is False
+
+    @pytest.mark.parametrize("closed", [False, True])
+    def test_falls_back_when_gateway_loop_is_unusable(self, closed: bool) -> None:
+        ctrl = StreamCardController()
+        ctrl._cfg = MagicMock()
+        ctrl._cfg.enabled = True
+        mock_client = AsyncMock()
+        mock_client.send_card_to_chat.return_value = "msg_123"
+        ctrl._client = mock_client
+        ctrl._initialized = True
+
+        loop = asyncio.new_event_loop()
+        if closed:
+            loop.close()
+        try:
+            assert ctrl.on_cron_deliver(chat_id="c1", content="hello", loop=loop) is True
+            mock_client.send_card_to_chat.assert_called_once()
+        finally:
+            if not loop.is_closed():
+                loop.close()
 
     def test_returns_false_on_send_failure(self) -> None:
         import threading

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -850,14 +850,19 @@ class TestOnCronDeliverHook:
             mock_get.return_value = ctrl
             assert on_cron_deliver(chat_id="c1", content="text", loop=MagicMock()) is False
 
-    def test_returns_false_when_no_loop(self) -> None:
+    def test_delegates_to_controller_when_no_loop(self) -> None:
         from hermes_lark_streaming.patch import on_cron_deliver
 
         with patch("hermes_lark_streaming.patch.get_controller") as mock_get:
             ctrl = MagicMock()
             ctrl.enabled = True
+            ctrl.on_cron_deliver.return_value = True
             mock_get.return_value = ctrl
-            assert on_cron_deliver(chat_id="c1", content="text", loop=None) is False
+            assert on_cron_deliver(chat_id="c1", content="text", loop=None) is True
+            ctrl.on_cron_deliver.assert_called_once_with(
+                chat_id="c1", content="text", loop=None,
+                task_name="", run_time="",
+            )
 
     def test_delegates_to_controller(self) -> None:
         from hermes_lark_streaming.patch import on_cron_deliver


### PR DESCRIPTION
Closes #86

## Problem

Hermes Desktop and Chronos invoke the shared cron delivery path without a gateway event loop. The injected hook returned `False` immediately when `loop=None`, so valid Feishu/Lark cron targets silently fell through to Hermes's plain-text standalone delivery.

Local post-0.19 Hermes also runs due jobs in a parallel `ThreadPoolExecutor`. A standalone fallback therefore needs to support separate worker-thread event loops without sharing loop-bound initialization state.

## Solution

Always delegate eligible cron deliveries to `StreamCardController`. The controller keeps `run_coroutine_threadsafe()` for a live gateway loop and runs the existing `_do_cron_deliver()` coroutine with `asyncio.run()` when the loop is missing, stopped, or closed. Failures still return `False`, preserving Hermes's native plain-text fallback.

Replace the controller's `asyncio.Lock` initialization guard with `threading.Lock`. Client construction is synchronous, and the thread lock prevents parallel standalone workers from waiting on one `asyncio.Lock` across different event loops.

## Changes

- Remove the hook-level `loop=None` rejection.
- Add standalone delivery for missing or unusable gateway loops.
- Preserve the existing live-loop delivery path and 30-second result timeout.
- Keep relay transports on Hermes's upstream delivery path.
- Make one-time Feishu client initialization safe across cron worker threads.
- Add hook, live-loop, standalone, unusable-loop, failure, and concurrent initialization coverage.

## Upstream Compatibility

Validated against the local post-0.19 Hermes source:

- Desktop starts the cron provider without adapters or a loop.
- Chronos calls `fire_due(..., adapters=None, loop=None)` from a worker thread.
- Gateway passes its running loop while cron execution remains in scheduler worker threads.
- Hermes's native standalone sender also uses `asyncio.run()` when no live adapter loop is available.

## Testing

- `12 passed` for `TestCronDeliver` and `TestOnCronDeliverHook`
- Ruff clean for the changed controller and tests
- mypy clean for `hermes_lark_streaming/controller.py`
- local Hermes gateway and cron targets pass `hermes_lark_streaming verify`
- `git diff --check` clean