### PR TITLE
fix: isolate streaming controllers by profile

### DIFF
--- a/hermes_lark_streaming/config.py
+++ b/hermes_lark_streaming/config.py
@@ -9,22 +9,36 @@ from typing import Any
 import yaml
 
 DEFAULT_DOMAIN = "https://open.feishu.cn"  # SDK 根域名，Larksuite 用 https://open.larksuite.com
+LARK_DOMAIN = "https://open.larksuite.com"
 
 
 def hermes_home() -> Path:
     """Hermes 主目录，优先级 HERMES_HOME 环境变量 → ~/.hermes."""
-    return Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
+    try:
+        from hermes_constants import get_hermes_home  # type: ignore[import-not-found]
+    except ImportError:
+        return Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
+    return Path(get_hermes_home())
 
 
-def _config_path() -> Path:
-    """Hermes 主配置路径，惰性计算以响应运行时 HERMES_HOME 变化."""
-    return hermes_home() / "config.yaml"
+def _get_secret(name: str) -> str:
+    try:
+        from agent.secret_scope import get_secret  # type: ignore[import-not-found]
+    except ImportError:
+        return os.environ.get(name, "")
+    return get_secret(name, "") or ""
+
+
+def _config_path(home: Path | None = None) -> Path:
+    """Hermes 主配置路径，支持绑定到指定 profile home."""
+    return (home or hermes_home()) / "config.yaml"
 
 
 class Config:
     """插件配置，惰性读取 Hermes 主配置."""
 
-    def __init__(self) -> None:
+    def __init__(self, home: Path | None = None) -> None:
+        self._home = Path(home) if home is not None else None
         self._raw: dict[str, Any] | None = None
 
     @property
@@ -138,11 +152,11 @@ class Config:
 
     @property
     def env_app_id(self) -> str:
-        return os.environ.get("FEISHU_APP_ID") or os.environ.get("LARK_APP_ID") or ""
+        return _get_secret("FEISHU_APP_ID") or _get_secret("LARK_APP_ID")
 
     @property
     def env_app_secret(self) -> str:
-        return os.environ.get("FEISHU_APP_SECRET") or os.environ.get("LARK_APP_SECRET") or ""
+        return _get_secret("FEISHU_APP_SECRET") or _get_secret("LARK_APP_SECRET")
 
     def _streaming_sec(self) -> dict[str, Any]:
         raw = self._load()
@@ -157,22 +171,43 @@ class Config:
             return {
                 "app_id": self.env_app_id,
                 "app_secret": self.env_app_secret,
-                "base_url": os.environ.get(
-                    "FEISHU_BASE_URL",
-                    os.environ.get("LARK_BASE_URL", DEFAULT_DOMAIN),
-                ),
+                "base_url": _get_secret("FEISHU_BASE_URL") or _get_secret("LARK_BASE_URL") or DEFAULT_DOMAIN,
             }
         raw = self._load()
         for key in ("feishu", "lark"):
             pf = raw.get(key)
             if isinstance(pf, dict) and pf.get("app_id"):
                 return pf
+        gateway = raw.get("gateway")
+        candidate_parents: list[dict[str, Any]] = []
+        if isinstance(gateway, dict) and isinstance(gateway.get("platforms"), dict):
+            candidate_parents.append(gateway["platforms"])
+        platforms = raw.get("platforms")
+        if isinstance(platforms, dict):
+            candidate_parents.append(platforms)
+        for parent in candidate_parents:
+            for key in ("feishu", "lark"):
+                platform = parent.get(key)
+                if not isinstance(platform, dict):
+                    continue
+                extra = platform.get("extra")
+                if not isinstance(extra, dict) or not extra.get("app_id"):
+                    continue
+                result = dict(extra)
+                if "base_url" in platform and "base_url" not in result:
+                    result["base_url"] = platform["base_url"]
+                if (
+                    "base_url" not in result
+                    and str(extra.get("domain", platform.get("domain", ""))).lower() == "lark"
+                ):
+                    result["base_url"] = LARK_DOMAIN
+                return result
         return {}
 
     def _load(self) -> dict[str, Any]:
         if self._raw is not None:
             return self._raw
-        path = _config_path()
+        path = _config_path(self._home)
         if path.exists():
             text = path.read_text(encoding="utf-8")
             self._raw = yaml.safe_load(text) or {}
