### PR TITLE
feat: split card around clarify tool interactions

### DIFF
--- a/hermes_lark_streaming/controller.py
+++ b/hermes_lark_streaming/controller.py
@@ -250,10 +250,45 @@ class StreamCardController(StreamingController):
                 error=detail if is_error else "",
                 output="" if is_error else detail,
             )
+            # clarify 工具 ended 且有待封卡标志 → 封旧卡 + 建新卡
+            if session.clarify_pending_split:
+                if tool_name and tool_name.strip().lower() == "clarify":
+                    session.clarify_pending_split = False
+                    self._schedule_clarify_split(session)
+                else:
+                    # pending 标志残留但工具名不匹配（如上游改名）——记录以便排查，
+                    # 避免切卡静默失效。
+                    _logger.warning(
+                        "clarify_pending_split set but tool '%s' did not match, msg=%s",
+                        tool_name,
+                        session.message_id[:12],
+                    )
 
         session.segment_state.on_tool_event(len(session.tool_use.build_display_steps()))
         self._schedule_flush(session)
         return True
+
+    def _schedule_clarify_split(self, session: CardSession) -> None:
+        """封旧卡 + 建新卡（clarify 工具 ended 后触发）。"""
+        loop = self._get_loop()
+        if loop is None:
+            return
+        future: ConcurrentFuture | None = None
+        try:
+            future = asyncio.run_coroutine_threadsafe(
+                self._do_clarify_split(session), loop,
+            )
+            # 预算 = 卡片创建等待 + seal/建卡余量
+            future.result(timeout=_CARD_CREATION_WAIT_SEC * 2 + 30)
+        except Exception:
+            _logger.warning(
+                "clarify_split failed or timed out, msg=%s",
+                session.message_id[:12],
+                exc_info=True,
+            )
+            # 取消仍在运行的切卡协程，避免与后续 flush 重叠。
+            if future is not None and not future.done():
+                future.cancel()
 
     def on_answer(self, *, message_id: str, text: str) -> bool:
         """答案文本增量（流式）."""
@@ -350,6 +385,37 @@ class StreamCardController(StreamingController):
         for key, val in list(self._interrupt_map.items()):
             if val == old_message_id:
                 self._interrupt_map[key] = new_message_id
