### PR TITLE
fix: recover CardKit reply failures

### DIFF
--- a/hermes_lark_streaming/controller.py
+++ b/hermes_lark_streaming/controller.py
@@ -325,7 +325,8 @@ class StreamCardController(StreamingController):
             )
             self._complete_session(old_session)
 
-        if new_message_id not in self._sessions:
+        existing = self._sessions.get(new_message_id)
+        if existing is None or existing.state.is_terminal:
             loop = self._get_loop()
             if loop is not None:
                 reply_anchor_id = anchor_id if anchor_id and anchor_id != new_message_id else None
@@ -370,21 +371,27 @@ class StreamCardController(StreamingController):
         message_id = session.message_id
 
         if not await self._wait_for_card_creation(session):
-            _logger.info("on_completed_wait: msg=%s card creation not ready, yielding to gateway", message_id[:12])
-            self._mark_text_fallback_needed(session)
-            self._cleanup(message_id)
+            if session.has_card:
+                _logger.info("on_completed_wait: msg=%s card creation not ready but card exists", message_id[:12])
+            else:
+                _logger.info("on_completed_wait: msg=%s card creation not ready, yielding to gateway", message_id[:12])
+                self._mark_text_fallback_needed(session)
+            self._cleanup_session(session)
             return False
 
         if session.state == SessionState.FAILED:
-            _logger.info("on_completed_wait: msg=%s state=FAILED, yielding to gateway", message_id[:12])
-            self._mark_text_fallback_needed(session)
-            self._cleanup(message_id)
+            if session.has_card:
+                _logger.info("on_completed_wait: msg=%s state=FAILED but card exists", message_id[:12])
+            else:
+                _logger.info("on_completed_wait: msg=%s state=FAILED, yielding to gateway", message_id[:12])
+                self._mark_text_fallback_needed(session)
+            self._cleanup_session(session)
             return False
 
         if not session.has_card:
             _logger.info("on_completed_wait: msg=%s has no card, yielding to gateway", message_id[:12])
             self._mark_text_fallback_needed(session)
-            self._cleanup(message_id)
+            self._cleanup_session(session)
             return False
 
         _logger.info(
@@ -513,6 +520,22 @@ class StreamCardController(StreamingController):
         if session.image_resolver:
             session.image_resolver.cancel_pending()
 
+    def _cleanup_session(self, session: CardSession) -> None:
+        if self._sessions.get(session.message_id) is session:
+            self._sessions.pop(session.message_id, None)
+        anchor = session.anchor_id
+        if anchor and self._sessions.get(anchor) is session:
+            del self._sessions[anchor]
+        session_key = session.session_key
+        if session_key and self._session_keys.get(session_key) is session:
+            del self._session_keys[session_key]
+        stale_keys = [key for key, value in self._interrupt_map.items() if value == session.message_id]
+        for key in stale_keys:
+            del self._interrupt_map[key]
+        session.flush.mark_completed()
+        if session.image_resolver:
+            session.image_resolver.cancel_pending()
+
     def _completion_session(self, message_id: str) -> CardSession | None:
         session = self._sessions.get(message_id)
         if session is not None and (not session.state.is_terminal or session.state == SessionState.FAILED):
@@ -589,7 +612,7 @@ class StreamCardController(StreamingController):
 
     async def _complete_session_after_creation(self, session: CardSession) -> bool:
         if not await self._wait_for_card_creation(session):
-            self._cleanup(session.message_id)
+            self._cleanup_session(session)
             return False
         return await self._complete_session_wait(session)
 

--- a/hermes_lark_streaming/streaming/controller.py
+++ b/hermes_lark_streaming/streaming/controller.py
@@ -69,6 +69,7 @@ class StreamingController:
     _cfg: Config
     _ensure_init: Callable[..., Coroutine[Any, Any, None]]
     _cleanup: Callable[[str], None]
+    _cleanup_session: Callable[[CardSession], None]
     _flush_deferred_background_reviews: Callable[[CardSession], None]
 
     def _schedule_flush(self, session: CardSession) -> None:
@@ -116,10 +117,25 @@ class StreamingController:
                 text_size=self._cfg.body_text_size,
             )
             card_id = await self._client.cardkit_create(card)
-            card_msg_id = await self._client.reply_card_by_id(
-                reply_to_message_id,
-                card_id,
-            )
+            try:
+                card_msg_id = await self._client.reply_card_by_id(
+                    reply_to_message_id,
+                    card_id,
+                )
+            except FeishuAPIError as error:
+                if error.code != CARDKIT_CONTENT_FAILED:
+                    raise
+                card_id = await self._client.cardkit_create(card)
+                try:
+                    card_msg_id = await self._client.reply_card_by_id(
+                        reply_to_message_id,
+                        card_id,
+                    )
+                except FeishuAPIError:
+                    card_msg_id = await self._client.send_card_to_chat(
+                        chat_id=session.chat_id,
+                        card={"type": "card", "data": {"card_id": card_id}},
+                    )
             session.set_card(card_id=card_id, card_msg_id=card_msg_id)
             session.element_count = 1  # loading element
             session.flush.set_throttle(CARDKIT_MS)
@@ -581,7 +597,7 @@ class StreamingController:
             return await self._do_complete_card_inner(session)
         finally:
             self._flush_deferred_background_reviews(session)
-            self._cleanup(session.message_id)
+            self._cleanup_session(session)
 
     async def _do_complete_card_inner(self, session: CardSession) -> bool:
         if session.guard.should_skip("_do_complete_card"):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -195,6 +195,30 @@ def test_on_interrupted_uses_new_message_id_and_anchor_alias() -> None:
     assert ctrl._session_keys["session:chat"] is session
 
 