@@ -182,7 +217,7 @@ class Config:
 
     def _reload(self) -> dict[str, Any]:
         """从磁盘重新读取配置（不更新缓存），供运行时可变的配置项使用."""
-        path = _config_path()
+        path = _config_path(self._home)
         if path.exists():
             text = path.read_text(encoding="utf-8")
             return yaml.safe_load(text) or {}

--- a/hermes_lark_streaming/controller.py
+++ b/hermes_lark_streaming/controller.py
@@ -6,11 +6,13 @@ import asyncio
 import logging
 import threading
 import time
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable, Coroutine, Iterator
 from concurrent.futures import Future as ConcurrentFuture
+from contextlib import contextmanager
+from pathlib import Path
 from typing import Any
 
-from .config import Config
+from .config import Config, hermes_home
 from .feishu import (
     FeishuClient,
     FeishuClientConfig,
@@ -27,8 +29,9 @@ _CARD_CREATION_WAIT_SEC = 10.0
 class StreamCardController(StreamingController):
     """流式卡片控制器 — 管理多条消息的卡片生命周期."""
 
-    def __init__(self) -> None:
-        self._cfg = Config()
+    def __init__(self, profile_home: Path | None = None) -> None:
+        self._profile_home = (profile_home or hermes_home()).resolve()
+        self._cfg = Config(self._profile_home)
         self._client: FeishuClient | None = None
         self._sessions: dict[str, CardSession] = {}
         self._session_keys: dict[str, CardSession] = {}
@@ -39,10 +42,48 @@ class StreamCardController(StreamingController):
         self._loop: asyncio.AbstractEventLoop | None = None
         self._text_fallback_needed: set[str] = set()
         self._text_fallback_aliases: dict[str, set[str]] = {}
+        self._unscoped_enabled: bool | None = None
 
     @property
     def enabled(self) -> bool:
-        return self._cfg.enabled and bool(self._cfg.feishu_app_id or self._cfg.env_app_id)
+        unscoped = self._needs_fallback_scope()
+        if unscoped and self._unscoped_enabled is not None:
+            return self._unscoped_enabled
+        with self._credential_scope():
+            enabled = self._cfg.enabled and bool(self._cfg.feishu_app_id or self._cfg.env_app_id)
+        if unscoped and enabled:
+            self._unscoped_enabled = True
+        return enabled
+
+    @staticmethod
+    def _needs_fallback_scope() -> bool:
+        try:
+            from agent.secret_scope import current_secret_scope, is_multiplex_active  # type: ignore[import-not-found]
+        except ImportError:
+            return False
+        return is_multiplex_active() and current_secret_scope() is None
+
+    @contextmanager
+    def _credential_scope(self) -> Iterator[None]:
+        try:
+            from agent.secret_scope import (  # type: ignore[import-not-found]
+                build_profile_secret_scope,
+                current_secret_scope,
+                is_multiplex_active,
+                reset_secret_scope,
+                set_secret_scope,
+            )
+        except ImportError:
+            yield
+            return
+        if not is_multiplex_active() or current_secret_scope() is not None:
+            yield
+            return
+        token = set_secret_scope(build_profile_secret_scope(self._profile_home))
+        try:
+            yield
+        finally:
+            reset_secret_scope(token)
 
     async def _ensure_init(self) -> None:
         if self._initialized:
@@ -50,17 +91,18 @@ class StreamCardController(StreamingController):
         with self._init_lock:
             if self._initialized:
                 return
-            app_id = self._cfg.feishu_app_id or self._cfg.env_app_id
-            app_secret = self._cfg.feishu_app_secret or self._cfg.env_app_secret
-            if not app_id or not app_secret:
-                raise RuntimeError("feishu credentials not configured")
-            self._client = FeishuClient(
-                FeishuClientConfig(
-                    app_id=app_id,
-                    app_secret=app_secret,
-                    base_url=self._cfg.feishu_base_url,
+            with self._credential_scope():
+                app_id = self._cfg.feishu_app_id or self._cfg.env_app_id
+                app_secret = self._cfg.feishu_app_secret or self._cfg.env_app_secret
+                if not app_id or not app_secret:
+                    raise RuntimeError("feishu credentials not configured")
+                self._client = FeishuClient(
+                    FeishuClientConfig(
+                        app_id=app_id,
+                        app_secret=app_secret,
+                        base_url=self._cfg.feishu_base_url,
+                    )
                 )
-            )
             self._initialized = True
 
     def _get_loop(self) -> asyncio.AbstractEventLoop | None:
@@ -573,13 +615,16 @@ class StreamCardController(StreamingController):
             _logger.warning("background task failed", exc_info=True)
 
 
-_controller: StreamCardController | None = None
+_controllers: dict[str, StreamCardController] = {}
 _controller_lock = threading.Lock()
 
 
 def get_controller() -> StreamCardController:
-    global _controller
+    profile_home = hermes_home().resolve()
+    key = str(profile_home)
     with _controller_lock:
-        if _controller is None:
-            _controller = StreamCardController()
-        return _controller
+        controller = _controllers.get(key)
+        if controller is None:
+            controller = StreamCardController(profile_home)
+            _controllers[key] = controller
+        return controller

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -249,3 +249,51 @@ class TestPlatformCfg:
         cfg = _make_config({})
         with patch.dict(os.environ, {}, clear=True):
             assert cfg._platform_cfg() == {}
+
+
+def test_bound_profile_homes_resolve_distinct_gateway_platform_credentials(tmp_path) -> None:
+    home_a = tmp_path / "profile-a"
+    home_b = tmp_path / "profile-b"
+    home_a.mkdir()
+    home_b.mkdir()
+    (home_a / "config.yaml").write_text(
+        (
+            "streaming:\n  enabled: true\ngateway:\n  platforms:\n    feishu:\n"
+            "      extra:\n        app_id: app-a\n        app_secret: secret-a\n"
+        ),
+        encoding="utf-8",
+    )
+    (home_b / "config.yaml").write_text(
+        (
+            "streaming:\n  enabled: true\ngateway:\n  platforms:\n    feishu:\n"
+            "      extra:\n        app_id: app-b\n        app_secret: secret-b\n"
+        ),
+        encoding="utf-8",
+    )
+
+    with patch.dict(os.environ, {}, clear=True):
+        cfg_a = Config(home_a)
+        cfg_b = Config(home_b)
+        assert (cfg_a.enabled, cfg_a.feishu_app_id, cfg_a.feishu_app_secret) == (True, "app-a", "secret-a")
+        assert (cfg_b.enabled, cfg_b.feishu_app_id, cfg_b.feishu_app_secret) == (True, "app-b", "secret-b")
+
+
+def test_nested_lark_domain_uses_larksuite_url() -> None:
+    cfg = _make_config(
+        {
+            "gateway": {
+                "platforms": {
+                    "lark": {
+                        "extra": {
+                            "app_id": "lark-id",
+                            "app_secret": "lark-secret",
+                            "domain": "lark",
+                        }
+                    }
+                }
+            }
+        }
+    )
+
+    with patch.dict(os.environ, {}, clear=True):
+        assert cfg.feishu_base_url == "https://open.larksuite.com"

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 import threading
 import time
 from contextlib import nullcontext
-from types import SimpleNamespace
+from contextvars import ContextVar
+from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -79,8 +81,31 @@ def test_enabled_retries_unsuccessful_unscoped_fallback() -> None:
     assert credential_scope.call_count == 2
 
 
-def test_enabled_uses_and_restores_profile_secret_scope(tmp_path) -> None:
-    from agent.secret_scope import current_secret_scope, is_multiplex_active, set_multiplex_active
+def test_enabled_uses_and_restores_profile_secret_scope(tmp_path, monkeypatch) -> None:
+    secret_scope = ModuleType("agent.secret_scope")
+    active_scope: ContextVar[dict[str, str] | None] = ContextVar("active_scope", default=None)
+    multiplex_active = True
+
+    def build_profile_secret_scope(home) -> dict[str, str]:
+        return dict(
+            line.split("=", 1)
+            for line in (home / ".env").read_text(encoding="utf-8").splitlines()
+            if "=" in line
+        )
+
+    def get_secret(name: str, default: str = "") -> str:
+        return (active_scope.get() or {}).get(name, default)
+
+    secret_scope.build_profile_secret_scope = build_profile_secret_scope
+    secret_scope.current_secret_scope = active_scope.get
+    secret_scope.get_secret = get_secret
+    secret_scope.is_multiplex_active = lambda: multiplex_active
+    secret_scope.reset_secret_scope = active_scope.reset
+    secret_scope.set_secret_scope = active_scope.set
+    agent = ModuleType("agent")
+    agent.secret_scope = secret_scope
+    monkeypatch.setitem(sys.modules, "agent", agent)
+    monkeypatch.setitem(sys.modules, "agent.secret_scope", secret_scope)
 
     profile_home = tmp_path / "profile"
     profile_home.mkdir()
@@ -90,14 +115,9 @@ def test_enabled_uses_and_restores_profile_secret_scope(tmp_path) -> None:
         encoding="utf-8",
     )
     ctrl = StreamCardController(profile_home)
-    was_multiplexed = is_multiplex_active()
-    set_multiplex_active(True)
-    try:
-        assert current_secret_scope() is None
-        assert ctrl.enabled is True
-        assert current_secret_scope() is None
-    finally:
-        set_multiplex_active(was_multiplexed)
+    assert active_scope.get() is None
+    assert ctrl.enabled is True
+    assert active_scope.get() is None
 
 
 def _set_cached_loop(ctrl: StreamCardController) -> asyncio.AbstractEventLoop:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -84,14 +84,11 @@ def test_enabled_retries_unsuccessful_unscoped_fallback() -> None:
 def test_enabled_uses_and_restores_profile_secret_scope(tmp_path, monkeypatch) -> None:
     secret_scope = ModuleType("agent.secret_scope")
     active_scope: ContextVar[dict[str, str] | None] = ContextVar("active_scope", default=None)
-    multiplex_active = True
+    scoped_homes = []
 
     def build_profile_secret_scope(home) -> dict[str, str]:
-        return dict(
-            line.split("=", 1)
-            for line in (home / ".env").read_text(encoding="utf-8").splitlines()
-            if "=" in line
-        )
+        scoped_homes.append(home)
+        return {"FEISHU_APP_ID": "profile-app", "FEISHU_APP_SECRET": "profile-secret"}
 
     def get_secret(name: str, default: str = "") -> str:
         return (active_scope.get() or {}).get(name, default)
@@ -99,7 +96,7 @@ def test_enabled_uses_and_restores_profile_secret_scope(tmp_path, monkeypatch) -
     secret_scope.build_profile_secret_scope = build_profile_secret_scope
     secret_scope.current_secret_scope = active_scope.get
     secret_scope.get_secret = get_secret
-    secret_scope.is_multiplex_active = lambda: multiplex_active
+    secret_scope.is_multiplex_active = lambda: True
     secret_scope.reset_secret_scope = active_scope.reset
     secret_scope.set_secret_scope = active_scope.set
     agent = ModuleType("agent")
@@ -110,14 +107,11 @@ def test_enabled_uses_and_restores_profile_secret_scope(tmp_path, monkeypatch) -
     profile_home = tmp_path / "profile"
     profile_home.mkdir()
     (profile_home / "config.yaml").write_text("streaming:\n  enabled: true\n", encoding="utf-8")
-    (profile_home / ".env").write_text(
-        "FEISHU_APP_ID=profile-app\nFEISHU_APP_SECRET=profile-secret\n",
-        encoding="utf-8",
-    )
     ctrl = StreamCardController(profile_home)
     assert active_scope.get() is None
     assert ctrl.enabled is True
     assert active_scope.get() is None
+    assert scoped_homes == [profile_home]
 
 
 def _set_cached_loop(ctrl: StreamCardController) -> asyncio.AbstractEventLoop:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import asyncio
 import threading
 import time
+from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from hermes_lark_streaming.controller import StreamCardController
+import hermes_lark_streaming.controller as controller_module
+from hermes_lark_streaming.controller import StreamCardController, get_controller
 from hermes_lark_streaming.feishu import FeishuAPIError, FeishuClient
 from hermes_lark_streaming.streaming.segment_helper import estimate_segment_elements
 from hermes_lark_streaming.streaming.segments import Segment, SegmentState
@@ -23,6 +25,79 @@ def _enable(ctrl: StreamCardController) -> None:
         "feishu": {"app_id": "app", "app_secret": "secret"},
     }
     _set_cached_loop(ctrl)