+
+    def on_clarify_enter(
+        self,
+        *,
+        message_id: str,
+        chat_id: str | None = None,
+        session_key: str | None = None,
+    ) -> None:
+        """clarify 进入：仅暂停 flush，等 tool.completed 再封卡（避免工具状态卡在 running）。"""
+        if not self.enabled:
+            return
+        session = self._get_active_session(message_id)
+        if session is None or session.state != SessionState.STREAMING:
+            return
+        session.state = SessionState.CLARIFY_PAUSED  # 暂停 flush，保留当前卡
+
+    def on_clarify_exit(
+        self,
+        *,
+        message_id: str,
+        chat_id: str | None = None,
+        session_key: str | None = None,
+    ) -> None:
+        """clarify 退出：标记待封卡，恢复 STREAMING，等 tool.completed 触发切卡。"""
+        if not self.enabled:
+            return
+        session = self._sessions.get(message_id)
+        if session is None or session.state != SessionState.CLARIFY_PAUSED:
+            return  # 已被 interrupt 接管 / enter 未生效
+        session.clarify_pending_split = True
+        session.state = SessionState.STREAMING  # 让 tool.completed 能更新卡片
 
     async def on_completed_wait(
         self,

--- a/hermes_lark_streaming/patch.py
+++ b/hermes_lark_streaming/patch.py
@@ -333,3 +333,27 @@ async def on_background_deliver(
     except Exception as exc:
         _logger.warning("on_background_deliver error: %s", exc, exc_info=True)
         return False
+
+
+@_safe_hook()
+def on_clarify_enter(
+    *,
+    ctrl: Any,
+    message_id: str,
+    chat_id: str | None = None,
+    session_key: str | None = None,
+) -> None:
+    """[注入点 12] clarify_callback 进入 — 暂停 flush 保留当前卡。"""
+    ctrl.on_clarify_enter(message_id=message_id, chat_id=chat_id, session_key=session_key)
+
+
+@_safe_hook()
+def on_clarify_exit(
+    *,
+    ctrl: Any,
+    message_id: str,
+    chat_id: str | None = None,
+    session_key: str | None = None,
+) -> None:
+    """[注入点 12] clarify_callback 退出 — 标记待封卡，等 tool.completed 触发切卡。"""
+    ctrl.on_clarify_exit(message_id=message_id, chat_id=chat_id, session_key=session_key)

--- a/hermes_lark_streaming/patcher.py
+++ b/hermes_lark_streaming/patcher.py
@@ -35,6 +35,7 @@ _HOOK_NAMES = [
     "STOP",
     "INTERRUPT",
     "BG_DELIVER",
+    "CLARIFY",
 ]
 MARKERS: list[tuple[str, str]] = [(f"# {PREFIX}_{n}_BEGIN", f"# {PREFIX}_{n}_END") for n in _HOOK_NAMES]
 
@@ -52,6 +53,7 @@ MK_ABORT, MK_ABORT_END = MARKERS[10]
 MK_STOP, MK_STOP_END = MARKERS[11]
 MK_INTERRUPT, MK_INTERRUPT_END = MARKERS[12]
 MK_BG_DELIVER, MK_BG_DELIVER_END = MARKERS[13]
+MK_CLARIFY, MK_CLARIFY_END = MARKERS[14]
 
 _BACKUP_SUFFIX = ".hermes_lark.bak"
 
@@ -199,6 +201,7 @@ _ANCHOR_CHECKS: list[tuple[str, tuple[str, ...], str]] = [
     ("images, text_content = adapter.extract_images(response)", (), "background deliver"),
     ("_already_sent = bool(", (), "complete"),
     ("Discarding stale agent result", (), "abort"),
+    ("agent.clarify_callback = _clarify_callback_sync", (), "clarify_callback"),
 ]
 
 
@@ -604,6 +607,43 @@ def _bg_deliver_hook(indent: str) -> str:
     )
 
 
+def _clarify_hook(indent: str) -> str:
+    return _make_hook(
+        indent,
+        MK_CLARIFY,
+        MK_CLARIFY_END,
+        [
+            "try:",
+            "    from hermes_lark_streaming.patch import on_clarify_enter, on_clarify_exit",
+            "    _lark_clarify_orig = agent.clarify_callback",
+            "    def _lark_clarify_wrapper(question, choices, multi_select=False):",
+            "        try:",
+            "            _lark_clarify_msg_id = ctx.event_message_id",
+            "            _lark_clarify_chat_id = ctx._status_chat_id",
+            "            _lark_clarify_sk = ctx.session_key",
+            "        except NameError:",
+            "            _lark_clarify_msg_id = event_message_id",
+            "            _lark_clarify_chat_id = None",
+            "            _lark_clarify_sk = None",
+            "        on_clarify_enter(",
+            "            message_id=_lark_clarify_msg_id,",
+            "            chat_id=_lark_clarify_chat_id,",
+            "            session_key=_lark_clarify_sk,",
+            "        )",
+            "        try:",
+            "            return _lark_clarify_orig(question, choices, multi_select)",
+            "        finally:",
+            "            on_clarify_exit(",
+            "                message_id=_lark_clarify_msg_id,",
+            "                chat_id=_lark_clarify_chat_id,",
+            "                session_key=_lark_clarify_sk,",
+            "            )",
+            "    agent.clarify_callback = _lark_clarify_wrapper",
+            *_hook_exception_lines("clarify"),
+        ],
+    )
+
+
 def _remove_block(content: str, begin: str, end: str) -> str:
     lines = content.splitlines(keepends=True)
     result: list[str] = []
@@ -786,6 +826,7 @@ class Patcher:
             ("reasoning", "reasoning", _find_reasoning_site(tree, lines)),
             ("background_review", "background_review", _find_background_review_site(tree, lines)),
             ("bg_deliver", "bg_deliver", _find_bg_deliver_site(tree, lines)),
+            ("clarify", "clarify", _find_clarify_site(tree, lines)),
         ]
         hook_defs.extend(
             ("answer", f"answer callback {index}", loc)
@@ -817,6 +858,7 @@ class Patcher:
             "reasoning": _reasoning_hook,
             "background_review": _background_review_hook,
             "bg_deliver": _bg_deliver_hook,
+            "clarify": _clarify_hook,
         }
         for idx, indent, fn_name in sites:
             hook = _HOOK_FNS[fn_name](indent)