+def test_on_interrupted_same_id_replaces_terminal_session() -> None:
+    ctrl = StreamCardController()
+    _enable(ctrl)
+
+    with patch.object(ctrl, "_fire_and_forget", side_effect=lambda coro, loop: coro.close()):
+        ctrl.on_message_started(message_id="msg", chat_id="chat")
+        old_session = ctrl._sessions["msg"]
+        ctrl.on_interrupted(
+            old_message_id="msg",
+            new_message_id="msg",
+            chat_id="chat",
+            anchor_id="msg",
+        )
+
+    new_session = ctrl._sessions["msg"]
+    assert old_session.state == SessionState.ABORTED
+    assert new_session is not old_session
+    assert new_session.state == SessionState.IDLE
+
+    ctrl._cleanup_session(old_session)
+
+    assert ctrl._sessions["msg"] is new_session
+
+
 @pytest.mark.asyncio
 async def test_on_session_aborted_only_stops_matching_session_key() -> None:
     ctrl = StreamCardController()
@@ -645,6 +669,55 @@ class TestDoCreateCard:
         assert session.segment_state is not None
         assert session.card_id == "card_id_abc"
         assert session.state == SessionState.STREAMING
+
+    @pytest.mark.asyncio
+    async def test_content_failure_recreates_card_and_retries_reply(self) -> None:
+        ctrl = _setup_ctrl()
+        ctrl._client.cardkit_create = AsyncMock(side_effect=["card_first", "card_second"])
+        ctrl._client.reply_card_by_id = AsyncMock(
+            side_effect=[FeishuAPIError("invalid card", code=230099), "reply_second"]
+        )
+        session = _make_session("msg_retry")
+
+        await ctrl._do_create_card(session)
+
+        assert session.card_id == "card_second"
+        assert session.card_msg_id == "reply_second"
+        assert ctrl._client.cardkit_create.await_count == 2
+        assert ctrl._client.reply_card_by_id.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_content_failure_uses_standalone_card_after_retry_fails(self) -> None:
+        ctrl = _setup_ctrl()
+        ctrl._client.cardkit_create = AsyncMock(side_effect=["card_first", "card_second"])
+        ctrl._client.reply_card_by_id = AsyncMock(side_effect=FeishuAPIError("invalid card", code=230099))
+        ctrl._client.send_card_to_chat = AsyncMock(return_value="standalone_reply")
+        session = _make_session("msg_standalone")
+
+        await ctrl._do_create_card(session)
+
+        assert session.card_id == "card_second"
+        assert session.card_msg_id == "standalone_reply"
+        ctrl._client.send_card_to_chat.assert_awaited_once_with(
+            chat_id="chat_456",
+            card={"type": "card", "data": {"card_id": "card_second"}},
+        )
+
+    @pytest.mark.asyncio
+    async def test_standalone_card_completion_does_not_require_text_fallback(self) -> None:
+        ctrl = _setup_ctrl()
+        ctrl._client.cardkit_create = AsyncMock(side_effect=["card_first", "card_second"])
+        ctrl._client.reply_card_by_id = AsyncMock(side_effect=FeishuAPIError("invalid card", code=230099))
+        ctrl._client.send_card_to_chat = AsyncMock(return_value="standalone_reply")
+        session = _make_session("msg_standalone_complete")
+        ctrl._sessions[session.message_id] = session
+
+        await ctrl._do_create_card(session)
+
+        with patch.object(ctrl, "_complete_session_wait", new_callable=AsyncMock, return_value=True):
+            assert await ctrl.on_completed_wait(message_id=session.message_id, answer="answer") is True
+
+        assert ctrl.consume_text_fallback(session.message_id) is False
 
     @pytest.mark.asyncio
     async def test_cardkit_failure_yields_to_gateway(self) -> None:


### PR DESCRIPTION
## Problem

CardKit may return `230099 CARDKIT_CONTENT_FAILED` when the freshly created `card_id` is not yet visible to the reply API. The existing creation path immediately yielded to Hermes plain-text fallback, even though recreating the card shortly afterward can succeed.

A queued synthetic follow-up can also re-enter with the same message id after its prior session has been aborted. The terminal session remained in the session map, so the new turn did not create a streaming card. An old asynchronous finalizer could additionally remove a replacement session sharing the same key.

## Solution

For `230099` from `reply_card_by_id`, create a fresh CardKit entity and retry the reply once. If that reply still fails, send the CardKit reference as a standalone card instead of falling back to plain text. Other API errors preserve the existing fallback behavior.

Allow same-id follow-up re-entry to replace a terminal session. Cleanup now removes session aliases only when they still reference the exact session instance, so an old finalizer cannot remove its replacement.

## Changes

- `streaming/controller.py`: recreate CardKit content after a `230099` reply failure, then fall back to a standalone card after the second reply failure.
- `controller.py`: replace terminal same-id sessions and use identity-safe session cleanup through completion and failure paths.
- Tests: cover card recreation, standalone-card delivery, completion without text fallback, and same-id replacement cleanup.

## Upstream Compatibility

Validated against the local Hermes 0.19 gateway flow. A completed streaming card sets `already_sent`; queued follow-up delivery clears `final_response` before drain, preventing a second plain-text send. The standalone-card path completes as a normal CardKit session and preserves that contract.

## Testing

- 468 tests passed
- Ruff clean
- `git diff --check` clean