+
+
+def test_get_controller_returns_one_instance_per_profile_home(tmp_path) -> None:
+    home_a = tmp_path / "profile-a"
+    home_b = tmp_path / "profile-b"
+    home_a.mkdir()
+    home_b.mkdir()
+
+    with patch.object(controller_module, "_controllers", {}), patch(
+        "hermes_lark_streaming.controller.hermes_home",
+        side_effect=[home_a, home_b, home_a],
+    ):
+        controller_a = get_controller()
+        controller_b = get_controller()
+        controller_a_again = get_controller()
+
+    assert controller_a is controller_a_again
+    assert controller_a is not controller_b
+    assert controller_a._profile_home == home_a.resolve()
+    assert controller_b._profile_home == home_b.resolve()
+
+
+def test_enabled_caches_unscoped_fallback_result() -> None:
+    ctrl = StreamCardController()
+    ctrl._cfg = MagicMock()
+    ctrl._cfg.enabled = True
+    ctrl._cfg.feishu_app_id = "app-id"
+
+    with patch.object(ctrl, "_needs_fallback_scope", return_value=True), patch.object(
+        ctrl, "_credential_scope", side_effect=lambda: nullcontext()
+    ) as credential_scope:
+        assert ctrl.enabled is True
+        assert ctrl.enabled is True
+
+    credential_scope.assert_called_once()
+
+
+def test_enabled_retries_unsuccessful_unscoped_fallback() -> None:
+    ctrl = StreamCardController()
+    ctrl._cfg = MagicMock()
+    ctrl._cfg.enabled = True
+    ctrl._cfg.feishu_app_id = ""
+    ctrl._cfg.env_app_id = ""
+
+    with patch.object(ctrl, "_needs_fallback_scope", return_value=True), patch.object(
+        ctrl, "_credential_scope", side_effect=lambda: nullcontext()
+    ) as credential_scope:
+        assert ctrl.enabled is False
+        ctrl._cfg.feishu_app_id = "app-id"
+        assert ctrl.enabled is True
+
+    assert credential_scope.call_count == 2
+
+
+def test_enabled_uses_and_restores_profile_secret_scope(tmp_path) -> None:
+    from agent.secret_scope import current_secret_scope, is_multiplex_active, set_multiplex_active
+
+    profile_home = tmp_path / "profile"
+    profile_home.mkdir()
+    (profile_home / "config.yaml").write_text("streaming:\n  enabled: true\n", encoding="utf-8")
+    (profile_home / ".env").write_text(
+        "FEISHU_APP_ID=profile-app\nFEISHU_APP_SECRET=profile-secret\n",
+        encoding="utf-8",
+    )
+    ctrl = StreamCardController(profile_home)
+    was_multiplexed = is_multiplex_active()
+    set_multiplex_active(True)
+    try:
+        assert current_secret_scope() is None
+        assert ctrl.enabled is True
+        assert current_secret_scope() is None
+    finally:
+        set_multiplex_active(was_multiplexed)
 
 
 def _set_cached_loop(ctrl: StreamCardController) -> asyncio.AbstractEventLoop:


### PR DESCRIPTION
## Problem

Hermes multiplex mode runs several profiles in one Gateway process. The plugin previously used a process-global `StreamCardController`, resolved its home through the ambient environment, and read Feishu/Lark credentials directly from `os.environ`.

That let the first active profile bind the controller and its persistent Feishu client for the process lifetime. A routed turn from another profile could then load the wrong `config.yaml`, use the wrong CardKit credentials, or fall back to default-profile values. The existing parser also did not read Hermes canonical `gateway.platforms.<feishu|lark>.extra` credentials, and `domain: lark` did not select the Larksuite API host.

## Solution

Bind each controller to the Hermes-resolved profile home, cache controllers by that resolved home, and resolve secrets through Hermes `agent.secret_scope`. Under an unscoped multiplex callback, install a temporary scope for the controller profile only while reading credentials; restore the original context immediately afterward.

This preserves legacy single-profile environment behavior while isolating multiplexed profile config, state, and persistent Feishu clients.

## Changes

- `config.py`: use `get_hermes_home()` and scoped `get_secret()` when available; allow `Config` to bind configuration reads to a profile home.
- `config.py`: read canonical nested `gateway.platforms.feishu/lark.extra` credentials and map `domain: lark` to `https://open.larksuite.com`.
- `controller.py`: cache `StreamCardController` instances per resolved profile home and create profile-bound configs/clients.
- `controller.py`: provide a temporary profile secret scope only for unscoped multiplex paths; cache successful fallback enablement without suppressing credential retries.
- Tests: cover isolated profile configs/controllers, nested Lark credentials, fallback caching/retry behavior, and secret-scope restoration.

## Testing

- 464 tests passed
- Ruff clean
- mypy clean across 22 source files
- Verified locally with Hermes multiplex enabled: one default Gateway connected Feishu for both `default` and `test-profile`, and the multiplex cron scheduler loaded both profiles.