@@ -965,6 +1007,13 @@ def _find_background_review_site(tree: ast.Module, lines: list[str]) -> tuple[in
 def _find_bg_deliver_site(tree: ast.Module, lines: list[str]) -> tuple[int, str] | None:
     for i, line in enumerate(lines):
         if line.strip() == "images, text_content = adapter.extract_images(response)":
+            return i + 1, _safe_indent(lines, i)
+    return None
+
+
+def _find_clarify_site(tree: ast.Module, lines: list[str]) -> tuple[int, str] | None:
+    for i, line in enumerate(lines):
+        if line.strip() == "agent.clarify_callback = _clarify_callback_sync":
             return i + 1, _safe_indent(lines, i)
     return None
 

--- a/hermes_lark_streaming/streaming/controller.py
+++ b/hermes_lark_streaming/streaming/controller.py
@@ -36,6 +36,7 @@ from .segment_helper import (
 from .segments import Segment, SegmentState, SegmentType
 from .session import SessionState
 from .text import split_reasoning_text
+from .tooluse import ToolUseTracker
 
 if TYPE_CHECKING:
     from ..config import Config
@@ -71,9 +72,12 @@ class StreamingController:
     _cleanup: Callable[[str], None]
     _cleanup_session: Callable[[CardSession], None]
     _flush_deferred_background_reviews: Callable[[CardSession], None]
+    _wait_for_card_creation: Callable[[CardSession], Coroutine[Any, Any, bool]]
 
     def _schedule_flush(self, session: CardSession) -> None:
         if session.state == SessionState.IDLE or session.state.is_terminal:
+            return
+        if session.state == SessionState.CLARIFY_PAUSED:
             return
         if session.guard.should_skip("_schedule_flush"):
             return
@@ -499,6 +503,83 @@ class StreamingController:
             return "failed"
         return "split"
 
+    async def _seal_current_card(
+        self,
+        session: CardSession,
+        seal_segments: list[Segment],
+        *,
+        card_id: str | None = None,
+        sequence: int | None = None,
+    ) -> None:
+        """封印指定卡（默认 session.card_id）：close_streaming + 全量重建。失败仅记录日志。
+
+        card_id 用于 session 已切到新卡、仍需封印旧卡的场景（clarify 切卡）；
+        sequence 传入旧卡续用的递增序列（CardKit 要求单调递增，不能用新卡的计数）。
+        """
+        assert self._client is not None
+        old_card_id = card_id or session.card_id
+        if not old_card_id:
+            return
+        if session.image_resolver:
+            await _resolve_answer_images(
+                seal_segments,
+                session.image_resolver,
+                log_prefix="CardKit seal",
+            )
+        all_steps = session.tool_use.build_display_steps()
+        seal_card = build_complete_card(
+            segments=seal_segments,
+            all_tool_steps=all_steps,
+            footer_fields=[],
+            footer_show_label=False,
+            footer_enabled=False,
+            panel_expanded=self._cfg.panel_expanded,
+            header_enabled=False,
+            body_text_size=self._cfg.body_text_size,
+            show_tool_use=self._cfg.show_tool_use,
+            width_mode=self._cfg.width_mode,
+        )
+        try:
+            seq = session.sequence if sequence is None else sequence
+            seq += 1
+            await self._client.cardkit_close_streaming(old_card_id, sequence=seq)
+            seq += 1
+            await self._client.cardkit_update(old_card_id, seal_card, sequence=seq)
+        except Exception:
+            _logger.warning(
+                "CardKit seal failed for old card %s, continuing",
+                old_card_id[:12],
+                exc_info=True,
+            )
+
+    async def _create_streaming_card(self, session: CardSession) -> tuple[str, str] | None:
+        """创建空白流式卡并挂到 anchor，返回 (card_id, msg_id)。失败返回 None。
+
+        不修改 session.card_id —— 调用方负责 set_card。
+        """
+        assert self._client is not None
+        try:
+            card = build_streaming_card_v2(
+                show_tool_use=False,
+                show_reasoning=False,
+                show_streaming_element=False,
+                header_enabled=self._cfg.header_enabled,
+                text_size=self._cfg.body_text_size,
+                width_mode=self._cfg.width_mode,
+            )
+            new_card_id = await self._client.cardkit_create(card)
+            new_msg_id = await self._client.reply_card_by_id(
+                session.anchor_id or session.message_id, new_card_id,
+            )
+        except Exception:
+            _logger.warning(
+                "CardKit create streaming card failed for msg=%s",
+                session.message_id[:12],
+                exc_info=True,
+            )
+            return None
+        return new_card_id, new_msg_id
+
     async def _do_split_card(
         self,
         session: CardSession,
@@ -515,7 +596,6 @@ class StreamingController:
         segment_state = session.segment_state
         assert segment_state is not None
         segments = segment_state.segments
-        all_steps = session.tool_use.build_display_steps()
         seal_start_idx = session.split_index
 
         if actions and not await self._do_batch_update(
@@ -524,61 +604,19 @@ class StreamingController:
             return False
 
         seal_segments = [s for s in segments[seal_start_idx:split_idx] if s.created]
-        if session.image_resolver:
-            await _resolve_answer_images(
-                seal_segments,
-                session.image_resolver,
-                log_prefix="CardKit seal",
-            )
 
-        seal_card = build_complete_card(
-            segments=seal_segments,
-            all_tool_steps=all_steps,
-            footer_fields=[],
-            footer_show_label=False,
-            footer_enabled=False,
-            panel_expanded=self._cfg.panel_expanded,
-            header_enabled=False,
-            body_text_size=self._cfg.body_text_size,
-            show_tool_use=self._cfg.show_tool_use,
-            width_mode=self._cfg.width_mode,
-        )
-
-        try:
-            card = build_streaming_card_v2(
-                show_tool_use=False,
-                show_reasoning=False,
-                show_streaming_element=False,
-                header_enabled=self._cfg.header_enabled,
-                text_size=self._cfg.body_text_size,
-                width_mode=self._cfg.width_mode,
-            )
-            new_card_id = await self._client.cardkit_create(card)
-            new_msg_id = await self._client.reply_card_by_id(session.anchor_id or session.message_id, new_card_id)
-        except Exception:
-            _logger.warning(
-                "CardKit split fallback: create next card failed, continue on current card",
-                exc_info=True,
-            )
-            # 拆卡失败时降级为继续写当前卡，并禁用后续拆卡重试以避免反复卡在同一边界。
-            session.split_disabled = True
+        # create → seal → set_card（顺序与原实现一致）
+        new_card = await self._create_streaming_card(session)
+        if new_card is None:
+            session.split_disabled = True  # 降级：继续写当前卡
             return True
 
-        try:
-            session.sequence += 1
-            await self._client.cardkit_close_streaming(old_card_id, sequence=session.sequence)
-            session.sequence += 1
-            await self._client.cardkit_update(old_card_id, seal_card, sequence=session.sequence)
-        except Exception:
-            _logger.warning(
-                "CardKit seal failed for old card %s, continuing",
-                old_card_id[:12],
-                exc_info=True,
-            )
+        await self._seal_current_card(session, seal_segments)
 
+        new_card_id, new_msg_id = new_card
         session.set_card(card_id=new_card_id, card_msg_id=new_msg_id)
-        session.element_count = 1  # loading
-        session.sequence = 1
+        session.element_count = 1  # loading element
+        session.sequence = 1  # 新卡从 1 重新计数
         session.split_disabled = False
         session.split_index = split_idx
         for seg in segments[split_idx:]:
@@ -592,6 +630,68 @@ class StreamingController:
             new_card_id[:12],
         )
         return True
+
+    async def _do_clarify_split(self, session: CardSession) -> bool:
+        """clarify 工具结束后切卡：建新卡 + 封旧卡。
+
+        返回 False 表示未切卡（无卡可封，或建卡失败降级继续写旧卡）。
+        """
+        await self._wait_for_card_creation(session)
+        if not session.has_card or session.state == SessionState.FAILED:
+            _logger.info(
+                "clarify_split: no card to seal, msg=%s state=%s",
+                session.message_id[:12], session.state,
+            )
+            return False
+
+        # 先禁拆卡再等 flush：否则进行中的 flush 可能先拆卡，随后被本流程封印成空白卡。
+        session.split_disabled = True
+        try:
+            await session.flush.wait_for_flush()
+            try:
+                await session.flush.flush_now(lambda: self._do_flush(session))
+            except Exception:
+                _logger.debug("clarify_split: final flush failed", exc_info=True)
+
+            # 先建新卡后封旧卡（与拆卡一致）：建卡失败时旧卡未 close，可降级继续流式。
+            new_card = await self._create_streaming_card(session)
+            if new_card is None:
+                _logger.warning(
+                    "clarify_split: create new card failed, continuing on current card, msg=%s",
+                    session.message_id[:12],
+                )
+                return False
+
+            # 先切到新卡再封旧卡：任意时刻被取消（超时兜底）时，session 指向的都是
+            # 未 close 的卡，后续 flush 不会写到已关闭的旧卡。
+            # seal 必须显式传旧 card_id + 旧 sequence（session 已切新卡，
+            # 且 CardKit sequence 要求单调递增，不能用新卡的计数）。
+            old_card_id = session.card_id
+            old_seq = session.sequence
+            new_card_id, new_msg_id = new_card
+            session.set_card(card_id=new_card_id, card_msg_id=new_msg_id)
+            session.sequence = 1  # 新卡从 1 重新计数
+
+            await self._seal_current_card(
+                session,
+                session.active_segments(),
+                card_id=old_card_id,
+                sequence=old_seq,
+            )
+
+            # 重置内容，新卡承载 clarify 后的输出
+            session.segment_state = SegmentState()
+            session.split_index = 0
+            session.element_count = 1  # loading element（与拆卡一致）
+            session.tool_use = ToolUseTracker()
+
+            _logger.info(
+                "clarify_split: sealed old + new card msg=%s card=%s",
+                session.message_id[:12], new_card_id[:12],
+            )
+            return True
+        finally:
+            session.split_disabled = False  # 取消/异常/失败均恢复拆卡能力
 
     def _handle_flush_error(self, e: FeishuAPIError) -> None:
         if e.code == CARDKIT_RATE_LIMITED:

--- a/hermes_lark_streaming/streaming/session.py
+++ b/hermes_lark_streaming/streaming/session.py
@@ -23,6 +23,7 @@ class SessionState(StrEnum):
     IDLE = "idle"
     CREATING = "creating"
     STREAMING = "streaming"
+    CLARIFY_PAUSED = "clarify_paused"
     COMPLETED = "completed"
     FAILED = "failed"
     ABORTED = "aborted"
@@ -45,6 +46,7 @@ class CardSession:
         "card_id",
         "card_msg_id",
         "chat_id",
+        "clarify_pending_split",
         "create_task",
         "created_at",
         "deferred_background_review_closed",
@@ -100,6 +102,7 @@ class CardSession:
         self.element_count: int = 0
         self.split_disabled = False
         self.split_index: int = 0
+        self.clarify_pending_split: bool = False
 
     @property
     def has_card(self) -> bool:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -425,6 +425,242 @@ def test_background_review_after_flush_not_deferred() -> None:
     assert sent == []
 
 
+# ── Clarify 卡片切换 ──
+
+
+@pytest.mark.asyncio
+async def test_clarify_split_seals_old_and_creates_new() -> None:
+    """_do_clarify_split 封旧卡 + 建新卡 + 重置状态。"""
+    ctrl = _setup_ctrl()
+    session = _make_session("msg_clarify")
+    session.state = SessionState.STREAMING
+    session.card_id = "old_card"
+    session.card_msg_id = "old_msg"
+    session.anchor_id = "anchor_msg"
+    session.sequence = 30  # 旧卡已流式很久，sequence 远大于新卡起始值
+    session.segment_state.on_answer_delta("content before clarify")
+    session.tool_use.record_start("clarify")
+    session.segment_state.on_tool_event(1)
+    session.flush.set_card_message_ready(True)
+    for seg in session.segment_state.segments:
+        seg.created = True
+    ctrl._sessions["msg_clarify"] = session
+
+    # mock _do_flush 为空，避免 final flush 递增旧卡 sequence 干扰断言
+    async def fake_flush(_session) -> None:
+        pass
+
+    with patch.object(ctrl, "_do_flush", side_effect=fake_flush):
+        result = await ctrl._do_clarify_split(session)
+
+    assert result is True
+    client = ctrl._client
+    # 旧卡被封印（close/update 目标是旧卡，而不是切卡后的新卡）
+    assert client.cardkit_close_streaming.await_count >= 1
+    assert client.cardkit_update.await_count >= 1
+    assert client.cardkit_close_streaming.await_args.args[0] == "old_card"
+    assert client.cardkit_update.await_args.args[0] == "old_card"
+    # seal 必须用旧卡续用的递增 sequence（CardKit 要求单调递增，不能用新卡的 2/3）
+    assert client.cardkit_close_streaming.await_args.kwargs["sequence"] == 31
+    assert client.cardkit_update.await_args.kwargs["sequence"] == 32
+    # 新卡已创建
+    assert session.card_id == "card_id_abc"
+    assert session.card_msg_id == "msg_id_reply"
+    # 状态重置
+    assert len(session.segment_state.segments) == 0
+    assert len(session.tool_use.build_display_steps()) == 0
+    assert session.split_index == 0
+    assert session.element_count == 1  # 新卡自带 loading element
+
+
+@pytest.mark.asyncio
+async def test_clarify_split_no_card_skips_seal() -> None:
+    """无活跃卡片时 _do_clarify_split 直接返回 False。"""
+    ctrl = _setup_ctrl()
+    session = _make_session("msg_clarify")
+    session.state = SessionState.STREAMING
+    ctrl._sessions["msg_clarify"] = session
+
+    result = await ctrl._do_clarify_split(session)
+
+    assert result is False
+    assert ctrl._client.cardkit_close_streaming.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_clarify_split_create_failure_continues_on_old_card() -> None:
+    """建新卡失败 → 不封旧卡，降级继续写旧卡（内容不丢）。"""
+    ctrl = _setup_ctrl()
+    session = _make_session("msg_clarify")
+    session.state = SessionState.STREAMING
+    session.card_id = "old_card"
+    session.flush.set_card_message_ready(True)
+    ctrl._sessions["msg_clarify"] = session
+
+    ctrl._client.cardkit_create = AsyncMock(side_effect=Exception("create failed"))
+
+    result = await ctrl._do_clarify_split(session)
+
+    assert result is False
+    # 旧卡未被封印，仍可继续流式
+    assert ctrl._client.cardkit_close_streaming.await_count == 0
+    assert session.card_id == "old_card"
+    assert session.state == SessionState.STREAMING
+    assert session.split_disabled is False  # 恢复拆卡能力
+
+
+@pytest.mark.asyncio
+async def test_clarify_split_seal_failure_still_switches_card() -> None:
+    """封旧卡失败（仅记录日志）不影响挂新卡。"""
+    ctrl = _setup_ctrl()
+    session = _make_session("msg_clarify")
+    session.state = SessionState.STREAMING
+    session.card_id = "old_card"
+    session.card_msg_id = "old_msg"
+    session.anchor_id = "anchor_msg"
+    session.flush.set_card_message_ready(True)
+    ctrl._sessions["msg_clarify"] = session
+
+    ctrl._client.cardkit_close_streaming = AsyncMock(side_effect=Exception("seal failed"))
+
+    result = await ctrl._do_clarify_split(session)
+
+    assert result is True
+    assert session.card_id == "card_id_abc"  # 新卡已挂上
+
+
+def test_on_clarify_enter_only_pauses_not_seals() -> None:
+    """on_clarify_enter 只设 CLARIFY_PAUSED，不封卡。"""
+    ctrl = _setup_ctrl()
+    session = _make_session("msg_clarify")
+    session.state = SessionState.STREAMING
+    session.card_id = "old_card"
+    ctrl._sessions["msg_clarify"] = session
+
+    ctrl.on_clarify_enter(message_id="msg_clarify")
+
+    assert session.state == SessionState.CLARIFY_PAUSED
+    # 没有封卡 API 调用
+    assert ctrl._client.cardkit_close_streaming.await_count == 0
+
+
+def test_on_clarify_enter_skips_non_streaming_session() -> None:
+    """非 STREAMING 状态不触发 clarify 暂停。"""
+    ctrl = _setup_ctrl()
+    session = _make_session("msg_clarify")
+    session.state = SessionState.IDLE
+    ctrl._sessions["msg_clarify"] = session
+
+    ctrl.on_clarify_enter(message_id="msg_clarify")
+
+    assert session.state == SessionState.IDLE
+
+
+def test_on_clarify_exit_sets_pending_flag_and_resumes() -> None:
+    """on_clarify_exit 设待封卡标志 + 恢复 STREAMING，不立即封卡。"""
+    ctrl = _setup_ctrl()
+    session = _make_session("msg_clarify")
+    session.state = SessionState.CLARIFY_PAUSED
+    ctrl._sessions["msg_clarify"] = session
+
+    ctrl.on_clarify_exit(message_id="msg_clarify")
+
+    assert session.state == SessionState.STREAMING
+    assert session.clarify_pending_split is True
+    # 没有封卡 API 调用
+    assert ctrl._client.cardkit_close_streaming.await_count == 0
+
+
+def test_on_clarify_exit_skips_non_clarify_paused_session() -> None:
+    """非 CLARIFY_PAUSED 状态不触发 exit 逻辑。"""
+    ctrl = _setup_ctrl()
+    session = _make_session("msg_clarify")
+    session.state = SessionState.ABORTED
+    ctrl._sessions["msg_clarify"] = session
+
+    ctrl.on_clarify_exit(message_id="msg_clarify")
+
+    assert session.state == SessionState.ABORTED
+    assert session.clarify_pending_split is False
+
+
+@pytest.mark.asyncio
+async def test_clarify_split_triggered_on_tool_completed() -> None:
+    """clarify 工具 completed + pending_split → 触发封卡+建新卡。"""
+    ctrl = _setup_ctrl()
+    loop = asyncio.get_running_loop()
+    ctrl._loop = loop
+    session = CardSession("msg_tool", "chat", loop)
+    session.state = SessionState.STREAMING
+    session.card_id = "old_card"
+    session.card_msg_id = "old_msg"
+    session.anchor_id = "anchor_msg"
+    session.flush.set_card_message_ready(True)
+    session.clarify_pending_split = True
+    session.segment_state.on_tool_event(0)
+    ctrl._sessions["msg_tool"] = session
+
+    # mock _do_flush 避免复杂 segment 逻辑
+    async def fake_flush(_session):
+        pass
+
+    with patch.object(ctrl, "_do_flush", side_effect=fake_flush):
+        # tool.completed 事件（在 agent 线程）
+        await asyncio.to_thread(
+            ctrl.on_tool_update,
+            message_id="msg_tool",
+            tool_name="clarify",
+            status="completed",
+            detail="answer",
+        )
+
+    # 封卡+建新卡已触发
+    assert session.clarify_pending_split is False
+    assert ctrl._client.cardkit_close_streaming.await_count >= 1
+    assert session.card_id == "card_id_abc"
+
+
+def test_clarify_tool_completed_without_pending_does_not_split() -> None:
+    """非 pending 状态的 clarify completed 不触发封卡。"""
+    ctrl = _setup_ctrl()
+    session = _make_session("msg_clarify")
+    session.state = SessionState.STREAMING
+    session.card_id = "old_card"
+    session.clarify_pending_split = False
+    ctrl._sessions["msg_clarify"] = session
+
+    ctrl.on_tool_update(
+        message_id="msg_clarify", tool_name="clarify", status="completed", detail="x",
+    )
+
+    # 没有封卡
+    assert ctrl._client.cardkit_close_streaming.await_count == 0
+    assert session.card_id == "old_card"
+
+
+def test_clarify_pending_requires_exact_tool_name() -> None:
+    """pending 标志只对精确工具名 clarify 触发切卡，不匹配时保留标志并告警。"""
+    ctrl = _setup_ctrl()
+    session = _make_session("msg_clarify")
+    session.state = SessionState.STREAMING
+    session.card_id = "old_card"
+    session.clarify_pending_split = True
+    ctrl._sessions["msg_clarify"] = session
+
+    with patch.object(ctrl, "_schedule_clarify_split") as mock_split:
+        ctrl.on_tool_update(
+            message_id="msg_clarify",
+            tool_name="data_clarifier",
+            status="completed",
+            detail="x",
+        )
+
+    # 不精确匹配：不切卡，pending 保留，且打 warning
+    mock_split.assert_not_called()
+    assert session.clarify_pending_split is True
+    assert session.card_id == "old_card"
+
+
 # ── 辅助函数 ──
 
 


### PR DESCRIPTION
## Problem

When the model calls Hermes's `clarify` tool, a poll is rendered inside the chat
while the agent worker thread blocks on the user response. The streaming card
keeps accumulating the pre-clarify prose, and once the user answers, the
remaining output is appended to the same card. There is no visual separation
between the prompt and the continuation, and the card grows unboundedly.

## Solution

Inject a CLARIFY hook (the 16th) around `agent.clarify_callback` and add a
`CLARIFY_PAUSED` session state that freezes card flushes while the clarify poll
is visible. When the tool completes, seal the old card and create a fresh
streaming card that carries all post-clarify output.

Card switching is also made cancellation-safe: the session is switched to the
new card before the old one is sealed, so a timeout cancel can never leave the
session pointing at a closed card. Sealing passes the old card's ID and
monotonic sequence explicitly, since CardKit rejects out-of-order updates.

## Changes

- Add `CLARIFY` to the injectable hook list and wrap `agent.clarify_callback`
  in `_run_agent` (enter/exit notifications to the controller).
- Add `SessionState.CLARIFY_PAUSED`; pause `_schedule_flush` while a clarify
  prompt is showing and resume on tool completion.
- Implement `_do_clarify_split`: flush pending content, create the new card,
  switch the session, then seal the old card (create → switch → seal order).
- Seal the old card with explicit `card_id` and `sequence` captured before the
  switch, using a local counter so the new card restarts at sequence 1.
- Reset `split_disabled` in a `finally` block covering cancel/exception paths.
- Add controller tests covering split lifecycle, no-card skip, create-failure
  fallback, seal-failure behavior, and enter/exit pause semantics.

## Compatibility

CLARIFY injection targets `agent.clarify_callback = _clarify_callback_sync`
(verified at Hermes 0.20.0 line 5098); the anchor is unchanged since 0.14.0,
the declared minimum.

## Testing

- 492 tests passed (10 new clarify cases)
- Ruff clean
- mypy clean across 22 source files
- Live gateway: 3 consecutive clarify splits succeeded; old card sealed without
  errors, new card streamed normally